### PR TITLE
Added public holiday "Weltkindertag" in DE-TH

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2104,6 +2104,9 @@ class Germany(HolidayBase):
 
             self[date(year, OCT, 3)] = 'Tag der Deutschen Einheit'
 
+        if year >= 2019 and self.prov == 'TH':
+            self[date(year, SEP, 20)] = 'Weltkindertag'
+
         if self.prov in ('BB', 'MV', 'SN', 'ST', 'TH'):
             self[date(year, OCT, 31)] = 'Reformationstag'
 


### PR DESCRIPTION
The "Weltkindertag" was resolved as a public holiday in Thuringia (Germany) in early 2019 [1] [2]

[1] https://www.mdr.de/nachrichten/politik/regional/kindertag-zwanzigster-september-feiertag-thueringen-100.html
[2] http://www.tellerreport.com/news/--landtag--world-children-s-day-is-now-a-public-holiday-in-thuringia-.rytDnSB8V.html