### PR TITLE
Make Czech deprecated, introduce Czechia instead

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2672,7 +2672,8 @@ class CZ(Czechia):
 
 class Czech(Czechia):
     def __init__(self):
-        warnings.warn("Czech is deprecated, use Czechia instead.", DeprecationWarning)
+        warnings.warn("Czech is deprecated, use Czechia instead.",
+                      DeprecationWarning)
         super(Czech, self).__init__()
 
 

--- a/holidays.py
+++ b/holidays.py
@@ -17,6 +17,8 @@ from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta as rd
 from dateutil.relativedelta import MO, TU, WE, TH, FR, SA, SU
 import six
+import warnings
+
 
 __version__ = '0.9.10'
 
@@ -2620,7 +2622,7 @@ class TAR(EuropeanCentralBank):
     pass
 
 
-class Czech(HolidayBase):
+class Czechia(HolidayBase):
     # https://en.wikipedia.org/wiki/Public_holidays_in_the_Czech_Republic
 
     def __init__(self, **kwargs):
@@ -2664,8 +2666,14 @@ class Czech(HolidayBase):
             self[date(year, DEC, 26)] = "2. svátek vánoční"
 
 
-class CZ(Czech):
+class CZ(Czechia):
     pass
+
+
+class Czech(Czechia):
+    def __init__(self):
+        warnings.warn("Czech is deprecated, use Czechia instead.", DeprecationWarning)
+        super(Czech, self).__init__()
 
 
 class Slovak(HolidayBase):

--- a/tests.py
+++ b/tests.py
@@ -15,6 +15,7 @@ from itertools import product
 from datetime import date, datetime, timedelta
 from dateutil.relativedelta import relativedelta, MO
 import unittest
+import warnings
 
 import holidays
 
@@ -3140,6 +3141,14 @@ class TestCZ(unittest.TestCase):
 
     def test_others(self):
         self.assertIn(date(1991, 5, 9), self.holidays)
+
+    def test_czech_deprecated(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            czech = holidays.Czech()
+            self.assertIsInstance(czech, holidays.Czechia)
+            self.assertEqual(1, len(w))
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
 
 
 class TestSK(unittest.TestCase):


### PR DESCRIPTION
It should work like this.

You're usually testing against the abbreviated names, e.g. CZ, IT, ... which leaves the test unchanged :-)

I am still having one issue - if I put the semantically correct deprecation warning in the code, it is by default not printed, as Python ignores it (see https://docs.python.org/3.6/library/warnings.html#default-warning-filters ).
