### PR TITLE
Use Alpha-2 code as 'country'

### DIFF
--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -27,7 +27,7 @@ class India(HolidayBase):
                  'TN', 'AP', 'WB', 'KL', 'HR', 'MH', 'MP', 'UP', 'UK', 'TS']
 
     def __init__(self, **kwargs):
-        self.country = "IND"
+        self.country = "IN"
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -18,7 +18,7 @@ from .united_kingdom import UnitedKingdom
 class Ireland(UnitedKingdom):
 
     def __init__(self, **kwargs):
-        self.country = 'Ireland'
+        self.country = 'IE'
         HolidayBase.__init__(self, **kwargs)
 
 


### PR DESCRIPTION
To follow the homogeneous use in the rest of the Countries, I propose to modify the value of 'country' by the Alpha-2 code of the ISO-3166 standard.

https://www.iso.org/glossary-for-iso-3166.html