### PR TITLE
Revert 'additional German provinces got "Reformationstag"'. Added holidays twice.

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2060,11 +2060,6 @@ class Germany(HolidayBase):
         if year == 2017:
             self[date(year, 10, 31)] = 'Reformationstag'
 
-        # since 2018 additional states got the Reformationstag
-        if year >= 2018:
-            if self.prov in ('HB', 'HH', 'NI', 'SH'):
-                self[date(year, 10, 31)] = 'Reformationstag'
-
         if self.prov in ('BW', 'BY', 'NW', 'RP', 'SL'):
             self[date(year, 11, 1)] = 'Allerheiligen'
 


### PR DESCRIPTION
This reverts commit 22e404c2d6662a012ecec64170d1c2d5545b2e10 because the new
holidays were already introduced in f2814a79b7ab7688763a711cf8274155d4857675.