### PR TITLE
Extending UK holidays in 2022 for Queen's Jubilee

### DIFF
--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -189,6 +189,8 @@ class UnitedKingdom(HolidayBase):
                     " Catherine"
             elif year == 2012:
                 self[date(year, JUN, 5)] = "Diamond Jubilee of Elizabeth II"
+            elif year == 2022:
+                self[date(year, JUN, 3)] = "Platinum Jubilee of Elizabeth II"
 
 
 class UK(UnitedKingdom):

--- a/tests.py
+++ b/tests.py
@@ -3086,10 +3086,17 @@ class TestUK(unittest.TestCase):
             self.assertNotIn(dt + relativedelta(days=-1), self.holidays)
             self.assertNotIn(dt + relativedelta(days=+1), self.holidays)
 
-    def test_royal_wedding(self):
-        self.assertIn('2011-04-29', self.holidays)
-        self.assertNotIn('2010-04-29', self.holidays)
-        self.assertNotIn('2012-04-29', self.holidays)
+    def test_royal_weddings(self):
+        for dt in [date(1981, 7, 29), date(2011, 4, 29)]:
+            self.assertIn(dt, self.holidays)
+            self.assertNotIn(dt + relativedelta(years=-1), self.holidays)
+            self.assertNotIn(dt + relativedelta(years=+1), self.holidays)
+
+    def test_queens_jubilees(self):
+        for dt in [date(1977, 6, 7), date(2002, 6, 3), date(2012, 6, 5), date(2022, 6, 3)]:
+            self.assertIn(dt, self.holidays)
+            self.assertNotIn(dt + relativedelta(years=-1), self.holidays)
+            self.assertNotIn(dt + relativedelta(years=+1), self.holidays)
 
     def test_may_day(self):
         for dt in [date(1978, 5, 1), date(1979, 5, 7), date(1980, 5, 5),


### PR DESCRIPTION
UK will have an additional bank holiday on 2022 due to Queen's Platinum Jubilee (https://www.gov.uk/bank-holidays). It is updated in the code as it is a special holiday. Extended UK unit tests.