### PR TITLE
add October Revolution Day to Russian holiday

### DIFF
--- a/holidays/countries/russia.py
+++ b/holidays/countries/russia.py
@@ -53,13 +53,12 @@ class Russia(HolidayBase):
         self[date(year, MAY, 9)] = "День Победы"
         # Russia's Day
         self[date(year, JUN, 12)] = "День России"
-        if year>=2005:
+        if year >= 2005:
             # Unity Day
             self[date(year, NOV, 4)] = "День народного единства"
         else:
             # October Revolution Day
             self[date(year, NOV, 7)] = "День Октябрьской революции"
-            
 
 
 class RU(Russia):

--- a/holidays/countries/russia.py
+++ b/holidays/countries/russia.py
@@ -53,8 +53,13 @@ class Russia(HolidayBase):
         self[date(year, MAY, 9)] = "День Победы"
         # Russia's Day
         self[date(year, JUN, 12)] = "День России"
-        # Unity Day
-        self[date(year, NOV, 4)] = "День народного единства"
+        if year>=2005:
+            # Unity Day
+            self[date(year, NOV, 4)] = "День народного единства"
+        else:
+            # October Revolution Day
+            self[date(year, NOV, 7)] = "День Октябрьской революции"
+            
 
 
 class RU(Russia):

--- a/tests.py
+++ b/tests.py
@@ -5277,6 +5277,10 @@ class TestRussia(unittest.TestCase):
 
     def setUp(self):
         self.holidays = holidays.RU()
+        
+    def test_before_2005(self):
+        self.assertIn(date(2004, 11, 7), self.holidays)
+        self.assertNotIn(date(2004, 11, 4), self.holidays)
 
     def test_2018(self):
         # https://en.wikipedia.org/wiki/Public_holidays_in_Russia
@@ -5294,6 +5298,7 @@ class TestRussia(unittest.TestCase):
         self.assertIn(date(2018, 5, 9), self.holidays)
         self.assertIn(date(2018, 6, 12), self.holidays)
         self.assertIn(date(2018, 11, 4), self.holidays)
+        self.assertNotIn(date(2018, 11, 7), self.holidays)
 
 
 class TestLatvia(unittest.TestCase):


### PR DESCRIPTION
Up to 2004 there was no holiday on the November 4th. There was day-off holiday on November 7th - the day of October revolution. https://en.wikipedia.org/wiki/October_Revolution_Day
November 4th began holiday and day off only in 2005 and replaced November 7th.

There is question abount naming November 7th. This holiday was renamed twice. This is written in the paragraph "Post-Soviet observance" in wikipedia page above. Shoud we consider holiday renaming if in fact it stayed the same?