### PR TITLE
Added day after Thanksgiving for California

### DIFF
--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -452,12 +452,12 @@ class UnitedStates(HolidayBase):
         # American Indian Heritage Day
         # Family Day
         # New Mexico Presidents' Day
-        if (self.state in ('DE', 'FL', 'NH', 'NC', 'OK', 'TX', 'WV', 'CA') and
+        if (self.state in ('CA', 'DE', 'FL', 'NH', 'NC', 'OK', 'TX', 'WV') and
             year >= 1975) \
                 or (self.state == 'IN' and year >= 2010) \
                 or (self.state == 'MD' and year >= 2008) \
                 or self.state in ('NV', 'NM'):
-            if self.state in ('DE', 'NH', 'NC', 'OK', 'WV', 'CA'):
+            if self.state in ('CA', 'DE', 'NH', 'NC', 'OK', 'WV'):
                 name = "Day After Thanksgiving"
             elif self.state in ('FL', 'TX'):
                 name = "Friday After Thanksgiving"

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -452,12 +452,12 @@ class UnitedStates(HolidayBase):
         # American Indian Heritage Day
         # Family Day
         # New Mexico Presidents' Day
-        if (self.state in ('DE', 'FL', 'NH', 'NC', 'OK', 'TX', 'WV') and
+        if (self.state in ('DE', 'FL', 'NH', 'NC', 'OK', 'TX', 'WV', 'CA') and
             year >= 1975) \
                 or (self.state == 'IN' and year >= 2010) \
                 or (self.state == 'MD' and year >= 2008) \
                 or self.state in ('NV', 'NM'):
-            if self.state in ('DE', 'NH', 'NC', 'OK', 'WV'):
+            if self.state in ('DE', 'NH', 'NC', 'OK', 'WV', 'CA'):
                 name = "Day After Thanksgiving"
             elif self.state in ('FL', 'TX'):
                 name = "Friday After Thanksgiving"

--- a/tests.py
+++ b/tests.py
@@ -1956,6 +1956,8 @@ class TestUS(unittest.TestCase):
             self.assertNotIn(dt + relativedelta(days=-1), self.holidays)
             self.assertNotIn(dt + relativedelta(days=+1), self.holidays)
             self.assertIn(dt + relativedelta(days=+1), de_holidays)
+            self.assertEqual(ca_holidays.get(dt + relativedelta(days=+1)),
+                             "Day After Thanksgiving")
             self.assertEqual(de_holidays.get(dt + relativedelta(days=+1)),
                              "Day After Thanksgiving")
             self.assertEqual(nh_holidays.get(dt + relativedelta(days=+1)),
@@ -1965,8 +1967,6 @@ class TestUS(unittest.TestCase):
             self.assertEqual(ok_holidays.get(dt + relativedelta(days=+1)),
                              "Day After Thanksgiving")
             self.assertEqual(wv_holidays.get(dt + relativedelta(days=+1)),
-                             "Day After Thanksgiving")
-            self.assertEqual(ca_holidays.get(dt + relativedelta(days=+1)),
                              "Day After Thanksgiving")
             self.assertIn(dt + relativedelta(days=+1), fl_holidays)
             self.assertEqual(fl_holidays.get(dt + relativedelta(days=+1)),

--- a/tests.py
+++ b/tests.py
@@ -1937,6 +1937,7 @@ class TestUS(unittest.TestCase):
         self.assertIn(date(2017, 11, 20), pr_holidays)
 
     def test_thanksgiving_day(self):
+        ca_holidays = holidays.US(state='CA')
         de_holidays = holidays.US(state='DE')
         fl_holidays = holidays.US(state='FL')
         in_holidays = holidays.US(state='IN')
@@ -1964,6 +1965,8 @@ class TestUS(unittest.TestCase):
             self.assertEqual(ok_holidays.get(dt + relativedelta(days=+1)),
                              "Day After Thanksgiving")
             self.assertEqual(wv_holidays.get(dt + relativedelta(days=+1)),
+                             "Day After Thanksgiving")
+            self.assertEqual(ca_holidays.get(dt + relativedelta(days=+1)),
                              "Day After Thanksgiving")
             self.assertIn(dt + relativedelta(days=+1), fl_holidays)
             self.assertEqual(fl_holidays.get(dt + relativedelta(days=+1)),


### PR DESCRIPTION
The day after Thanksgiving is a state holiday as noted here https://www.calhr.ca.gov/employees/pages/state-holidays.aspx