### PR TITLE
Feature/add malawi holidays

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -26,7 +26,7 @@ Released July 15, 2020
 - Switzerland fixes (cgrigis)
 - Germany fix (MikeTsenatek)
 - Added korean_cal attribute to Korea and Vietnam (seriousran, pelennor)
-- United States fixes (patrick-nicholson, raffg, dr-p)
+- United States fixes (patrick-nicholson, dr-p)
 - Singapore fixes + 2021 holidays (mborsetti)
 
 

--- a/CHANGES
+++ b/CHANGES
@@ -6,7 +6,9 @@ Released ????? ??, ????
 - Support for Djibouti (Abdisamade)
 - Support for United Arab Emirates (marcomasulli, mborsetti)
 - Korea 2020 fix (MYUNGJE, dr-p)
-- Australia 2020 fix (bencollerson)
+- Australia 2020 fix (bencollerson, trauty-is-me)
+- Croatia fixes (jangrg, dr-p)
+- United States fixes (raffg, dr-p)
 
 
 Version 0.10.3
@@ -26,7 +28,6 @@ Released July 15, 2020
 - Added korean_cal attribute to Korea and Vietnam (seriousran, pelennor)
 - United States fixes (patrick-nicholson, raffg, dr-p)
 - Singapore fixes + 2021 holidays (mborsetti)
-- Croatia fixes (jangrg, dr-p)
 
 
 Version 0.10.2

--- a/CHANGES
+++ b/CHANGES
@@ -9,6 +9,7 @@ Released ????? ??, ????
 - Australia 2020 fix (bencollerson, trauty-is-me)
 - Croatia fixes (jangrg, dr-p)
 - United States fixes (raffg, dr-p)
+- UK fixes (dr-p, richard-kunert)
 
 
 Version 0.10.3

--- a/README.rst
+++ b/README.rst
@@ -153,7 +153,7 @@ NewZealand          NZ/NZL    prov = NTL, AUK, TKI, HKB, WGN, MBH, NSN, CAN, STC
                               OTA, STL, CIT
 Nicaragua           NI/NIC    prov = MN
 Nigeria             NG/NGA    None
-Northern Ireland              None
+NorthernIreland               None
 Norway              NO/NOR    None
 Paraguay            PY/PRY    None
 Peru                PE/PER    None

--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,7 @@ Korea               KR/KOR    None
 Latvia              LV/LVA    None
 Lithuania           LT/LTU    None
 Luxembourg          LU/LUX    None
+Malawi              MW/MWI    None
 Mexico              MX/MEX    None
 Morocco             MA/MOR    None
 Netherlands         NL/NLD    None

--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -48,6 +48,7 @@ from .korea import Korea, KR, KOR
 from .latvia import Latvia, LV, LVA
 from .lithuania import Lithuania, LT, LTU
 from .luxembourg import Luxembourg, LU, LUX
+from .malawi import Malawi, MW, MWI
 from .mexico import Mexico, MX, MEX
 from .morocco import Morocco, MA, MOR
 from .netherlands import Netherlands, NL, NLD

--- a/holidays/countries/malawi.py
+++ b/holidays/countries/malawi.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+#  python-holidays
+#  ---------------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Author:  ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#           dr-prodigy <maurizio.montel@gmail.com> (c) 2017-2020
+#  Website: https://github.com/dr-prodigy/python-holidays
+#  License: MIT (see LICENSE file)
+
+from datetime import date
+
+from dateutil.easter import easter
+from dateutil.relativedelta import relativedelta as rd
+
+from holidays.constants import TUE, SAT, SUN
+from holidays.constants import JAN, FEB, MAR, APR, MAY, JUL, SEP, OCT, NOV, DEC
+from holidays.holiday_base import HolidayBase
+
+
+class Malawi(HolidayBase):
+
+    def __init__(self, **kwargs):
+        # https://www.officeholidays.com/countries/malawi
+        # https://www.timeanddate.com/holidays/malawi/
+        self.country = 'MW'
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+        # Observed since 2000
+        if year > 1999:
+            self[date(year, 1, 1)] = "New Year's Day"
+
+            e = easter(year)
+            good_friday = e - rd(days=2)
+            easter_monday = e + rd(days=1)
+            self[good_friday] = "Good Friday"
+            self[easter_monday] = "Easter Monday"
+
+            self[date(year, JAN, 15)] = "John Chilembwe Day"
+            self[date(year, MAR, 3)] = "Martyrs Day"
+            self[date(year, MAY, 1)] = "Labour Day"
+            self[date(year, MAY, 14)] = "Kamuzu Day"
+            self[date(year, JUL, 6)] = "Independence Day"
+            self[date(year, OCT, 15)] = "Mother's Day"
+            self[date(year, DEC, 25)] = "Christmas Day"
+            self[date(year, DEC, 26)] = "Boxing Day"
+
+        for k, v in list(self.items()):
+            if self.observed and year > 1994:
+                if k.weekday() == SUN:
+                    self[k + rd(days=1)] = v + " (Observed)"
+                elif k.weekday() == SAT:
+                    self[k + rd(days=2)] = v + " (Observed)"
+
+
+class MW(Malawi):
+    pass
+
+
+class MWI(Malawi):
+    pass

--- a/tests.py
+++ b/tests.py
@@ -6654,5 +6654,33 @@ class TestAngola(unittest.TestCase):
         self.assertNotIn('2015-03-02', self.holidays)
 
 
+class TestMalawi(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays = holidays.MW()
+
+    def test_new_years(self):
+        self.assertIn('2015-01-01', self.holidays)
+        self.assertIn('2017-01-01', self.holidays)
+        self.assertIn('2999-01-01', self.holidays)
+        self.assertIn('2017-01-02', self.holidays)  # sunday
+
+    def test_good_friday(self):
+        self.assertIn('2022-04-15', self.holidays)
+        self.assertIn('2018-03-30', self.holidays)
+
+    def test_easter(self):
+        self.assertIn(date(2017, 4, 14), self.holidays)
+        self.assertIn(date(2020, 4, 10), self.holidays)
+        self.assertIn(date(2015, 4, 6), self.holidays)
+
+    def test_static(self):
+        self.assertIn('2004-03-03', self.holidays)
+
+    def test_not_holiday(self):
+        self.assertNotIn('2016-12-28', self.holidays)
+        self.assertNotIn('2015-03-02', self.holidays)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Missing Eid al-Fitr public holiday as the date of Eid depends on the sighting of the moon, there may be variations in the exact date that is celebrated around the world. The announcement of the exact dates of Eid Al-Fitr may not happen until close to the start of Ramadan.