### PR TITLE
Korea alternative holiday added

### DIFF
--- a/holidays/countries/korea.py
+++ b/holidays/countries/korea.py
@@ -184,6 +184,11 @@ class Korea(HolidayBase):
         christmas_date = date(year, DEC, 25)
         self[christmas_date] = name
 
+        # Just for year 2020 - since 2020.08.15 is Sat, the government decides to make 2020.08.17 holiday, yay
+        name = "Alternative public holiday"
+        alt_date = date(2020, OCT, 17)
+        self[alt_date] = name
+
     # convert lunar calendar date to solar
     def get_solar_date(self, year, month, day):
         self.korean_cal.setLunarDate(year, month, day, False)


### PR DESCRIPTION
#### Alternative holiday for Korea just in 2020
* since date(2020,8,15) is Saturday, the government has decided to make date(2020,8,17) public holiday. 

#### Source
https://en.yna.co.kr/view/AEN20200721003200315