### PR TITLE
Only return nationwide holidays for Germany when no province is passed explicitly

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2251,7 +2251,7 @@ class Germany(HolidayBase):
 
     def __init__(self, **kwargs):
         self.country = 'DE'
-        self.prov = kwargs.pop('prov', 'SH')
+        self.prov = kwargs.pop('prov', None)
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):


### PR DESCRIPTION
At the moment `"2019-10-31" in holidays.DE()` returns `True` which leads to confusion as we expected the library to only check for nationwide holidays when not passing a specific province.
The PR makes sure we only check for nationwide holidays in this case.