### PR TITLE
Resolve HolidaysBase() typo for HolidayBase() in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -412,7 +412,7 @@ More Examples
     # use the append() method which accepts a dictionary of {date: name} pairs,
     # a list of dates, or even singular date/string/timestamp objects.
 
-    >>> custom_holidays = holidays.HolidaysBase()
+    >>> custom_holidays = holidays.HolidayBase()
     >>> custom_holidays.append(['2015-01-01', '07/04/2015'])
     >>> custom_holidays.append(date(2015, 12, 25))
 


### PR DESCRIPTION
Found a minor typo in the README while using this great library. 🎉 

Thanks for the work put into this by the way.