### PR TITLE
Add pop_named(), to make removing holidays easier.  No need to look up or calculate the date.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -226,6 +226,9 @@ get_list(key)
 pop(key, default=None)
     Same as `get` except the key is removed from the holiday object
 
+pop_name(name)
+    Same as `pop` but takes the name of the holiday rather than the date
+
 update/append
     Accepts dictionary of {date: name} pairs, a list of dates, or even singular
     date/string/timestamp objects and adds them to the list of holidays
@@ -364,13 +367,12 @@ More Examples
     # "Ninja Turtle Day" on July 13th. We can create a new class that inherits
     # the UnitedStates class and the only method we need to override is _populate()
 
-    >>> from dateutil.relativedelta import relativedelta
     >>> class CorporateHolidays(holidays.UnitedStates):
     >>>     def _populate(self, year):
     >>>         # Populate the holiday list with the default US holidays
     >>>         holidays.UnitedStates._populate(self, year)
     >>>         # Remove Columbus Day
-    >>>         self.pop(date(year, 10, 1) + relativedelta(weekday=MO(+2)), None)
+    >>>         self.pop_name("Columbus Day")
     >>>         # Add Ninja Turtle Day
     >>>         self[date(year, 7, 13)] = "Ninja Turtle Day"
     >>> date(2014, 10, 14) in Holidays(country="US")

--- a/README.rst
+++ b/README.rst
@@ -226,7 +226,7 @@ get_list(key)
 pop(key, default=None)
     Same as `get` except the key is removed from the holiday object
 
-pop_name(name)
+pop_named(name)
     Same as `pop` but takes the name of the holiday rather than the date
 
 update/append

--- a/README.rst
+++ b/README.rst
@@ -372,7 +372,7 @@ More Examples
     >>>         # Populate the holiday list with the default US holidays
     >>>         holidays.UnitedStates._populate(self, year)
     >>>         # Remove Columbus Day
-    >>>         self.pop_name("Columbus Day")
+    >>>         self.pop_named("Columbus Day")
     >>>         # Add Ninja Turtle Day
     >>>         self[date(year, 7, 13)] = "Ninja Turtle Day"
     >>> date(2014, 10, 14) in Holidays(country="US")

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -152,7 +152,7 @@ class HolidayBase(dict):
     def pop_named(self, name):
         to_pop = [key for key in self if self[key] == name]
         if not to_pop:
-            raise KeyError
+            raise KeyError(name)
         for key in to_pop:
             self.pop(key)
 

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -149,6 +149,13 @@ class HolidayBase(dict):
             return dict.pop(self, self.__keytransform__(key))
         return dict.pop(self, self.__keytransform__(key), default)
 
+    def pop_named(self, name):
+        to_pop = [key for key in self if self[key] == name]
+        if not to_pop:
+            raise KeyError
+        for key in to_pop:
+            self.pop(key)
+
     def __eq__(self, other):
         return dict.__eq__(self, other) and self.__dict__ == other.__dict__
 

--- a/tests.py
+++ b/tests.py
@@ -120,6 +120,13 @@ class TestBasics(unittest.TestCase):
         self.assertNotIn(date(2014, 1, 1), self.holidays)
         self.assertIn(date(2014, 7, 4), self.holidays)
 
+    def test_pop_named(self):
+        self.assertIn(date(2014, 1, 1), self.holidays)
+        self.holidays.pop_named("New Year's Day")
+        self.assertNotIn(date(2014, 1, 1), self.holidays)
+        self.assertRaises(KeyError,
+                          lambda: self.holidays.pop_named("New Year's Dayz"))
+
     def test_setitem(self):
         self.holidays = holidays.US(years=[2014])
         self.assertEqual(len(self.holidays), 10)


### PR DESCRIPTION
I found it surprisingly hard to remove "Columbus Day" from the holiday list - the example code in the README works but it requires that the caller know when the holiday falls, but that's why I'm using the library! :)  So this PR adds a pop_named() call that does the reverse lookup and pop.