### PR TITLE
Add international women's day to berlin/germany's holidays

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2126,6 +2126,9 @@ class Germany(HolidayBase):
             weekday_delta = WE(-2) if base_data.weekday() == 2 else WE(-1)
             self[base_data + rd(weekday=weekday_delta)] = 'Buß- und Bettag'
 
+        if year >= 2019 and self.prov == 'BE':
+            self[date(year, MAR, 8)] = 'Internationaler Frauentag'
+
         self[date(year, DEC, 25)] = 'Erster Weihnachtstag'
         self[date(year, DEC, 26)] = 'Zweiter Weihnachtstag'
 

--- a/tests.py
+++ b/tests.py
@@ -2613,6 +2613,18 @@ class TestDE(unittest.TestCase):
         for province, (y, m, d) in product(holidays.DE.PROVINCES, known_good):
             self.assertIn(date(y, m, d), self.prov_hols[province])
 
+    def test_internationaler_frauentag(self):
+        prov_that_have = {'BE'}
+        prov_that_dont = set(holidays.DE.PROVINCES) - prov_that_have
+
+        for province, year in product(
+                holidays.DE.PROVINCES, range(1991, 2018)):
+            self.assertNotIn(date(year, 3, 8), self.prov_hols[province])
+        for province, year in product(prov_that_have, range(2019, 2050)):
+            self.assertIn(date(year, 3, 8), self.prov_hols[province])
+        for province, year in product(prov_that_dont, range(2019, 2050)):
+            self.assertNotIn(date(year, 3, 8), self.prov_hols[province])
+
 
 class TestAT(unittest.TestCase):
 


### PR DESCRIPTION
Senate of Berlin has decided to add this holiday. See https://www.berlin.de/aktuelles/berlin/5652179-958092-nun-auch-offiziell-frauentag-wird-feiert.html