### PR TITLE
Add Reformationstag to more german states

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -1744,6 +1744,9 @@ class Germany(HolidayBase):
         if self.prov in ('BB', 'MV', 'SN', 'ST', 'TH'):
             self[date(year, 10, 31)] = 'Reformationstag'
 
+        if self.prov in ('HB', 'SH', 'NI', 'HH') and year >= 2018:
+            self[date(year, 10, 31)] = 'Reformationstag'
+
         # in 2017 all states got the Reformationstag (500th anniversary of
         # Luther's thesis)
         if year == 2017:

--- a/tests.py
+++ b/tests.py
@@ -2543,22 +2543,25 @@ class TestDE(unittest.TestCase):
             self.assertNotIn(date(year, 8, 15), self.prov_hols[province])
 
     def test_reformationstag(self):
-        provinces_that_have = {'BB', 'MV', 'SN', 'ST', 'TH'}
-        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+        min_year = 1991
+        max_year = 2050
+        province_to_start_year = {}
+        province_to_start_year.update(
+            dict.fromkeys(['BB', 'MV', 'SN', 'ST', 'TH'], 0)
+        )
+        province_to_start_year.update(
+            dict.fromkeys(['HB', 'SH', 'NI', 'HH'], 2018)
+        )
 
-        for province, year in product(provinces_that_have, range(1991, 2050)):
-            # in 2017 all states got the reformationstag for that year
-            if year == 2017:
-                continue
-            self.assertIn(date(year, 10, 31), self.prov_hols[province])
-        for province, year in product(provinces_that_dont, range(1991, 2050)):
-            # in 2017 all states got the reformationstag for that year
-            if year == 2017:
-                continue
-            self.assertNotIn(date(year, 10, 31), self.prov_hols[province])
-        # check the 2017 case where all states have the reformationstag
-        for province in holidays.DE.PROVINCES:
-            self.assertIn(date(2017, 10, 31), self.prov_hols[province])
+        for province, year in product(
+            holidays.DE.PROVINCES, range(min_year, max_year)
+        ):
+            # in 2017 all states have the reformationstag
+            start_year = province_to_start_year.get(province, max_year + 1)
+            if year == 2017 or year >= start_year:
+                self.assertIn(date(year, 10, 31), self.prov_hols[province])
+            else:
+                self.assertNotIn(date(year, 10, 31), self.prov_hols[province])
 
     def test_allerheiligen(self):
         provinces_that_have = {'BW', 'BY', 'NW', 'RP', 'SL'}


### PR DESCRIPTION
The Reformationstag has been added as a holiday to several german states since 2018, see [here](https://de.wikipedia.org/wiki/Reformationstag#Deutschland)