### PR TITLE
Update Grand Final Public holiday for Victoria AU 2020.

### DIFF
--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -206,7 +206,10 @@ class Australia(HolidayBase):
 
         if self.prov == 'VIC':
             # Grand Final Day
-            if year >= 2015:
+            if year == 2020:
+                # Rescheduled due to COVID-19
+                self[date(year, OCT, 23)] = "Grand Final Day"
+            elif year >= 2015:
                 self[date(year, SEP, 24) + rd(weekday=FR)] = "Grand Final Day"
 
             # Melbourne Cup

--- a/tests.py
+++ b/tests.py
@@ -2635,8 +2635,13 @@ class TestAU(unittest.TestCase):
 
     def test_grand_final_day(self):
         dt = date(2019, 9, 27)
+        dt_2020 = date(2020, 10, 23)
+        dt_2020_old = date(2020, 9, 25)
         self.assertIn(dt, self.state_hols['VIC'], dt)
         self.assertEqual(self.state_hols['VIC'][dt], "Grand Final Day")
+        self.assertIn(dt_2020, self.state_hols['VIC'], dt_2020)
+        self.assertEqual(self.state_hols['VIC'][dt_2020], "Grand Final Day")
+        self.assertNotIn(dt_2020_old, self.state_hols['VIC'], dt_2020_old)
 
     def test_melbourne_cup(self):
         for dt in [date(2014, 11, 4), date(2015, 11, 3), date(2016, 11, 1)]:


### PR DESCRIPTION
This has been moved due to COVID-19.
Refer to: https://www.business.vic.gov.au/victorian-public-holidays-and-daylight-saving/victorian-public-holidays