### PR TITLE
update: Allow passing years to CountryHoliday

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -228,9 +228,10 @@ def createHolidaySum(h1, h2):
     return HolidaySum
 
 
-def CountryHoliday(country, prov=None, state=None):
+def CountryHoliday(country, years=[], prov=None, state=None):
     try:
-        country_holiday = globals()[country](prov=prov, state=state)
+        country_holiday = globals()[country](years=years,
+                                             prov=prov, state=state)
     except (KeyError):
         raise KeyError("Country %s not available" % country)
     return country_holiday

--- a/tests.py
+++ b/tests.py
@@ -472,6 +472,10 @@ class TestCountryHoliday(unittest.TestCase):
     def test_country(self):
         self.assertEqual(self.holidays.country, 'US')
 
+    def test_country_years(self):
+        h = holidays.CountryHoliday('US', years=[2015, 2016])
+        self.assertEqual(h.years, {2015, 2016})
+
     def test_country_state(self):
         h = holidays.CountryHoliday('US', state='NY')
         self.assertEqual(h.state, 'NY')


### PR DESCRIPTION
* Ensure `years` can be passed to the `CountryHoliday` function.

  This simplifies programatic generation of years for multiple countries
  (i.e. one does not have to call specific country-specfic functions
  when one wants to create holidays for multiple years based just on
  country strings).

* Add a test that ensure this new functionality works correctly.

Signed-off-by: mr.Shu <mr@shu.io>