### PR TITLE
Add 1990-11-12 and 1993-06-09 into Japan

### DIFF
--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -15,8 +15,8 @@ from datetime import date
 
 from dateutil.relativedelta import relativedelta as rd, MO
 
-from holidays.constants import JAN, FEB, MAR, APR, MAY, JUL, AUG, SEP, OCT, \
-    NOV, DEC
+from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP, \
+    OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
 
 
@@ -105,12 +105,20 @@ class Japan(HolidayBase):
         # Labour Thanksgiving Day
         self[date(year, NOV, 23)] = "勤労感謝の日"
 
-        # Heisei Emperor's Birthday
+        # Regarding the Emperor of Heisei
         if 1989 <= year <= 2018:
+            # Heisei Emperor's Birthday
             self[date(year, DEC, 23)] = "天皇誕生日"
 
+            if year == 1990:
+                # Enthronement ceremony
+                self[date(year, NOV, 12)] = "即位礼正殿の儀"
+
         # Regarding the Emperor of Reiwa
-        if year == 2019:
+        if year == 1993:
+            # Marriage ceremony
+            self[date(year, JUN, 9)] = "結婚の儀"
+        elif year == 2019:
             # Enthronement Day
             self[date(year, MAY, 1)] = '天皇の即位の日'
             # Enthronement ceremony

--- a/tests.py
+++ b/tests.py
@@ -4000,6 +4000,7 @@ class TestJapan(unittest.TestCase):
         self.assertIn(date(2020, 2, 23), self.holidays)
 
     def test_reiwa_emperor_holidays(self):
+        self.assertIn(date(1993, 6, 9), self.holidays)
         self.assertIn(date(2019, 4, 30), self.holidays)
         self.assertIn(date(2019, 5, 1), self.holidays)
         self.assertIn(date(2019, 5, 2), self.holidays)


### PR DESCRIPTION
Adding 2 days into Japan because these 1990-11-12 and 1993-06-09 are also national holidays in Japan according to [CSV file](https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv) published by Cabinet Office, Government of Japan.

**Check before code change**

```console
(ENV) C:\Users\sakurai\git\python-holidays>git rev-parse HEAD
3b24dcb11eab639ac7833d5ac95413b858f510a2

(ENV) C:\Users\sakurai\git\python-holidays>flake8 holidays\countries\japan.py tests.py

(ENV) C:\Users\sakurai\git\python-holidays>coverage run --omit=*site-packages* tests.py TestJapan
..................
----------------------------------------------------------------------
Ran 18 tests in 0.015s

OK

(ENV) C:\Users\sakurai\git\python-holidays>coverage report -m -i holidays\countries\japan.py
Name                          Stmts   Miss  Cover   Missing
-----------------------------------------------------------
holidays\countries\japan.py     113      0   100%
```

**Check after code change**

```console
(ENV) C:\Users\sakurai\git\python-holidays>git rev-parse HEAD
05dcd2480523807dda2cf2f104384e93d836ccec

(ENV) C:\Users\sakurai\git\python-holidays>flake8 holidays\countries\japan.py tests.py

(ENV) C:\Users\sakurai\git\python-holidays>coverage run --omit=*site-packages* tests.py TestJapan
..................
----------------------------------------------------------------------
Ran 18 tests in 0.016s

OK

(ENV) C:\Users\sakurai\git\python-holidays>coverage report -m -i holidays\countries\japan.py
Name                          Stmts   Miss  Cover   Missing
-----------------------------------------------------------
holidays\countries\japan.py     117      0   100%
```
