### PR TITLE
2020 Royal Queensland Show holiday moved

### DIFF
--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -218,8 +218,11 @@ class Australia(HolidayBase):
         # Friday. The Wednesday during the show is a public holiday.
         if self.prov == 'QLD':
             name = "The Royal Queensland Show"
-            self[date(year, AUG, 5) + rd(weekday=FR) + rd(weekday=WE)] = \
-                name
+            if year == 2020:
+                self[date(year, AUG, 14)] = name
+            else:
+                self[date(year, AUG, 5) + rd(weekday=FR) + rd(weekday=WE)] = \
+                    name
 
         # Christmas Day
         name = "Christmas Day"

--- a/tests.py
+++ b/tests.py
@@ -2644,7 +2644,7 @@ class TestAU(unittest.TestCase):
             self.assertEqual(self.state_hols['VIC'][dt], "Melbourne Cup")
 
     def test_royal_queensland_show(self):
-        for year, day in enumerate([15, 14, 12, 11, 10, 16], 2018):
+        for year, day in enumerate([15, 14, 14, 11, 10, 16], 2018):
             dt = date(year, 8, day)
             self.assertIn(dt, self.state_hols['QLD'], dt)
             self.assertEqual(self.state_hols['QLD'][dt],


### PR DESCRIPTION
The 2020 Royal Queensland Show (Ekka) holiday was moved to Friday 14
August 2020 for one year only.

See: https://www.qld.gov.au/recreation/travel/holidays/public