### PR TITLE
additional German provinces got "Reformationstag"

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -1749,6 +1749,11 @@ class Germany(HolidayBase):
         if year == 2017:
             self[date(year, 10, 31)] = 'Reformationstag'
 
+        # since 2018 additional states got the Reformationstag
+        if year >= 2018:
+            if self.prov in ('HB', 'HH', 'NI', 'SH'):
+                self[date(year, 10, 31)] = 'Reformationstag'
+
         if self.prov in ('BW', 'BY', 'NW', 'RP', 'SL'):
             self[date(year, 11, 1)] = 'Allerheiligen'
 

--- a/tests.py
+++ b/tests.py
@@ -2544,11 +2544,9 @@ class TestDE(unittest.TestCase):
 
     def test_reformationstag(self):
         prov_that_have = {'BB', 'MV', 'SN', 'ST', 'TH'}
-        prov_that_have_since_2018 = \
-                        prov_that_have.union({'HB', 'HH', 'NI', 'SH'})
+        prov_yes_since_2018 = prov_that_have.union({'HB', 'HH', 'NI', 'SH'})
         prov_that_dont = set(holidays.DE.PROVINCES) - prov_that_have
-        prov_that_dont_since_2018 = \
-                    set(holidays.DE.PROVINCES) - prov_that_have_since_2018
+        prov_not_since_2018 = set(holidays.DE.PROVINCES) - prov_yes_since_2018
 
         for province, year in product(prov_that_have, range(1991, 2050)):
             # in 2017 all states got the reformationstag for that year
@@ -2556,17 +2554,14 @@ class TestDE(unittest.TestCase):
                 continue
             self.assertIn(date(year, 10, 31), self.prov_hols[province])
         # additional provinces got this holiday 2018
-        for province, \
-            year in product(prov_that_have_since_2018, range(2018, 2050)):
+        for province, year in product(prov_yes_since_2018, range(2018, 2050)):
             self.assertIn(date(year, 10, 31), self.prov_hols[province])
-        for province, \
-            year in product(prov_that_dont, range(1991, 2017)):
+        for province, year in product(prov_that_dont, range(1991, 2017)):
             # in 2017 all states got the reformationstag for that year
             if year == 2017:
                 continue
             self.assertNotIn(date(year, 10, 31), self.prov_hols[province])
-        for province, \
-            year in product(prov_that_dont_since_2018, range(2018, 2050)):
+        for province, year in product(prov_not_since_2018, range(2018, 2050)):
             self.assertNotIn(date(year, 10, 31), self.prov_hols[province])
         # check the 2017 case where all states have the reformationstag
         for province in holidays.DE.PROVINCES:

--- a/tests.py
+++ b/tests.py
@@ -2543,25 +2543,30 @@ class TestDE(unittest.TestCase):
             self.assertNotIn(date(year, 8, 15), self.prov_hols[province])
 
     def test_reformationstag(self):
-        provinces_that_have = {'BB', 'MV', 'SN', 'ST', 'TH'}
-        provinces_that_have_since_2018 = provinces_that_have.union({'HB', 'HH', 'NI', 'SH'})
-        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
-        provinces_that_dont_since_2018 = set(holidays.DE.PROVINCES) - provinces_that_have_since_2018
+        prov_that_have = {'BB', 'MV', 'SN', 'ST', 'TH'}
+        prov_that_have_since_2018 = \
+                        prov_that_have.union({'HB', 'HH', 'NI', 'SH'})
+        prov_that_dont = set(holidays.DE.PROVINCES) - prov_that_have
+        prov_that_dont_since_2018 = \
+                    set(holidays.DE.PROVINCES) - prov_that_have_since_2018
 
-        for province, year in product(provinces_that_have, range(1991, 2050)):
+        for province, year in product(prov_that_have, range(1991, 2050)):
             # in 2017 all states got the reformationstag for that year
             if year == 2017:
                 continue
             self.assertIn(date(year, 10, 31), self.prov_hols[province])
-		# additional provinces got this holiday 2018
-        for province, year in product(provinces_that_have_since_2018, range(2018, 2050)):
+        # additional provinces got this holiday 2018
+        for province, \
+            year in product(prov_that_have_since_2018, range(2018, 2050)):
             self.assertIn(date(year, 10, 31), self.prov_hols[province])
-        for province, year in product(provinces_that_dont, range(1991, 2017)):
+        for province, \
+            year in product(prov_that_dont, range(1991, 2017)):
             # in 2017 all states got the reformationstag for that year
             if year == 2017:
                 continue
             self.assertNotIn(date(year, 10, 31), self.prov_hols[province])
-        for province, year in product(provinces_that_dont_since_2018, range(2018, 2050)):
+        for province, \
+            year in product(prov_that_dont_since_2018, range(2018, 2050)):
             self.assertNotIn(date(year, 10, 31), self.prov_hols[province])
         # check the 2017 case where all states have the reformationstag
         for province in holidays.DE.PROVINCES:

--- a/tests.py
+++ b/tests.py
@@ -2557,9 +2557,6 @@ class TestDE(unittest.TestCase):
         for province, year in product(prov_yes_since_2018, range(2018, 2050)):
             self.assertIn(date(year, 10, 31), self.prov_hols[province])
         for province, year in product(prov_that_dont, range(1991, 2017)):
-            # in 2017 all states got the reformationstag for that year
-            if year == 2017:
-                continue
             self.assertNotIn(date(year, 10, 31), self.prov_hols[province])
         for province, year in product(prov_not_since_2018, range(2018, 2050)):
             self.assertNotIn(date(year, 10, 31), self.prov_hols[province])

--- a/tests.py
+++ b/tests.py
@@ -2544,17 +2544,24 @@ class TestDE(unittest.TestCase):
 
     def test_reformationstag(self):
         provinces_that_have = {'BB', 'MV', 'SN', 'ST', 'TH'}
+        provinces_that_have_since_2018 = provinces_that_have.union({'HB', 'HH', 'NI', 'SH'})
         provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+        provinces_that_dont_since_2018 = set(holidays.DE.PROVINCES) - provinces_that_have_since_2018
 
         for province, year in product(provinces_that_have, range(1991, 2050)):
             # in 2017 all states got the reformationstag for that year
             if year == 2017:
                 continue
             self.assertIn(date(year, 10, 31), self.prov_hols[province])
-        for province, year in product(provinces_that_dont, range(1991, 2050)):
+		# additional provinces got this holiday 2018
+        for province, year in product(provinces_that_have_since_2018, range(2018, 2050)):
+            self.assertIn(date(year, 10, 31), self.prov_hols[province])
+        for province, year in product(provinces_that_dont, range(1991, 2017)):
             # in 2017 all states got the reformationstag for that year
             if year == 2017:
                 continue
+            self.assertNotIn(date(year, 10, 31), self.prov_hols[province])
+        for province, year in product(provinces_that_dont_since_2018, range(2018, 2050)):
             self.assertNotIn(date(year, 10, 31), self.prov_hols[province])
         # check the 2017 case where all states have the reformationstag
         for province in holidays.DE.PROVINCES:


### PR DESCRIPTION
Since 2018 these provinces in Germany also have Reformationstag.
- HB (Bremen)
- HH (Hamburg)
- NI (Niedersachsen)
- SH (Schleswig-Holstein)
See also https://www.schulferien.org/deutschland/feiertage/reformationstag/ for reference.