### PR TITLE
Add 2 holidays to Berlin/Germany

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2089,6 +2089,9 @@ class Germany(HolidayBase):
 
             self[date(year, MAY, 1)] = 'Erster Mai'
 
+            if self.prov == "BE" and year == 2020:
+                self[date(year, MAY, 8)] = '75. Jahrestag der Befreiung vom Nationalsozialismus und der Beendigung des Zweiten Weltkriegs in Europa'
+
             self[easter(year) + rd(days=39)] = 'Christi Himmelfahrt'
 
             if self.prov == "BB":

--- a/holidays.py
+++ b/holidays.py
@@ -2074,6 +2074,9 @@ class Germany(HolidayBase):
             if self.prov in ('BW', 'BY', 'ST'):
                 self[date(year, JAN, 6)] = 'Heilige Drei Könige'
 
+            if self.prov == "BE" and year >= 2019:
+                self[date(year, MAR, 8)] = 'Internationaler Frauentag'
+
             self[easter(year) - rd(days=2)] = 'Karfreitag'
 
             if self.prov == "BB":

--- a/holidays.py
+++ b/holidays.py
@@ -2074,9 +2074,6 @@ class Germany(HolidayBase):
             if self.prov in ('BW', 'BY', 'ST'):
                 self[date(year, JAN, 6)] = 'Heilige Drei Könige'
 
-            if self.prov == "BE" and year >= 2019:
-                self[date(year, MAR, 8)] = 'Internationaler Frauentag'
-
             self[easter(year) - rd(days=2)] = 'Karfreitag'
 
             if self.prov == "BB":

--- a/holidays.py
+++ b/holidays.py
@@ -2087,7 +2087,9 @@ class Germany(HolidayBase):
             self[date(year, MAY, 1)] = 'Erster Mai'
 
             if self.prov == "BE" and year == 2020:
-                self[date(year, MAY, 8)] = '75. Jahrestag der Befreiung vom Nationalsozialismus und der Beendigung des Zweiten Weltkriegs in Europa'
+                self[date(year, MAY, 8)] = \
+                    "75. Jahrestag der Befreiung vom Nationalsozialismus " \
+                    "und der Beendigung des Zweiten Weltkriegs in Europa"
 
             self[easter(year) + rd(days=39)] = 'Christi Himmelfahrt'
 

--- a/tests.py
+++ b/tests.py
@@ -2510,6 +2510,16 @@ class TestDE(unittest.TestCase):
         for province, (y, m, d) in product(holidays.DE.PROVINCES, known_good):
             self.assertIn(date(y, m, d), self.prov_hols[province])
 
+    def test_75_jahrestag_beendigung_zweiter_weltkrieg(self):
+        known_good = [(2020, 5, 8)]
+        provinces_that_have = {"BE"}
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+
+        for province, (y, m, d) in product(provinces_that_have, known_good):
+            self.assertIn(date(y, m, d), self.prov_hols[province])
+        for province, (y, m, d) in product(provinces_that_dont, known_good):
+            self.assertNotIn(date(y, m, d), self.prov_hols[province])
+
     def test_christi_himmelfahrt(self):
         known_good = [(2014, 5, 29), (2015, 5, 14), (2016, 5, 5),
                       (2017, 5, 25), (2018, 5, 10), (2019, 5, 30),


### PR DESCRIPTION
From 2019 onwards, March 8 will be a national holiday in Berlin/Germany (International Women's Day).
In 2020, May 8 will be a national holiday in Berlin/Germany (75th anniversary of the end of World War 2).