### PR TITLE
Change Maria to Mariä for AT/CH

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2357,13 +2357,13 @@ class Austria(HolidayBase):
         self[easter(year) + rd(days=39)] = "Christi Himmelfahrt"
         self[easter(year) + rd(days=50)] = "Pfingstmontag"
         self[easter(year) + rd(days=60)] = "Fronleichnam"
-        self[date(year, AUG, 15)] = "Maria Himmelfahrt"
+        self[date(year, AUG, 15)] = "Mariä Himmelfahrt"
         if 1919 <= year <= 1934:
             self[date(year, NOV, 12)] = "Nationalfeiertag"
         if year >= 1967:
             self[date(year, OCT, 26)] = "Nationalfeiertag"
         self[date(year, NOV, 1)] = "Allerheiligen"
-        self[date(year, DEC, 8)] = "Maria Empfängnis"
+        self[date(year, DEC, 8)] = "Mariä Empfängnis"
         self[date(year, DEC, 25)] = "Christtag"
         self[date(year, DEC, 26)] = "Stefanitag"
 
@@ -3968,7 +3968,7 @@ class Switzerland(HolidayBase):
 
         if self.prov in ('AI', 'JU', 'LU', 'NW', 'OW', 'SZ', 'TI', 'UR',
                          'VS', 'ZG'):
-            self[date(year, AUG, 15)] = 'Maria Himmelfahrt'
+            self[date(year, AUG, 15)] = 'Mariä Himmelfahrt'
 
         if self.prov == 'VD':
             # Monday after the third Sunday of September
@@ -3984,7 +3984,7 @@ class Switzerland(HolidayBase):
 
         if self.prov in ('AI', 'LU', 'NW', 'OW', 'SZ', 'TI', 'UR', 'VS',
                          'ZG'):
-            self[date(year, DEC, 8)] = 'Maria Empfängnis'
+            self[date(year, DEC, 8)] = 'Mariä Empfängnis'
 
         if self.prov == 'GE':
             self[date(year, DEC, 12)] = 'Escalade de Genève'


### PR DESCRIPTION
The public holiday "Maria Empfängis" / "Maria Himmelfahrt" is officially written using a german umlaut ä.
Source for Austria: https://www.oesterreich.gv.at/themen/bildung_und_neue_medien/schule/3/Seite.1100108.html
Source for Swizzerland: https://de.wikipedia.org/wiki/Feiertage_in_der_Schweiz