### PR TITLE
Fix Alaska Day bug

### DIFF
--- a/holidays.py
+++ b/holidays.py
@@ -1726,7 +1726,8 @@ class UnitedStates(HolidayBase):
 
         # Alaska Day
         if self.state == 'AK' and year >= 1867:
-            self[date(year, OCT, 18)] = "Alaska Day"
+            name = "Alaska Day"
+            self[date(year, OCT, 18)] = name
             if self.observed \
                     and date(year, OCT, 18).weekday() == SAT:
                 self[date(year, OCT, 18) + rd(days=-1)] = name + \


### PR DESCRIPTION
The 'name' variable has not been set to Alaska Day resulting in an incorrect name when the observed day logic is executed. The name is incorrectly set to Independence Day under this condition.