### PR TITLE
Day after Christmas is St Stephen's Day in Ireland

### DIFF
--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -166,6 +166,8 @@ class UnitedKingdom(HolidayBase):
 
         # Boxing Day
         name = "Boxing Day"
+        if self.country == "Ireland":
+            name = "St. Stephen's Day"
         self[date(year, DEC, 26)] = name
         if self.observed and date(year, DEC, 26).weekday() == SAT:
             self[date(year, DEC, 28)] = name + " (Observed)"


### PR DESCRIPTION
A small fix, just encountered your library and think highly of it and spotted something I could easily do.
The day after Christmas is not called "Boxing Day" in Ireland, it is called [St Stephen's Day](https://en.wikipedia.org/wiki/Saint_Stephen%27s_Day).