### PR TITLE
Make Polish deprecated, introduce Poland instead

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2861,7 +2861,7 @@ class Poland(HolidayBase):
 
 
 class Polish(Poland):
-    def __init__(self):
+    def __init__(self, **kwargs):
         warnings.warn("Polish is deprecated, use Poland instead.",
                       DeprecationWarning)
         super(Polish, self).__init__()

--- a/holidays.py
+++ b/holidays.py
@@ -2861,10 +2861,10 @@ class Poland(HolidayBase):
 
 
 class Polish(Poland):
-    def __init__(self, **kwargs):
+    def __init__(self):
         warnings.warn("Polish is deprecated, use Poland instead.",
                       DeprecationWarning)
-        super(Poland, self).__init__()
+        super(Polish, self).__init__()
 
 
 class PL(Poland):


### PR DESCRIPTION
stumbled upon this when trying to use and thought it should be aligned with #186 .
What do you think?