### PR TITLE
Don't return holidays before country exists

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2258,9 +2258,6 @@ class Germany(HolidayBase):
         if year <= 1989:
             return
 
-        if year == 1990:
-            self[date(year, JUN, 17)] = 'Tag der deutschen Einheit'
-
         if year > 1990:
 
             self[date(year, JAN, 1)] = 'Neujahr'

--- a/tests.py
+++ b/tests.py
@@ -2874,12 +2874,6 @@ class TestDE(unittest.TestCase):
         for province, (y, m, d) in product(provinces_that_dont, known_good):
             self.assertNotIn(date(y, m, d), self.prov_hols[province])
 
-    def test_tag_der_deutschen_einheit(self):
-        known_good = [(1990, 6, 17)]
-
-        for province, (y, m, d) in product(holidays.DE.PROVINCES, known_good):
-            self.assertIn(date(y, m, d), self.prov_hols[province])
-
     def test_internationaler_frauentag(self):
         prov_that_have = {'BE'}
         prov_that_dont = set(holidays.DE.PROVINCES) - prov_that_have


### PR DESCRIPTION
The docstring clearly states:

    This class doesn't return any holidays before
    1990-10-03.

1990-06-17 is before 1990-10-03 and was no holiday in parts
of todays's Germany.

Source: https://de.wikipedia.org/wiki/Tag_der_Deutschen_Einheit#Bundesrepublik_Deutschland