### PR TITLE
Added Singapore 2020 polling day

### DIFF
--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -182,8 +182,8 @@ class Singapore(HolidayBase):
             storeholiday(self, date(year, DEC, 26), "Boxing Day")
 
         # Polling Day
-        dates_obs = {2001: (NOV, 3), 2006: (MAY, 6),
-                     2011: (MAY, 7), 2015: (SEP, 11)}
+        dates_obs = {2001: (NOV, 3), 2006: (MAY, 6),  2011: (MAY, 7),
+                     2015: (SEP, 11), 2020: (JUL, 10)}
         if year in dates_obs:
             self[date(year, *dates_obs[year])] = "Polling Day"
 


### PR DESCRIPTION
A public holiday.

Source: https://www.mom.gov.sg/newsroom/press-releases/2020/0624-public-holiday-on-polling-day---10-july-2020