### PR TITLE
Add method to list all supported countries

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -16,9 +16,10 @@ from dateutil.easter import easter, EASTER_ORTHODOX
 from dateutil.parser import parse
 from dateutil.relativedelta import relativedelta as rd
 from dateutil.relativedelta import MO, TU, WE, TH, FR, SA, SU
+import inspect
 import six
+import sys
 import warnings
-
 
 __version__ = '0.9.11'
 
@@ -226,6 +227,13 @@ def createHolidaySum(h1, h2):
                 self.update(h)
 
     return HolidaySum
+
+
+def list_supported_countries():
+    """List all supported countries incl. their abbreviation."""
+    return [name for name, obj in
+            inspect.getmembers(sys.modules[__name__], inspect.isclass)
+            if obj.__module__ is __name__]
 
 
 def CountryHoliday(country, years=[], prov=None, state=None):

--- a/tests.py
+++ b/tests.py
@@ -278,6 +278,10 @@ class TestBasics(unittest.TestCase):
         self.assertEqual(na.get_list(date(1969, 7, 1)), ["Dominion Day"])
         self.assertEqual(na.get_list(date(1969, 1, 3)), [])
 
+    def test_list_supported_countries(self):
+        self.assertEqual(holidays.list_supported_countries()[0], "AR")
+        self.assertEqual(holidays.list_supported_countries()[-1], "ZA")
+
     def test_radd(self):
         self.assertRaises(TypeError, lambda: 1 + holidays.US())
 
@@ -462,6 +466,11 @@ class TestKeyTransforms(unittest.TestCase):
             (TypeError, ValueError), self.holidays.__setitem__, "abc", "Test")
         self.assertRaises(
             (TypeError, ValueError), lambda: {} in self.holidays)
+
+
+
+
+
 
 
 class TestCountryHoliday(unittest.TestCase):

--- a/tests.py
+++ b/tests.py
@@ -468,11 +468,6 @@ class TestKeyTransforms(unittest.TestCase):
             (TypeError, ValueError), lambda: {} in self.holidays)
 
 
-
-
-
-
-
 class TestCountryHoliday(unittest.TestCase):
 
     def setUp(self):


### PR DESCRIPTION
We are using `holidays` in [Home Assistant](https://www.home-assistant.io/) to allow the users to get information about workdays. We maintain a copy of the supported countries to have configuration validation. With the proposed addition (`list_supported_countries()`) it would be possible to get the supported countries from the module itself. This would help us to avoid issue like  https://github.com/home-assistant/home-assistant/issues/28977.

```bash
$ python3
Python 3.7.5 (default, Oct 17 2019, 12:16:48) 
[GCC 9.2.1 20190827 (Red Hat 9.2.1-1)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import holidays
>>> holidays.list_supported_countries()
['AR', 'AT', 'AU', 'AW', 'Argentina', 'Aruba', 'Australia', 'Austria', 'BE', 'BG', 'BR', 'BY', 'Belarus', 'Belgium', 'Brazil', 'Bulgaria', 'CA', 'CH', 'CO', 'CZ', 'Canada', 'Colombia', 'Croatia', 'Czech', 'Czechia', 'DE', 'DK', 'Denmark', 'ECB', 'EE', 'ES', 'England', 'Estonia', 'EuropeanCentralBank', 'FI', 'FRA', 'Finland', 'France', 'GB', 'Germany', 'HK', 'HND', 'HR', 'HU', 'HolidayBase', 'Honduras', 'HongKong', 'Hungary', 'IE', 'IND', 'IS', 'IT', 'Iceland', 'India', 'Ireland', 'IsleOfMan', 'Italy', 'JP', 'Japan', 'KE', 'Kenya', 'LT', 'LU', 'Lithuania', 'Luxembourg', 'MX', 'Mexico', 'NL', 'NO', 'NZ', 'Netherlands', 'NewZealand', 'NorthernIreland', 'Norway', 'PE', 'PL', 'PT', 'PTE', 'Peru', 'Poland', 'Polish', 'Portugal', 'PortugalExt', 'RU', 'Russia', 'SE', 'SI', 'SK', 'Scotland', 'Slovak', 'Slovakia', 'Slovenia', 'SouthAfrica', 'Spain', 'Sweden', 'Switzerland', 'TAR', 'UA', 'UK', 'US', 'Ukraine', 'UnitedKingdom', 'UnitedStates', 'Wales', 'ZA']
```