### PR TITLE
Belarus (BY): add January, 2nd as a national holiday

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -470,6 +470,12 @@ class Belarus(HolidayBase):
         # New Year's Day
         self[date(year, JAN, 1)] = "Новый год"
 
+        # Jan 2nd is the national holiday (New Year) from 2020
+        # http://president.gov.by/uploads/documents/2019/464uk.pdf
+        if year >= 2020:
+            # New Year's Day
+            self[date(year, JAN, 2)] = "Новый год"
+
         # Christmas Day (Orthodox)
         self[date(year, JAN, 7)] = "Рождество Христово " \
                                    "(православное Рождество)"

--- a/tests.py
+++ b/tests.py
@@ -4780,6 +4780,14 @@ class TestBelarus(unittest.TestCase):
         self.assertIn(date(2018, 11, 7), self.holidays)
         self.assertIn(date(2018, 12, 25), self.holidays)
 
+    def test_new_year(self):
+        self.assertIn(date(2019, 1, 1), self.holidays)
+        self.assertNotIn(date(2019, 1, 2), self.holidays)
+        self.assertIn(date(2020, 1, 1), self.holidays)
+        self.assertIn(date(2020, 1, 2), self.holidays)
+        self.assertIn(date(2021, 1, 1), self.holidays)
+        self.assertIn(date(2021, 1, 2), self.holidays)
+
     def test_radunitsa(self):
         # http://calendar.by/content.php?id=20
         self.assertIn(date(2012, 4, 24), self.holidays)


### PR DESCRIPTION
Hurray!

From 2020 the second of January is the new national holiday in Belarus (New Year) according to the [presidential decree #464](http://president.gov.by/uploads/documents/2019/464uk.pdf):

"New Year - 1 **and 2 of January**"