### PR TITLE
Travis tests for Python 3.9, released 2020-10-05

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
 matrix:
   include:
-#    - python: '3.9'
+    - python: '3.9'
     - python: '3.8'
     - python: '3.7'
     - python: '3.6'


### PR DESCRIPTION
Didn't implement it, but suggest dropping support of Python 3.5 since it was rendered obsolete by Python 3.6 on December 23, 2016