### PR TITLE
ISO code implementation for France

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,7 +121,7 @@ England                       None
 Estonia             EE/EST    None
 EuropeanCentralBank ECB/TAR   Trans-European Automated Real-time Gross Settlement (TARGET2)
 Finland             FI/FIN    None
-France              FRA       **Métropole** (default), Alsace-Moselle, Guadeloupe, Guyane,
+France              FR/FRA    **Métropole** (default), Alsace-Moselle, Guadeloupe, Guyane,
                               Martinique, Mayotte, Nouvelle-Calédonie, La Réunion,
                               Polynésie Française, Saint-Barthélémy, Saint-Martin,
                               Wallis-et-Futuna
@@ -176,7 +176,7 @@ Switzerland         CH/CHE    prov = AG, AR, AI, BL, BS, BE, FR, GE, GL, GR, JU,
 Turkey              TR/TUR    None
 Ukraine             UA/UKR    None
 UnitedArabEmirates  AE/ARE    None
-UnitedKingdom       UK/GB/GBR None
+UnitedKingdom       GB/GBR/UK None
 UnitedStates        US/USA    state = AL, AK, AS, AZ, AR, CA, CO, CT, DE, DC, FL, GA,
                               GU, HI, ID, IL, IN, IA, KS, KY, LA, ME, MD, MH, MA, MI,
                               FM, MN, MS, MO, MT, NE, NV, NH, NJ, NM, NY, NC, ND, MP,

--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -30,7 +30,7 @@ from .egypt import Egypt, EG, EGY
 from .estonia import Estonia, EE, EST
 from .european_central_bank import EuropeanCentralBank, ECB, TAR
 from .finland import Finland, FI, FIN
-from .france import France, FRA
+from .france import France, FR, FRA
 from .germany import Germany, DE, DEU
 from .greece import Greece, GR, GRC
 from .honduras import Honduras, HN, HND

--- a/holidays/countries/france.py
+++ b/holidays/countries/france.py
@@ -123,6 +123,10 @@ class France(HolidayBase):
             self[date(year, DEC, 20)] = "Abolition de l'esclavage"
 
 
-# FR already exists (Friday), we don't want to mess it up
+# *Warning* FR is also used by dateutlis (Friday), so be careful with its use
+class FR(France):
+    pass
+
+
 class FRA(France):
     pass

--- a/tests.py
+++ b/tests.py
@@ -3974,8 +3974,8 @@ class TestFrance(unittest.TestCase):
 
     def setUp(self):
         self.holidays = holidays.France()
-        self.prov_holidays = {prov: holidays.France(prov=prov)
-                              for prov in holidays.France.PROVINCES}
+        self.prov_holidays = {prov: holidays.FR(prov=prov)
+                              for prov in holidays.FRA.PROVINCES}
 
     def test_2017(self):
         self.assertIn(date(2017, 1, 1), self.holidays)


### PR DESCRIPTION
Closes #348 

As long as dateutil.relativedelta.FR is not imported within the FR class, which isn't, we're fine.