### PR TITLE
Hungarian calendar is flavoured by bit of history & swapped days off.

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -4129,6 +4129,11 @@ class HND(Honduras):
 
 class Hungary(HolidayBase):
     # https://en.wikipedia.org/wiki/Public_holidays_in_Hungary
+    # observed days off work around national holidays in the last 10 years:
+    # https://www.munkaugyiforum.hu/munkaugyi-segedanyagok/2018-evi-munkaszuneti-napok-koruli-munkarend-9-2017-ngm-rendelet
+    # codification dates:
+    # - https://hvg.hu/gazdasag/20170307_Megszavaztak_munkaszuneti_nap_lett_a_nagypentek
+    # - https://www.tankonyvtar.hu/hu/tartalom/historia/92-10/ch01.html#id496839
 
     def __init__(self, **kwargs):
         self.country = "HU"
@@ -4136,45 +4141,98 @@ class Hungary(HolidayBase):
 
     def _populate(self, year):
         # New years
-        self[date(year, JAN, 1)] = "Újév"
+        self._add_with_observed_day_off(date(year, JAN, 1), "Újév", since=2014)
 
         # National Day
-        self[date(year, MAR, 15)] = "Nemzeti ünnep"
+        if 1945 <= year <= 1950 or 1989 <= year:
+            self._add_with_observed_day_off(
+                date(year, MAR, 15), "Nemzeti ünnep")
+
+        # Soviet era
+        if 1950 <= year <= 1989:
+            # Proclamation of Soviet socialist governing system
+            self[date(year, MAR, 21)] = \
+                "A Tanácsköztársaság kikiáltásának ünnepe"
+            # Liberation Day
+            self[date(year, APR, 4)] = "A felszabadulás ünnepe"
+            # Memorial day of The Great October Soviet Socialist Revolution
+            if year not in (1956, 1989):
+                self[date(year, NOV, 7)] = \
+                    "A nagy októberi szocialista forradalom ünnepe"
 
         easter_date = easter(year)
 
         # Good Friday
-        self[easter_date + rd(weekday=FR(-1))] = "Nagypéntek"
+        if 2017 <= year:
+            self[easter_date + rd(weekday=FR(-1))] = "Nagypéntek"
 
         # Easter
         self[easter_date] = "Húsvét"
 
         # Second easter day
-        self[easter_date + rd(days=1)] = "Húsvét Hétfő"
+        if 1955 != year:
+            self[easter_date + rd(days=1)] = "Húsvét Hétfő"
 
         # Pentecost
         self[easter_date + rd(days=49)] = "Pünkösd"
 
         # Pentecost monday
-        self[easter_date + rd(days=50)] = "Pünkösdhétfő"
+        if year <= 1952 or 1992 <= year:
+            self[easter_date + rd(days=50)] = "Pünkösdhétfő"
 
         # International Workers' Day
-        self[date(year, MAY, 1)] = "A Munka ünnepe"
+        if 1946 <= year:
+            self._add_with_observed_day_off(
+                date(year, MAY, 1), "A Munka ünnepe")
+        if 1950 <= year <= 1953:
+            self[date(year, MAY, 2)] = "A Munka ünnepe"
 
-        # State Foundation Day
-        self[date(year, AUG, 20)] = "Az államalapítás ünnepe"
+        # State Foundation Day (1771-????, 1891-)
+        if 1950 <= year < 1990:
+            self[date(year, AUG, 20)] = "A kenyér ünnepe"
+        else:
+            self._add_with_observed_day_off(
+                date(year, AUG, 20), "Az államalapítás ünnepe")
 
         # National Day
-        self[date(year, OCT, 23)] = "Nemzeti ünnep"
+        if 1991 <= year:
+            self._add_with_observed_day_off(
+                date(year, OCT, 23), "Nemzeti ünnep")
 
         # All Saints' Day
-        self[date(year, NOV, 1)] = "Mindenszentek"
+        if 1999 <= year:
+            self._add_with_observed_day_off(
+                date(year, NOV, 1), "Mindenszentek")
+
+        # Christmas Eve is not endorsed officially
+        # but nowadays it is usually a day off work
+        if self.observed and 2010 <= year \
+                and date(year, DEC, 24).weekday() not in WEEKEND:
+            self[date(year, DEC, 24)] = "Szenteste"
 
         # First christmas
         self[date(year, DEC, 25)] = "Karácsony"
 
         # Second christmas
-        self[date(year, DEC, 26)] = "Karácsony másnapja"
+        if 1955 != year:
+            self._add_with_observed_day_off(
+                date(year, DEC, 26), "Karácsony másnapja", since=2013,
+                before=False, after=True)
+
+        # New Year's Eve
+        if self.observed and 2014 <= year \
+                and date(year, DEC, 31).weekday() == MON:
+            self[date(year, DEC, 31)] = "Szilveszter"
+
+    def _add_with_observed_day_off(self, day, desc, since=2010, before=True, after=True):
+        """Swapped days off were in place earlier but I haven't found official record yet."""
+        self[day] = desc
+        # TODO: should it be a separate flag?
+        if self.observed and since <= day.year:
+            if day.weekday() == TUE and before:
+                self[day - rd(days=1)] = desc + " előtti pihenőnap"
+            elif day.weekday() == THU and after:
+                self[day + rd(days=1)] = desc + " utáni pihenőnap"
 
 
 class HU(Hungary):

--- a/tests.py
+++ b/tests.py
@@ -4166,12 +4166,82 @@ class TestFinland(unittest.TestCase):
 class TestHungary(unittest.TestCase):
 
     def setUp(self):
-        self.holidays = holidays.HU()
+        self.holidays = holidays.HU(observed=False)
+        self.next_year = date.today().year + 1
+
+    def test_national_day_was_not_celebrated_during_communism(self):
+        for year in range(1951, 1988):
+            self.assertNotIn(date(year, 3, 15), self.holidays)
+        self.assertIn(date(1989, 3, 15), self.holidays)
+
+    def test_holidays_during_communism(self):
+        for year in range(1950, 1989):
+            self.assertIn(date(year, 3, 21), self.holidays)
+            self.assertIn(date(year, 4, 4), self.holidays)
+            if year != 1956:
+                self.assertIn(date(year, 11, 7), self.holidays)
+        self.assertIn(date(1989, 3, 21), self.holidays)
+
+    def test_foundation_day_renamed_during_communism(self):
+        for year in range(1950, 1990):
+            self.assertEqual(self.holidays[date(year, 8, 20)], "A kenyér ünnepe")
+
+    def test_christian_holidays_2nd_day_was_not_held_in_1955(self):
+        hu_1955 = holidays.Hungary(years=[1955])
+        self.assertNotIn(date(1955, 4, 11), hu_1955)
+        self.assertNotIn(date(1955, 12, 26), hu_1955)
+
+    def test_good_friday_since_2017(self):
+        self.assertNotIn(date(2016, 3, 25), self.holidays)
+        self.assertIn(date(2017, 4, 14), self.holidays)
+        self.assertIn(date(2018, 3, 30), self.holidays)
+
+    def test_whit_monday_since_1992(self):
+        self.assertNotIn(date(1991, 5, 20), self.holidays)
+        self.assertIn(date(1992, 6, 8), self.holidays)
+
+    def test_labour_day_since_1946(self):
+        self.assertNotIn(date(1945, 5, 1), self.holidays)
+        for year in range(1946, self.next_year):
+            self.assertIn(date(year, 5, 1), self.holidays)
+
+    def test_labour_day_was_doubled_in_early_50s(self):
+        for year in range(1950, 1954):
+            self.assertIn(date(year, 5, 2), self.holidays)
+
+    def test_october_national_day_since_1991(self):
+        for year in range(1991, self.next_year):
+            self.assertIn(date(year, 10, 23), self.holidays)
+
+    def test_all_saints_day_since_1999(self):
+        for year in range(1999, self.next_year):
+            self.assertIn(date(year, 11, 1), self.holidays)
+
+    def test_additional_day_off(self):
+        observed_days_off = holidays.HU(observed=True, years=range(2010, self.next_year))
+        for day in [
+            date(2010, 12, 24),
+            date(2011,  3, 14), date(2011, 10, 31),
+            date(2012,  3, 16), date(2012,  4, 30), date(2012, 10, 22),
+            date(2012, 11,  2), date(2012, 12, 24),
+            date(2013,  8, 19), date(2013, 12, 24), date(2013, 12, 27),
+            date(2014,  5,  2), date(2014, 10, 24), date(2014, 12, 24),
+            date(2015,  1,  2), date(2015,  8, 21), date(2015, 12, 24),
+            date(2016,  3, 14), date(2016, 10, 31),
+            date(2018,  3, 16), date(2018,  4, 30), date(2018, 10, 22),
+            date(2018, 11,  2), date(2018, 12, 24), date(2018, 12, 31),
+            date(2019,  8, 19), date(2019, 12, 24), date(2019, 12, 27)]:
+            self.assertNotIn(day, self.holidays)
+            self.assertIn(day, observed_days_off)
+
+    def test_monday_new_years_eve_day_off(self):
+        observed_day_off = holidays.HU(observed=True)
+        self.assertIn(date(2018, 12, 31), observed_day_off)
 
     def test_2018(self):
         self.assertIn(date(2018, 1, 1), self.holidays)  # newyear
         self.assertIn(date(2018, 3, 15), self.holidays)  # national holiday
-        self.assertIn(date(2018, 3, 30), self.holidays)  # good friday
+        self.assertIn(date(2018, 3, 30), self.holidays) # good friday
         self.assertIn(date(2018, 4, 1), self.holidays)  # easter 1.
         self.assertIn(date(2018, 4, 2), self.holidays)  # easter 2.
         self.assertIn(date(2018, 5, 1), self.holidays)  # Workers' Day


### PR DESCRIPTION
In the last century, Hungary switched its governmental system several
times backed by drastically different ideologies and, of course, it came
with change of officially endorsed holidays, too. I also did my best to
figure out which currently endorsed national holiday had been introduced
in which year.

In the last couple of decades, another trend emerged, the swap days
around official national holidays. Basically, if a holiday falls on
Tuesday or Thursday, that is, only one weekday is between the holiday
and the closest weekend, that weekday is a day off work usually. These
days are also captured if observed is True.

So far so good but these rest days come at cost. Saturday within at most
2 week distance of that weekday will be a working day. I do not know how
to represent those days in this package because, to my best knowledge,
`holidays` has no notion about such a construct. Anyway since large
number of people do not work on those swap days either the current setup
is good enough.

Unfortunately, there is a hidden caveat with swap days. Nowadays, one
may count on them for sure but technically those are regulated by yearly
governmental edicts, renewed year by year.