### PR TITLE
Add example for listing holidays of multiple years

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -424,6 +424,10 @@ More Examples
 >>> from datetime import date
 >>> holidays.US()[date(2013, 12, 31): date(2014, 1, 2)]
 
+# Intermediate years are only shown if they are listed in the years parameter.
+
+>>> holidays.US(years=[2014])[datetime.date(2013, 1, 1): datetime.date(2015, 12, 31)]
+
 Development Version
 -------------------
 


### PR DESCRIPTION
Add an example for listing all holidays in a range of multiple years.