### PR TITLE
Added new German public holidays

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2126,6 +2126,13 @@ class Germany(HolidayBase):
             weekday_delta = WE(-2) if base_data.weekday() == 2 else WE(-1)
             self[base_data + rd(weekday=weekday_delta)] = 'Buß- und Bettag'
 
+        if year >= 2019:
+            if self.prov == 'TH':
+                self[date(year, SEP, 20)] = 'Weltkindertag'
+
+            if self.prov == 'BE':
+                self[date(year, MAR, 8)] = "Frauentag"
+
         self[date(year, DEC, 25)] = 'Erster Weihnachtstag'
         self[date(year, DEC, 26)] = 'Zweiter Weihnachtstag'
 

--- a/tests.py
+++ b/tests.py
@@ -2519,6 +2519,26 @@ class TestDE(unittest.TestCase):
         for province, (y, m, d) in product(holidays.DE.PROVINCES, known_good):
             self.assertIn(date(y, m, d), self.prov_hols[province])
 
+    def test_weltkindertag(self):
+        known_good = [(2019, 9, 20), (2021, 9, 20)]
+
+        provinces_that_have = {"TH"}
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+        for province, (y, m, d) in product(provinces_that_have, known_good):
+            self.assertIn(date(y, m, d), self.prov_hols[province])
+        for province, (y, m, d) in product(provinces_that_dont, known_good):
+            self.assertNotIn(date(y, m, d), self.prov_hols[province])
+
+    def test_frauentag(self):
+        known_good = [(2019, 3, 8), ]
+
+        provinces_that_have = {"BE"}
+        provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have
+        for province, (y, m, d) in product(provinces_that_have, known_good):
+            self.assertIn(date(y, m, d), self.prov_hols[province])
+        for province, (y, m, d) in product(provinces_that_dont, known_good):
+            self.assertNotIn(date(y, m, d), self.prov_hols[province])
+
     def test_pfingstsonntag(self):
         known_good = [(2014, 6, 8), (2015, 5, 24), (2016, 5, 15),
                       (2017, 6, 4), (2018, 5, 20), (2019, 6, 9),

--- a/tests.py
+++ b/tests.py
@@ -2334,9 +2334,9 @@ class TestAU(unittest.TestCase):
                              "Family & Community Day")
 
     def test_grand_final_day(self):
-            dt = date(2019, 9, 27)
-            self.assertIn(dt, self.state_hols['VIC'], dt)
-            self.assertEqual(self.state_hols['VIC'][dt], "Grand Final Day")
+        dt = date(2019, 9, 27)
+        self.assertIn(dt, self.state_hols['VIC'], dt)
+        self.assertEqual(self.state_hols['VIC'][dt], "Grand Final Day")
 
     def test_melbourne_cup(self):
         for dt in [date(2014, 11, 4), date(2015, 11, 3), date(2016, 11, 1)]:


### PR DESCRIPTION
* The "Weltkindertag" was resolved as a public holiday in Thuringia (Germany) in early 2019 [1] [2]
* The "Frauentag" was resolved as a public holiday in Berlin (Germany) in mid 2018 [3] [4]

[1] https://www.mdr.de/nachrichten/politik/regional/kindertag-zwanzigster-september-feiertag-thueringen-100.html
[2] http://www.tellerreport.com/news/--landtag--world-children-s-day-is-now-a-public-holiday-in-thuringia-.rytDnSB8V.html
[3] https://www.dw.com/en/berlin-set-to-make-international-womens-day-a-public-holiday/a-46446222
[4] https://www.berlin.de/special/familien/5597854-2864562-frauentag-8-maerz-neuer-feiertag.html