### PR TITLE
Add Slovak holidays

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -114,6 +114,7 @@ Portugal            PT       None
 PortugalExt         PTE      *Portugal plus extended days most people have off*
 Scotland                     None
 Slovenia            SI       None
+Slovakia            SK       None
 South Africa        ZA       None
 Spain               ES       prov = AND, ARG, AST, CAN, CAM, CAL, CAT, CVA, EXT, GAL,
                              IBA, ICA, MAD, MUR, NAV, PVA, RIO

--- a/holidays.py
+++ b/holidays.py
@@ -2026,6 +2026,53 @@ class CZ(Czech):
     pass
 
 
+class Slovak(HolidayBase):
+    # https://sk.wikipedia.org/wiki/Sviatok
+    # https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1993/241/20160101
+
+    def __init__(self, **kwargs):
+        self.country = 'SK'
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+        self[date(year, 1, 1)] = "Deň vzniku Slovenskej republiky" \
+
+        self[date(year, 1, 6)] = "Zjavenie Pána (Traja králi a vianočný" \
+            "sviatok pravoslávnych kresťanov)"
+
+        e = easter(year)
+        self[e - rd(days=2)] = "Veľký piatok"
+        self[e + rd(days=1)] = "Veľkonočný pondelok"
+
+        self[date(year, 5, 1)] = "Sviatok práce"
+
+        if year >= 1997:
+            self[date(year, 5, 8)] = "Deň víťazstva nad fašizmom"
+
+        self[date(year, 7, 5)] = "Sviatok svätého Cyrila a svätého Metoda"
+
+        self[date(year, 8, 29)] = "Výročie Slovenského národného povstania"
+
+        self[date(year, 9, 1)] = "Deň Ústavy Slovenskej republiky"
+
+        self[date(year, 9, 15)] = "Sedembolestná Panna Mária"
+
+        self[date(year, 11, 1)] = "Sviatok Všetkých svätých"
+
+        if year >= 2001:
+            self[date(year, 11, 17)] = "Deň boja za slobodu a demokraciu"
+
+        self[date(year, 12, 24)] = "Štedrý deň"
+
+        self[date(year, 12, 25)] = "Prvý sviatok vianočný"
+
+        self[date(year, 12, 26)] = "Druhý sviatok vianočný"
+
+
+class SK(Slovak):
+    pass
+
+
 class Polish(HolidayBase):
     # https://pl.wikipedia.org/wiki/Dni_wolne_od_pracy_w_Polsce
 

--- a/tests.py
+++ b/tests.py
@@ -2904,6 +2904,30 @@ class TestCZ(unittest.TestCase):
         self.assertTrue(date(2017, 12, 26) in self.holidays)
 
 
+class TestSK(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays = holidays.SK()
+
+    def test_2018(self):
+        # https://www.officeholidays.com/countries/slovakia/2018.php
+        self.assertTrue(date(2018, 1, 1) in self.holidays)
+        self.assertTrue(date(2018, 1, 6) in self.holidays)
+        self.assertTrue(date(2018, 3, 30) in self.holidays)
+        self.assertTrue(date(2018, 5, 1) in self.holidays)
+        self.assertTrue(date(2018, 5, 8) in self.holidays)
+        self.assertTrue(date(2018, 4, 2) in self.holidays)
+        self.assertTrue(date(2018, 7, 5) in self.holidays)
+        self.assertTrue(date(2018, 8, 29) in self.holidays)
+        self.assertTrue(date(2018, 9, 1) in self.holidays)
+        self.assertTrue(date(2018, 9, 15) in self.holidays)
+        self.assertTrue(date(2018, 11, 1) in self.holidays)
+        self.assertTrue(date(2018, 11, 17) in self.holidays)
+        self.assertTrue(date(2018, 12, 24) in self.holidays)
+        self.assertTrue(date(2018, 12, 25) in self.holidays)
+        self.assertTrue(date(2018, 12, 26) in self.holidays)
+
+
 class TestPL(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
Slovakia is official country since 1.1.1993 when Czechoslovakia split into Czechia (Czech republic and Slovakia (Slovak republic). Since then, two official holidays were added in 1997 and 2001.
Sources:
https://www.slov-lex.sk/pravne-predpisy/SK/ZZ/1993/241/20160101.html (legislation)
https://sk.wikipedia.org/wiki/Sviatok (wikipedia)

With this PR I grant all required licenses to this code.