### PR TITLE
Fix E305 expected 2 blank lines missing - Coverage Tests

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -5624,5 +5624,6 @@ class TestDominicanRepublic(unittest.TestCase):
         # Christmas Day
         self.assertIn(date(year, 12, 25), self.do_holidays)
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A missing blank line in tests.py, the build was failed and got E305 expected 2 blank lines after class or function definition.

All tests passed. Coverage 100%
![Screen Shot 2019-12-02 at 5 06 40 PM](https://user-images.githubusercontent.com/24206382/69995411-67a49000-1526-11ea-9d63-9eb93bccce06.png)
