### PR TITLE
Fixes for Switzerland GE

### DIFF
--- a/holidays/countries/switzerland.py
+++ b/holidays/countries/switzerland.py
@@ -33,7 +33,7 @@ class Switzerland(HolidayBase):
         # public holidays
         self[date(year, JAN, 1)] = 'Neujahrestag'
 
-        if self.prov in ('AG', 'BE', 'FR', 'GE', 'GL', 'GR', 'JU', 'LU',
+        if self.prov in ('AG', 'BE', 'FR', 'GL', 'GR', 'JU', 'LU',
                          'NE', 'OW', 'SH', 'SO', 'TG', 'VD', 'ZG', 'ZH'):
             self[date(year, JAN, 2)] = 'Berchtoldstag'
 

--- a/holidays/countries/switzerland.py
+++ b/holidays/countries/switzerland.py
@@ -95,6 +95,11 @@ class Switzerland(HolidayBase):
             dt = date(year, SEP, 1) + rd(weekday=SU(+3)) + rd(weekday=MO)
             self[dt] = 'Lundi du Jeûne'
 
+        if self.prov == 'GE':
+            # Thursday after the first Sunday of September
+            dt = date(year, SEP, 1) + rd(weekday=SU) + rd(weekday=TH)
+            self[dt] = 'Jeûne genevois'
+
         if self.prov == 'OW':
             self[date(year, SEP, 25)] = 'Bruder Klaus'
 
@@ -105,9 +110,6 @@ class Switzerland(HolidayBase):
         if self.prov in ('AI', 'LU', 'NW', 'OW', 'SZ', 'TI', 'UR', 'VS',
                          'ZG'):
             self[date(year, DEC, 8)] = 'Mariä Empfängnis'
-
-        if self.prov == 'GE':
-            self[date(year, DEC, 12)] = 'Escalade de Genève'
 
         self[date(year, DEC, 25)] = 'Weihnachten'
 

--- a/tests.py
+++ b/tests.py
@@ -4398,7 +4398,7 @@ class TestSwitzerland(unittest.TestCase):
             self.assertTrue(date(y, m, d) in self.holidays)
 
     def test_berchtoldstag(self):
-        provinces_that_have = {'AG', 'BE', 'FR', 'GE', 'GL', 'GR', 'JU', 'LU',
+        provinces_that_have = {'AG', 'BE', 'FR', 'GL', 'GR', 'JU', 'LU',
                                'NE', 'OW', 'SH', 'SO', 'TG', 'VD', 'ZG', 'ZH'}
         provinces_that_dont = set(holidays.CH.PROVINCES) - provinces_that_have
 

--- a/tests.py
+++ b/tests.py
@@ -4598,14 +4598,18 @@ class TestSwitzerland(unittest.TestCase):
         for province, year in product(provinces_that_dont, range(1970, 2050)):
             self.assertTrue(date(year, 11, 1) not in self.prov_hols[province])
 
-    def test_escalade_de_geneve(self):
+    def test_jeune_genevois(self):
+        known_good = [(2014, 9, 11), (2015, 9, 10), (2016, 9,  8),
+                      (2017, 9,  7), (2018, 9,  6), (2019, 9,  5),
+                      (2020, 9, 10), (2021, 9,  9), (2022, 9,  8),
+                      (2023, 9,  7), (2024, 9,  5), (2025, 9, 11)]
         provinces_that_have = {'GE'}
         provinces_that_dont = set(holidays.CH.PROVINCES) - provinces_that_have
 
-        for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 12, 12) in self.prov_hols[province])
-        for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 12, 12) not in self.prov_hols[province])
+        for province, (y, m, d) in product(provinces_that_have, known_good):
+            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+        for province, (y, m, d) in product(provinces_that_dont, known_good):
+            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
 
     def test_stephanstag(self):
         provinces_that_have = {'AG', 'AR', 'AI', 'BL', 'BS', 'BE', 'FR', 'GL',


### PR DESCRIPTION
A couple of fixes for the Geneva canton in Switzerland:
* "Berchtoldstag" is not a holiday in Geneva.
* "L'Escalade", while a celebration in Geneva, is not a holiday.
* Unlike the rest of Switzerland where the Federal fast is a holiday (3rd Sunday in September), Geneva has the Genevan fast on the Thursday following the 1st Sunday in September.

References:
https://en.wikipedia.org/wiki/Public_holidays_in_Switzerland
https://www.ge.ch/legislation/rsg/f/s/rsg_j1_45.html (in French)