### PR TITLE
return national holiday already for 1990

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2301,7 +2301,7 @@ class Germany(HolidayBase):
             if self.prov in ('BY', 'SL'):
                 self[date(year, AUG, 15)] = 'Mariä Himmelfahrt'
 
-            self[date(year, OCT, 3)] = 'Tag der Deutschen Einheit'
+        self[date(year, OCT, 3)] = 'Tag der Deutschen Einheit'
 
         if self.prov in ('BB', 'MV', 'SN', 'ST', 'TH'):
             self[date(year, OCT, 31)] = 'Reformationstag'

--- a/tests.py
+++ b/tests.py
@@ -2707,6 +2707,9 @@ class TestDE(unittest.TestCase):
         for y, (m, d) in product(range(1991, 2050), fixed_days_whole_country):
             self.assertIn(date(y, m, d), self.holidays)
 
+    def test_tag_der_deutschen_einheit_in_1990(self):
+        self.assertIn(date(1990, 10, 3), self.holidays)
+
     def test_heilige_drei_koenige(self):
         provinces_that_have = {'BW', 'BY', 'ST'}
         provinces_that_dont = set(holidays.DE.PROVINCES) - provinces_that_have


### PR DESCRIPTION
The docstring states:

    This class doesn't return any holidays before 1990-10-03.

So we can return the holiday on 1990-10-03 itself.