### PR TITLE
Deprecated Czech class was not backwards compatible.

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -2766,7 +2766,7 @@ class Czech(Czechia):
     def __init__(self, **kwargs):
         warnings.warn("Czech is deprecated, use Czechia instead.",
                       DeprecationWarning)
-        super(Czech, self).__init__()
+        super(Czech, self).__init__(**kwargs)
 
 
 class Slovakia(HolidayBase):


### PR DESCRIPTION
Hello! Wonderful library, thanks so much for maintaining it! I found that the **Czech** class (although deprecated) was not backwards compatible. It's definitely not a huge issue, but I was forced to develop a workaround for this in my use-case, so I figured I'd create a PR for it. 

Deprecated Czech class was not backwards compatible by failing to pass `**kwargs` through to parent's `__init__`.