### PR TITLE
Fixes for Australian public holidays

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -1814,7 +1814,7 @@ class Australia(HolidayBase):
 
     def __init__(self, **kwargs):
         self.country = 'AU'
-        self.prov = kwargs.pop('prov', kwargs.pop('state', 'ACT'))
+        self.prov = kwargs.pop('prov', None)
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
@@ -1868,7 +1868,7 @@ class Australia(HolidayBase):
         self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
         if self.prov in ('ACT', 'NSW', 'NT', 'QLD', 'SA', 'VIC'):
             self[easter(year) + rd(weekday=SA(-1))] = "Easter Saturday"
-        if self.prov == 'NSW':
+        if self.prov in ('ACT', 'NSW', 'QLD', 'VIC'):
             self[easter(year)] = "Easter Sunday"
         self[easter(year) + rd(weekday=MO)] = "Easter Monday"
 
@@ -1911,7 +1911,7 @@ class Australia(HolidayBase):
             elif self.prov == 'WA':
                 # by proclamation ?!?!
                 self[date(year, OCT, 1) + rd(weekday=MO(-1))] = name
-            else:
+            elif self.prov in ('NSW', 'VIC', 'ACT', 'SA', 'NT', 'TAS'):
                 dt = date(year, JUN, 1) + rd(weekday=MO(+2))
                 self[dt] = name
         elif year > 1911:
@@ -1923,6 +1923,11 @@ class Australia(HolidayBase):
         if self.prov == 'NT':
             name = "Picnic Day"
             self[date(year, AUG, 1) + rd(weekday=MO)] = name
+
+        # Bank Holiday
+        if self.prov == 'NSW':
+            name = "Bank Holiday"
+            self[date(year, 8, 1) + rd(weekday=MO)] = name
 
         # Labour Day
         name = "Labour Day"
@@ -1967,19 +1972,14 @@ class Australia(HolidayBase):
                 self[date(year, SEP, 28)] = name
             elif year == 2016:
                 self[date(year, SEP, 26)] = name
-            elif 2017 <= year <= 2020:
-                labour_day = date(year, OCT, 1) + rd(weekday=MO)
-                if year == 2017:
-                    dt = date(year, SEP, 23) + rd(weekday=MO)
-                elif year == 2018:
-                    dt = date(year, SEP, 29) + rd(weekday=MO)
-                elif year == 2019:
-                    dt = date(year, SEP, 28) + rd(weekday=MO)
-                elif year == 2020:
-                    dt = date(year, SEP, 26) + rd(weekday=MO)
-                if dt == labour_day:
-                    dt += rd(weekday=MO(+1))
-                self[date(year, SEP, 26)] = name
+            elif year == 2017:
+                self[date(year, SEP, 25)] = name
+
+        # Reconciliation Day
+        if self.prov == 'ACT':
+            name = "Reconciliation Day"
+            if year >= 2018:
+                self[date(year, 5, 27) + rd(weekday=MO)] = name
 
         if self.prov == 'VIC':
             # Grand Final Day

--- a/holidays.py
+++ b/holidays.py
@@ -1926,8 +1926,9 @@ class Australia(HolidayBase):
 
         # Bank Holiday
         if self.prov == 'NSW':
-            name = "Bank Holiday"
-            self[date(year, 8, 1) + rd(weekday=MO)] = name
+            if year >= 1912:
+                name = "Bank Holiday"
+                self[date(year, 8, 1) + rd(weekday=MO)] = name
 
         # Labour Day
         name = "Labour Day"
@@ -1985,6 +1986,7 @@ class Australia(HolidayBase):
             # Grand Final Day
             if year >= 2015:
                 self[date(year, SEP, 24) + rd(weekday=FR)] = "Grand Final Day"
+
             # Melbourne Cup
             self[date(year, NOV, 1) + rd(weekday=TU)] = "Melbourne Cup"
 

--- a/tests.py
+++ b/tests.py
@@ -2234,9 +2234,10 @@ class TestAU(unittest.TestCase):
         for dt in [date(1900, 4, 15), date(1901, 4, 7), date(1902, 3, 30),
                    date(1999, 4, 4), date(2010, 4, 4),
                    date(2018, 4, 1), date(2019, 4, 21), date(2020, 4, 12)]:
-            self.assertIn(dt, self.state_hols['NSW'], dt)
-            self.assertEqual(self.state_hols['NSW'][dt], "Easter Sunday")
-            for state in ['ACT', 'NT', 'QLD', 'SA', 'VIC', 'TAS', 'WA']:
+            for state in ['NSW', 'ACT', 'QLD', 'VIC']:
+                self.assertIn(dt, self.state_hols[state], (state, dt))
+                self.assertEqual(self.state_hols[state][dt], "Easter Sunday")
+            for state in ['NT', 'SA', 'TAS', 'WA']:
                 self.assertNotIn(dt, self.state_hols[state], (state, dt))
 
     def test_easter_monday(self):
@@ -2246,6 +2247,12 @@ class TestAU(unittest.TestCase):
             self.assertIn(dt, self.holidays)
             self.assertEqual(self.holidays[dt], "Easter Monday")
             self.assertNotIn(dt + relativedelta(days=+1), self.holidays)
+
+    def test_bank_holiday(self):
+        for dt in [date(1912, 8, 5), date(1913, 8, 5),
+                   date(1999, 8, 2), date(2018, 8, 6), date(2020, 8, 3)]:
+            self.assertIn(dt, self.state_hols['NSW'], dt)
+            self.assertEqual(self.state_hols['NSW'][dt], "Bank Holiday")
 
     def test_labour_day(self):
         for year, day in enumerate([7, 5, 4, 3, 2, 7, 6, ], 2011):
@@ -2328,15 +2335,19 @@ class TestAU(unittest.TestCase):
     def test_family_and_community_day(self):
         for dt in [date(2010, 9, 26), date(2011, 10, 10), date(2012, 10, 8),
                    date(2013, 9, 30), date(2014, 9, 29), date(2015, 9, 28),
-                   date(2016, 9, 26)]:
+                   date(2016, 9, 26), date(2017, 9, 25)]:
             self.assertIn(dt, self.state_hols['ACT'], dt)
-            self.assertEqual(self.state_hols['ACT'][dt],
-                             "Family & Community Day")
+            self.assertEqual(self.state_hols['ACT'][dt], "Family & Community Day")
+
+    def test_reconciliation_day(self):
+        for dt in [date(2018, 5, 28), date(2019, 5, 27), date(2020, 6, 1)]:
+            self.assertIn(dt, self.state_hols['ACT'], dt)
+            self.assertEqual(self.state_hols['ACT'][dt], "Reconciliation Day")
 
     def test_grand_final_day(self):
-            dt = date(2019, 9, 27)
-            self.assertIn(dt, self.state_hols['VIC'], dt)
-            self.assertEqual(self.state_hols['VIC'][dt], "Grand Final Day")
+        dt = date(2019, 9, 27)
+        self.assertIn(dt, self.state_hols['VIC'], dt)
+        self.assertEqual(self.state_hols['VIC'][dt], "Grand Final Day")
 
     def test_melbourne_cup(self):
         for dt in [date(2014, 11, 4), date(2015, 11, 3), date(2016, 11, 1)]:

--- a/tests.py
+++ b/tests.py
@@ -2249,7 +2249,7 @@ class TestAU(unittest.TestCase):
             self.assertNotIn(dt + relativedelta(days=+1), self.holidays)
 
     def test_bank_holiday(self):
-        for dt in [date(1912, 8, 5), date(1913, 8, 5),
+        for dt in [date(1912, 8, 5), date(1913, 8, 4),
                    date(1999, 8, 2), date(2018, 8, 6), date(2020, 8, 3)]:
             self.assertIn(dt, self.state_hols['NSW'], dt)
             self.assertEqual(self.state_hols['NSW'][dt], "Bank Holiday")

--- a/tests.py
+++ b/tests.py
@@ -2333,7 +2333,8 @@ class TestAU(unittest.TestCase):
             self.assertEqual(self.state_hols['NT'][dt], "Picnic Day")
 
     def test_family_and_community_day(self):
-        for dt in [date(2010, 9, 26), date(2011, 10, 10), date(2012, 10, 8),
+        for dt in [date(2007, 11, 6), date(2008, 11, 4), date(2009, 11, 3),
+                   date(2010, 9, 26), date(2011, 10, 10), date(2012, 10, 8),
                    date(2013, 9, 30), date(2014, 9, 29), date(2015, 9, 28),
                    date(2016, 9, 26), date(2017, 9, 25)]:
             self.assertIn(dt, self.state_hols['ACT'], dt)

--- a/tests.py
+++ b/tests.py
@@ -2337,7 +2337,8 @@ class TestAU(unittest.TestCase):
                    date(2013, 9, 30), date(2014, 9, 29), date(2015, 9, 28),
                    date(2016, 9, 26), date(2017, 9, 25)]:
             self.assertIn(dt, self.state_hols['ACT'], dt)
-            self.assertEqual(self.state_hols['ACT'][dt], "Family & Community Day")
+            self.assertEqual(self.state_hols['ACT'][dt],
+                             "Family & Community Day")
 
     def test_reconciliation_day(self):
         for dt in [date(2018, 5, 28), date(2019, 5, 27), date(2020, 6, 1)]:


### PR DESCRIPTION
Changes in this PR:

- Let `prov` be None by default to get national public holidays (and not the ones from ACT)
- Easter Sunday also in ACT, QLD and VIC
- Queen's Birthday is not a national but a common state public holiday
- NSW has a Bank Holiday on the first Monday in August
- Family & Community Day in ACT was replaced by Reconciliation Day starting 2018