### PR TITLE
fixed MLK comma issue

### DIFF
--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -104,7 +104,7 @@ class UnitedStates(HolidayBase):
             elif self.state == 'GA' and year < 2012:
                 name = "Robert E. Lee's Birthday"
             elif self.state == 'ID' and year >= 2006:
-                name = "Martin Luther King, Jr. - Idaho Human Rights Day"
+                name = "Martin Luther King Jr. - Idaho Human Rights Day"
             self[date(year, JAN, 1) + rd(weekday=MO(+3))] = name
 
         # Lincoln's Birthday


### PR DESCRIPTION
This PR fixes https://github.com/dr-prodigy/python-holidays/issues/351 by removing the comma in the Idaho-specific MLK, Jr. holiday. I searched all countries and it appears that this is the only remaining comma included in a holiday name. This change removes any confusion with holidays falling on the same day being comma-separated.