### PR TITLE
Holidays in date range

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,6 +47,8 @@ Example Usage
 
     us_holidays.get('2014-01-01')  # "New Year's Day"
 
+    us_holidays['2014-01-01': '2014-01-03']  # [date(2014, 1, 1)]
+
     us_pr_holidays = holidays.UnitedStates(state='PR')  # or holidays.US(...), or holidays.CountryHoliday('US', state='PR')
 
     # some holidays are only present in parts of a country

--- a/holidays.py
+++ b/holidays.py
@@ -114,7 +114,7 @@ class HolidayBase(dict):
             for delta_days in range(0, date_diff.days, step):
                 day = start + timedelta(days=delta_days)
                 try:
-                    _ = dict.__getitem__(
+                    dict.__getitem__(
                         self,
                         day
                     )

--- a/holidays.py
+++ b/holidays.py
@@ -11,7 +11,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from dateutil.easter import easter, EASTER_ORTHODOX
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta as rd
@@ -85,6 +85,43 @@ class HolidayBase(dict):
         return dict.__contains__(self, self.__keytransform__(key))
 
     def __getitem__(self, key):
+        if isinstance(key, slice):
+            if not key.start or not key.stop:
+                raise ValueError("Both start and stop must be given.")
+
+            start = self.__keytransform__(key.start)
+            stop = self.__keytransform__(key.stop)
+
+            if key.step is None:
+                step = 1
+            elif isinstance(key.step, timedelta):
+                step = key.step.days
+            elif isinstance(key.step, int):
+                step = key.step
+            else:
+                raise TypeError(
+                    "Cannot convert type '%s' to int." % type(key.step)
+                )
+
+            if step == 0:
+                raise ValueError('Step value must not be zero.')
+
+            date_diff = stop - start
+            if date_diff.days < 0 <= step or date_diff.days >= 0 > step:
+                step *= -1
+
+            days_in_range = []
+            for delta_days in range(0, date_diff.days, step):
+                day = start + timedelta(days=delta_days)
+                try:
+                    _ = dict.__getitem__(
+                        self,
+                        day
+                    )
+                    days_in_range.append(day)
+                except (KeyError):
+                    pass
+            return days_in_range
         return dict.__getitem__(self, self.__keytransform__(key))
 
     def __setitem__(self, key, value):

--- a/tests.py
+++ b/tests.py
@@ -12,7 +12,7 @@
 #  License: MIT (see LICENSE file)
 
 from itertools import product
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 from dateutil.relativedelta import relativedelta, MO
 import unittest
 
@@ -33,6 +33,75 @@ class TestBasics(unittest.TestCase):
         self.assertEqual(self.holidays.get(date(2014, 1, 1)), "New Year's Day")
         self.assertRaises(KeyError, lambda: self.holidays[date(2014, 1, 2)])
         self.assertIsNone(self.holidays.get(date(2014, 1, 2)))
+
+        self.assertListEqual(
+            self.holidays[date(2013, 12, 31): date(2014, 1, 2)],
+            [date(2014, 1, 1)]
+        )
+        self.assertListEqual(
+            self.holidays[date(2013, 12, 24): date(2014, 1, 2)],
+            [date(2013, 12, 25), date(2014, 1, 1)]
+        )
+        self.assertListEqual(
+            self.holidays[date(2013, 12, 25): date(2014, 1, 2): 3],
+            [date(2013, 12, 25)]
+        )
+        self.assertListEqual(
+            self.holidays[date(2013, 12, 25): date(2014, 1, 2): 7],
+            [date(2013, 12, 25), date(2014, 1, 1)]
+        )
+        self.assertListEqual(
+            self.holidays[date(2014, 1, 2): date(2013, 12, 30)],
+            [date(2014, 1, 1)]
+        )
+        self.assertListEqual(
+            self.holidays[date(2014, 1, 2): date(2013, 12, 25)],
+            [date(2014, 1, 1)]
+        )
+        self.assertListEqual(
+            self.holidays[date(2014, 1, 2): date(2013, 12, 24)],
+            [date(2014, 1, 1), date(2013, 12, 25)]
+        )
+        self.assertListEqual(
+            self.holidays[date(2014, 1, 1): date(2013, 12, 24): 3],
+            [date(2014, 1, 1)]
+        )
+        self.assertListEqual(
+            self.holidays[date(2014, 1, 1): date(2013, 12, 24): 7],
+            [date(2014, 1, 1), date(2013, 12, 25)]
+        )
+        self.assertListEqual(
+            self.holidays[date(2013, 12, 31): date(2014, 1, 2): 3],
+            []
+        )
+        self.assertListEqual(
+            self.holidays[
+                date(2014, 1, 1): date(2013, 12, 24): timedelta(days=3)
+            ],
+            [date(2014, 1, 1)]
+        )
+        self.assertListEqual(
+            self.holidays[
+                date(2014, 1, 1): date(2013, 12, 24): timedelta(days=7)
+            ],
+            [date(2014, 1, 1), date(2013, 12, 25)]
+        )
+        self.assertListEqual(
+            self.holidays[
+                date(2013, 12, 31): date(2014, 1, 2): timedelta(days=3)
+            ],
+            []
+        )
+        self.assertRaises(ValueError, lambda: self.holidays[date(2014, 1, 1):])
+        self.assertRaises(ValueError, lambda: self.holidays[:date(2014, 1, 1)])
+        self.assertRaises(
+            TypeError,
+            lambda: self.holidays[date(2014, 1, 1): date(2014, 1, 2): '']
+        )
+        self.assertRaises(
+            ValueError,
+            lambda: self.holidays[date(2014, 1, 1): date(2014, 1, 2): 0]
+        )
 
     def test_get(self):
         self.assertEqual(self.holidays.get('2014-01-01'), "New Year's Day")

--- a/tests.py
+++ b/tests.py
@@ -71,7 +71,7 @@ class TestBasics(unittest.TestCase):
             [date(2014, 1, 1), date(2013, 12, 25)]
         )
         self.assertListEqual(
-            self.holidays[date(2013, 12, 31): date(2014, 1, 2): 3],
+            self.holidays[date(2013, 12, 31): date(2014, 1, 2): -3],
             []
         )
         self.assertListEqual(


### PR DESCRIPTION
RE #113 Allow users to get the dates for which any holiday falls within a date range. Implemented using slice notation; users simply give [start, stop, step], where step is optional. Sample usage:

```
>>> holidays.US()[date(2013, 12, 31): date(2014, 1, 2)]
[datetime.date(2014, 1, 1)]
>>> holidays.US()[date(2014, 1, 1): date(2013, 12, 24)]
[datetime.date(2014, 1, 1), datetime.date(2013, 12, 25)]
>>> holidays.CA()[date(2013, 12, 25): date(2014, 1, 2): 3]
[datetime.date(2013, 12, 25)]
```

Uses the existing `__keytransform__` functionality so users may use dates, datetimes, strings, etc. Step field may be given as a positive or negative integer or timedelta (only days interpreted), or use default step of one day.

Infinite sequences, such as `[date(2014, 1, 1):]` are not implemented and are protected against, as the need was not previously described, and the use case seems limited. If this use case would be useful to have, further implementation of such a generator could be done.

Let me know if you'd like any further tests or tweaks!