### PR TITLE
Correctly handle United Kingdom "May Day" holiday in 2020.

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2457,24 +2457,28 @@ class UnitedKingdom(HolidayBase):
         # May Day bank holiday (first Monday in May)
         if year >= 1978:
             name = "May Day"
-            if year == 1995:
-                dt = date(year, MAY, 8)
+            if year == 2020 and self.country != 'Ireland':
+                # Moved to Friday to mark 75th anniversary of VE Day.
+                self[date(year, MAY, 8)] = name
             else:
-                dt = date(year, MAY, 1)
-            if dt.weekday() == MON:
-                self[dt] = name
-            elif dt.weekday() == TUE:
-                self[dt + rd(days=+6)] = name
-            elif dt.weekday() == WED:
-                self[dt + rd(days=+5)] = name
-            elif dt.weekday() == THU:
-                self[dt + rd(days=+4)] = name
-            elif dt.weekday() == FRI:
-                self[dt + rd(days=+3)] = name
-            elif dt.weekday() == SAT:
-                self[dt + rd(days=+2)] = name
-            elif dt.weekday() == SUN:
-                self[dt + rd(days=+1)] = name
+                if year == 1995:
+                    dt = date(year, MAY, 8)
+                else:
+                    dt = date(year, MAY, 1)
+                if dt.weekday() == MON:
+                    self[dt] = name
+                elif dt.weekday() == TUE:
+                    self[dt + rd(days=+6)] = name
+                elif dt.weekday() == WED:
+                    self[dt + rd(days=+5)] = name
+                elif dt.weekday() == THU:
+                    self[dt + rd(days=+4)] = name
+                elif dt.weekday() == FRI:
+                    self[dt + rd(days=+3)] = name
+                elif dt.weekday() == SAT:
+                    self[dt + rd(days=+2)] = name
+                elif dt.weekday() == SUN:
+                    self[dt + rd(days=+1)] = name
 
         # Spring bank holiday (last Monday in May)
         if self.country != 'Ireland':

--- a/tests.py
+++ b/tests.py
@@ -3012,10 +3012,11 @@ class TestUK(unittest.TestCase):
     def test_may_day(self):
         for dt in [date(1978, 5, 1), date(1979, 5, 7), date(1980, 5, 5),
                    date(1999, 5, 3), date(2000, 5, 1), date(2010, 5, 3),
-                   date(2018, 5, 7), date(2019, 5, 6), date(2020, 5, 4)]:
+                   date(2018, 5, 7), date(2019, 5, 6), date(2020, 5, 8)]:
             self.assertIn(dt, self.holidays)
             self.assertNotIn(dt + relativedelta(days=-1), self.holidays)
             self.assertNotIn(dt + relativedelta(days=+1), self.holidays)
+        self.assertNotIn(date(2020, 5, 4), self.holidays)
 
     def test_spring_bank_holiday(self):
         for dt in [date(1978, 5, 29), date(1979, 5, 28), date(1980, 5, 26),
@@ -3106,6 +3107,25 @@ class TestIsleOfMan(unittest.TestCase):
     def test_2018(self):
         self.assertIn('2018-06-01', self.holidays)
         self.assertIn('2018-07-05', self.holidays)
+
+
+class TestIreland(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays = holidays.Ireland()
+
+    def test_2020(self):
+        self.assertIn('2020-01-01', self.holidays)  # New Year's Day
+        self.assertIn('2020-03-17', self.holidays)  # St. Patrick's Day
+        self.assertIn('2020-04-13', self.holidays)  # Easter Monday
+        self.assertIn('2020-05-04', self.holidays)  # May Day in IE
+        self.assertNotIn('2020-05-08', self.holidays)  # May Day in UK not IE
+        self.assertIn('2020-06-01', self.holidays)  # June Bank Holiday
+        self.assertIn('2020-08-03', self.holidays)  # Summer Bank Holiday
+        self.assertIn('2020-10-26', self.holidays)  # October Bank Holiday
+        self.assertIn('2020-12-25', self.holidays)  # Christmas Day
+        self.assertIn('2020-12-26', self.holidays)  # Boxing Day
+        self.assertIn('2020-12-28', self.holidays)  # Boxing Day (Observed)
 
 
 class TestES(unittest.TestCase):


### PR DESCRIPTION
This holiday is normally on the first Monday in May, but in 2020
it's being moved to Friday 8th May in order to mark the 75th
anniversary of VE Day.  This is as published on the following
official government webpages for England and Wales, Scotland, and
Northern Ireland:

 * https://www.gov.uk/bank-holidays#england-and-wales
 * https://www.gov.uk/bank-holidays#scotland
 * https://www.gov.uk/bank-holidays#northern-ireland

However, note that Ireland (which also inherits from the
UnitedKingdom class in a not very politically correct manner)
seems to be following the normal 'first Monday in May' rules in
2020 to the best of my knowledge at time of writing:

 * https://publicholidays.ie/2020-dates/