### PR TITLE
Add Berlin: YYYY-03-08 International Women's Day

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2115,6 +2115,9 @@ class Germany(HolidayBase):
         if year == 2017:
             self[date(year, OCT, 31)] = 'Reformationstag'
 
+        if year >= 2019 and self.prov in ('BE'):
+            self[date(year, MAR, 8)] = 'Internationaler Frauentag'
+
         if self.prov in ('BW', 'BY', 'NW', 'RP', 'SL'):
             self[date(year, NOV, 1)] = 'Allerheiligen'
 


### PR DESCRIPTION
New holiday in Berlin since 8.3.2019 "International Women's Day"
See:
https://www.google.com/search?q=berlin+holiday+international+women%27s+day
https://www.dw.com/en/berlin-set-to-make-international-womens-day-a-public-holiday/a-46446222