### PR TITLE
Support for Luxembourgish holidays

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -4077,8 +4077,9 @@ class Croatia(HolidayBase):
 class HR(Croatia):
     pass
 
+
 class Luxembourg(HolidayBase):
-     
+
     # https://en.wikipedia.org/wiki/Public_holidays_in_Luxembourg
 
     def __init__(self, **kwargs):

--- a/holidays.py
+++ b/holidays.py
@@ -4078,6 +4078,7 @@ class HR(Croatia):
     pass
 
 class Luxembourg(HolidayBase):
+     
     # https://en.wikipedia.org/wiki/Public_holidays_in_Luxembourg
 
     def __init__(self, **kwargs):
@@ -4090,7 +4091,7 @@ class Luxembourg(HolidayBase):
         self[easter(year) + rd(weekday=MO)] = "Ouschterméindeg"
         self[date(year, MAY, 1)] = "Dag vun der Aarbecht"
         if year >= 2019:
-            # Europe Day: not in legislation yet, but introduced starting in 2019
+            # Europe Day: not in legislation yet, but introduced starting 2019
             self[date(year, MAY, 9)] = "Europadag"
         self[easter(year) + rd(days=39)] = "Christi Himmelfaart"
         self[easter(year) + rd(days=50)] = "Péngschtméindeg"

--- a/holidays.py
+++ b/holidays.py
@@ -4076,3 +4076,30 @@ class Croatia(HolidayBase):
 
 class HR(Croatia):
     pass
+
+class Luxembourg(HolidayBase):
+    # https://en.wikipedia.org/wiki/Public_holidays_in_Luxembourg
+
+    def __init__(self, **kwargs):
+        self.country = 'LU'
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+        # Public holidays
+        self[date(year, JAN, 1)] = "Neijoerschdag"
+        self[easter(year) + rd(weekday=MO)] = "Ouschterméindeg"
+        self[date(year, MAY, 1)] = "Dag vun der Aarbecht"
+        if year >= 2019:
+            # Europe Day: not in legislation yet, but introduced starting in 2019
+            self[date(year, MAY, 9)] = "Europadag"
+        self[easter(year) + rd(days=39)] = "Christi Himmelfaart"
+        self[easter(year) + rd(days=50)] = "Péngschtméindeg"
+        self[date(year, JUN, 23)] = "Nationalfeierdag"
+        self[date(year, AUG, 15)] = "Léiffrawëschdag"
+        self[date(year, NOV, 1)] = "Allerhellgen"
+        self[date(year, DEC, 25)] = "Chrëschtdag"
+        self[date(year, DEC, 26)] = "Stiefesdag"
+
+
+class LU(Luxembourg):
+    pass

--- a/tests.py
+++ b/tests.py
@@ -4680,7 +4680,7 @@ class TestBrazil(unittest.TestCase):
         self.assertEqual(to_holidays[date(2018, 10, 5)],
                          "Criação de Tocantins")
 
- 
+
 class TestLU(unittest.TestCase):
 
     def setUp(self):

--- a/tests.py
+++ b/tests.py
@@ -4680,6 +4680,26 @@ class TestBrazil(unittest.TestCase):
         self.assertEqual(to_holidays[date(2018, 10, 5)],
                          "Criação de Tocantins")
 
+ 
+class TestLU(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays = holidays.LU()
+
+    def test_2019(self):
+        # https://www.officeholidays.com/countries/luxembourg/2019
+        self.assertIn(date(2019, 1, 1), self.holidays)
+        self.assertIn(date(2019, 4, 22), self.holidays)
+        self.assertIn(date(2019, 5, 1), self.holidays)
+        self.assertIn(date(2019, 5, 9), self.holidays)
+        self.assertIn(date(2019, 5, 30), self.holidays)
+        self.assertIn(date(2019, 6, 10), self.holidays)
+        self.assertIn(date(2019, 6, 23), self.holidays)
+        self.assertIn(date(2019, 8, 15), self.holidays)
+        self.assertIn(date(2019, 11, 1), self.holidays)
+        self.assertIn(date(2019, 12, 25), self.holidays)
+        self.assertIn(date(2019, 12, 26), self.holidays)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Added support for Luxembourgish holidays.

More info can be found here: https://en.wikipedia.org/wiki/Public_holidays_in_Luxembourg

This list also includes May 9th, which will be a public holiday starting in 2019 (although the legislation has yet to be updated).

Edit: Please excuse the many fixes, this is my first PR ;-)