### PR TITLE
Use Alpha-2 code as 'country'

### DIFF
--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -27,7 +27,7 @@ class India(HolidayBase):
                  'TN', 'AP', 'WB', 'KL', 'HR', 'MH', 'MP', 'UP', 'UK', 'TS']
 
     def __init__(self, **kwargs):
-        self.country = "IND"
+        self.country = "IN"
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -31,17 +31,12 @@ class Ireland(UnitedKingdom):
     def _country_specific(self, year):
         # Ireland exclusive holidays
 
+        # St. Patrick's Day
         name = "St. Patrick's Day"
         self[date(year, MAR, 17)] = name
         if self.observed and date(year, MAR, 17).weekday() in WEEKEND:
             self[date(year, MAR, 17) + rd(weekday=MO)] = name + \
                 " (Observed)"
-
-        # June bank holiday (first Monday in June)
-        self[date(year, JUN, 1) + rd(weekday=MO)] = "June Bank Holiday"
-
-        # Summer bank holiday (first Monday in August)
-        self[date(year, AUG, 1) + rd(weekday=MO)] = "Summer Bank Holiday"
 
         # Easter Monday
         self[easter(year) + rd(weekday=MO)] = "Easter Monday"
@@ -67,6 +62,12 @@ class Ireland(UnitedKingdom):
                 self[dt + rd(days=+2)] = name
             elif dt.weekday() == SUN:
                 self[dt + rd(days=+1)] = name
+
+        # June bank holiday (first Monday in June)
+        self[date(year, JUN, 1) + rd(weekday=MO)] = "June Bank Holiday"
+
+        # Summer bank holiday (first Monday in August)
+        self[date(year, AUG, 1) + rd(weekday=MO)] = "Summer Bank Holiday"
 
         # October Bank Holiday (last Monday in October)
         self[date(year, OCT, 31) + rd(weekday=MO(-1))] = "October Bank Holiday"

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -11,6 +11,14 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
+from datetime import date
+
+from dateutil.easter import easter
+from dateutil.relativedelta import relativedelta as rd, MO, FR
+
+from holidays.constants import JAN, MAR, APR, MAY, JUN, JUL, AUG, OCT, \
+    NOV, DEC
+from holidays.constants import MON, TUE, WED, THU, FRI, SAT, SUN, WEEKEND
 from holidays.holiday_base import HolidayBase
 from .united_kingdom import UnitedKingdom
 
@@ -20,6 +28,56 @@ class Ireland(UnitedKingdom):
     def __init__(self, **kwargs):
         self.country = 'IE'
         HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+        # populate from UnitedKingdom
+        super()._populate(year)
+
+    def _country_especific(self, year):
+        # Irelan exclusive holidays
+        name = "St. Patrick's Day"
+        self[date(year, MAR, 17)] = name
+        if self.observed and date(year, MAR, 17).weekday() in WEEKEND:
+            self[date(year, MAR, 17) + rd(weekday=MO)] = name + \
+                " (Observed)"
+        # June bank holiday (first Monday in June)
+        self[date(year, JUN, 1) + rd(weekday=MO)] = "June Bank Holiday"
+        # Summer bank holiday (first Monday in August)
+        self[date(year, AUG, 1) + rd(weekday=MO)] = "Summer Bank Holiday"
+        # Easter Monday
+        self[easter(year) + rd(weekday=MO)] = "Easter Monday"
+
+        # May Day bank holiday (first Monday in May)
+        if year >= 1978:
+            name = "May Day"
+            if year == 1995:
+                dt = date(year, MAY, 8)
+            else:
+                dt = date(year, MAY, 1)
+            if dt.weekday() == MON:
+                self[dt] = name
+            elif dt.weekday() == TUE:
+                self[dt + rd(days=+6)] = name
+            elif dt.weekday() == WED:
+                self[dt + rd(days=+5)] = name
+            elif dt.weekday() == THU:
+                self[dt + rd(days=+4)] = name
+            elif dt.weekday() == FRI:
+                self[dt + rd(days=+3)] = name
+            elif dt.weekday() == SAT:
+                self[dt + rd(days=+2)] = name
+            elif dt.weekday() == SUN:
+                self[dt + rd(days=+1)] = name
+
+        # October Bank Holiday (last Monday in October)
+        self[date(year, OCT, 31) + rd(weekday=MO(-1))] = "October Bank Holiday"
+        # St. Stephen's Day
+        name = "St. Stephen's Day"
+        self[date(year, DEC, 26)] = name
+        if self.observed and date(year, DEC, 26).weekday() == SAT:
+            self[date(year, DEC, 28)] = name + " (Observed)"
+        elif self.observed and date(year, DEC, 26).weekday() == SUN:
+            self[date(year, DEC, 28)] = name + " (Observed)"
 
 
 class IE(Ireland):

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -18,7 +18,7 @@ from .united_kingdom import UnitedKingdom
 class Ireland(UnitedKingdom):
 
     def __init__(self, **kwargs):
-        self.country = 'Ireland'
+        self.country = 'IE'
         HolidayBase.__init__(self, **kwargs)
 
 

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -14,10 +14,9 @@
 from datetime import date
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd, MO, FR
+from dateutil.relativedelta import relativedelta as rd, MO
 
-from holidays.constants import JAN, MAR, APR, MAY, JUN, JUL, AUG, OCT, \
-    NOV, DEC
+from holidays.constants import MAR, MAY, JUN, AUG, OCT, DEC
 from holidays.constants import MON, TUE, WED, THU, FRI, SAT, SUN, WEEKEND
 from holidays.holiday_base import HolidayBase
 from .united_kingdom import UnitedKingdom
@@ -29,21 +28,21 @@ class Ireland(UnitedKingdom):
         self.country = 'IE'
         HolidayBase.__init__(self, **kwargs)
 
-    def _populate(self, year):
-        # populate from UnitedKingdom
-        super()._populate(year)
+    def _country_specific(self, year):
+        # Ireland exclusive holidays
 
-    def _country_especific(self, year):
-        # Irelan exclusive holidays
         name = "St. Patrick's Day"
         self[date(year, MAR, 17)] = name
         if self.observed and date(year, MAR, 17).weekday() in WEEKEND:
             self[date(year, MAR, 17) + rd(weekday=MO)] = name + \
                 " (Observed)"
+
         # June bank holiday (first Monday in June)
         self[date(year, JUN, 1) + rd(weekday=MO)] = "June Bank Holiday"
+
         # Summer bank holiday (first Monday in August)
         self[date(year, AUG, 1) + rd(weekday=MO)] = "Summer Bank Holiday"
+
         # Easter Monday
         self[easter(year) + rd(weekday=MO)] = "Easter Monday"
 
@@ -71,6 +70,7 @@ class Ireland(UnitedKingdom):
 
         # October Bank Holiday (last Monday in October)
         self[date(year, OCT, 31) + rd(weekday=MO(-1))] = "October Bank Holiday"
+
         # St. Stephen's Day
         name = "St. Stephen's Day"
         self[date(year, DEC, 26)] = name

--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -24,6 +24,9 @@ from holidays.holiday_base import HolidayBase
 
 class UnitedKingdom(HolidayBase):
     # https://en.wikipedia.org/wiki/Public_holidays_in_the_United_Kingdom
+    # This class is extended by other countries (Ireland, Isle of Man, ...)
+    # It must be taken into account when adding or modifying holidays.
+    # Look at _country_specific() method for country specific behavior.
 
     def __init__(self, **kwargs):
         self.country = 'UK'
@@ -66,13 +69,6 @@ class UnitedKingdom(HolidayBase):
                 self[date(year, MAR, 17) + rd(weekday=MO)] = name + \
                     " (Observed)"
 
-        # Easter Monday
-        if self.country != 'Scotland':
-            name = "Easter Monday"
-            if self.country == 'UK':
-                name += " [England, Wales, Northern Ireland]"
-            self[easter(year) + rd(weekday=MO)] = name
-
         # TT bank holiday (first Friday in June)
         if self.country == 'Isle of Man':
             self[date(year, JUN, 1) + rd(weekday=FR)] = "TT Bank Holiday"
@@ -110,21 +106,21 @@ class UnitedKingdom(HolidayBase):
         elif self.observed and date(year, DEC, 25).weekday() == SUN:
             self[date(year, DEC, 27)] = name + " (Observed)"
 
-        # Boxing Day
-        name = "Boxing Day"
-        self[date(year, DEC, 26)] = name
-        if self.observed and date(year, DEC, 26).weekday() == SAT:
-            self[date(year, DEC, 28)] = name + " (Observed)"
-        elif self.observed and date(year, DEC, 26).weekday() == SUN:
-            self[date(year, DEC, 28)] = name + " (Observed)"
+        # Overwrite to modify country specific holidays
+        self._country_specific(year)
 
-        self._country_especific(year)
-
-    def _country_especific(self, year: int):
+    def _country_specific(self, year):
         # UnitedKingdom exclusive holidays
 
         # Good Friday
         self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
+
+        # Easter Monday
+        if self.country != 'Scotland':
+            name = "Easter Monday"
+            if self.country == 'UK':
+                name += " [England, Wales, Northern Ireland]"
+            self[easter(year) + rd(weekday=MO)] = name
 
         # Late Summer bank holiday (last Monday in August)
         if self.country not in ('Scotland') and year >= 1971:
@@ -165,6 +161,14 @@ class UnitedKingdom(HolidayBase):
             self[date(year, JUN, 4)] = name
         elif year >= 1971:
             self[date(year, MAY, 31) + rd(weekday=MO(-1))] = name
+
+        # Boxing Day
+        name = "Boxing Day"
+        self[date(year, DEC, 26)] = name
+        if self.observed and date(year, DEC, 26).weekday() == SAT:
+            self[date(year, DEC, 28)] = name + " (Observed)"
+        elif self.observed and date(year, DEC, 26).weekday() == SUN:
+            self[date(year, DEC, 28)] = name + " (Observed)"
 
         # Special holidays
         if year == 1977:

--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -122,13 +122,6 @@ class UnitedKingdom(HolidayBase):
                 name += " [England, Wales, Northern Ireland]"
             self[easter(year) + rd(weekday=MO)] = name
 
-        # Late Summer bank holiday (last Monday in August)
-        if self.country not in ('Scotland') and year >= 1971:
-            name = "Late Summer Bank Holiday"
-            if self.country == 'UK':
-                name += " [England, Wales, Northern Ireland]"
-            self[date(year, AUG, 31) + rd(weekday=MO(-1))] = name
-
         # May Day bank holiday (first Monday in May)
         if year >= 1978:
             name = "May Day"
@@ -161,6 +154,13 @@ class UnitedKingdom(HolidayBase):
             self[date(year, JUN, 4)] = name
         elif year >= 1971:
             self[date(year, MAY, 31) + rd(weekday=MO(-1))] = name
+
+        # Late Summer bank holiday (last Monday in August)
+        if self.country not in ('Scotland') and year >= 1971:
+            name = "Late Summer Bank Holiday"
+            if self.country == 'UK':
+                name += " [England, Wales, Northern Ireland]"
+            self[date(year, AUG, 31) + rd(weekday=MO(-1))] = name
 
         # Boxing Day
         name = "Boxing Day"

--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -57,7 +57,7 @@ class UnitedKingdom(HolidayBase):
                     " (Observed)"
 
         # St. Patrick's Day
-        if self.country in ('UK', 'Northern Ireland', 'Ireland'):
+        if self.country in ('UK', 'Northern Ireland'):
             name = "St. Patrick's Day"
             if self.country == 'UK':
                 name += " [Northern Ireland]"
@@ -66,10 +66,6 @@ class UnitedKingdom(HolidayBase):
                 self[date(year, MAR, 17) + rd(weekday=MO)] = name + \
                     " (Observed)"
 
-        # Good Friday
-        if self.country != 'Ireland':
-            self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
-
         # Easter Monday
         if self.country != 'Scotland':
             name = "Easter Monday"
@@ -77,10 +73,70 @@ class UnitedKingdom(HolidayBase):
                 name += " [England, Wales, Northern Ireland]"
             self[easter(year) + rd(weekday=MO)] = name
 
+        # TT bank holiday (first Friday in June)
+        if self.country == 'Isle of Man':
+            self[date(year, JUN, 1) + rd(weekday=FR)] = "TT Bank Holiday"
+
+        # Tynwald Day
+        if self.country == 'Isle of Man':
+            self[date(year, JUL, 5)] = "Tynwald Day"
+
+        # Battle of the Boyne
+        if self.country in ('UK', 'Northern Ireland'):
+            name = "Battle of the Boyne"
+            if self.country == 'UK':
+                name += " [Northern Ireland]"
+            self[date(year, JUL, 12)] = name
+
+        # Summer bank holiday (first Monday in August)
+        if self.country in ('UK', 'Scotland'):
+            name = "Summer Bank Holiday"
+            if self.country == 'UK':
+                name += " [Scotland]"
+            self[date(year, AUG, 1) + rd(weekday=MO)] = name
+
+        # St. Andrew's Day
+        if self.country in ('UK', 'Scotland'):
+            name = "St. Andrew's Day"
+            if self.country == 'UK':
+                name += " [Scotland]"
+            self[date(year, NOV, 30)] = name
+
+        # Christmas Day
+        name = "Christmas Day"
+        self[date(year, DEC, 25)] = name
+        if self.observed and date(year, DEC, 25).weekday() == SAT:
+            self[date(year, DEC, 27)] = name + " (Observed)"
+        elif self.observed and date(year, DEC, 25).weekday() == SUN:
+            self[date(year, DEC, 27)] = name + " (Observed)"
+
+        # Boxing Day
+        name = "Boxing Day"
+        self[date(year, DEC, 26)] = name
+        if self.observed and date(year, DEC, 26).weekday() == SAT:
+            self[date(year, DEC, 28)] = name + " (Observed)"
+        elif self.observed and date(year, DEC, 26).weekday() == SUN:
+            self[date(year, DEC, 28)] = name + " (Observed)"
+
+        self._country_especific(year)
+
+    def _country_especific(self, year: int):
+        # UnitedKingdom exclusive holidays
+
+        # Good Friday
+        self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
+
+        # Late Summer bank holiday (last Monday in August)
+        if self.country not in ('Scotland') and year >= 1971:
+            name = "Late Summer Bank Holiday"
+            if self.country == 'UK':
+                name += " [England, Wales, Northern Ireland]"
+            self[date(year, AUG, 31) + rd(weekday=MO(-1))] = name
+
         # May Day bank holiday (first Monday in May)
         if year >= 1978:
             name = "May Day"
-            if year == 2020 and self.country != 'Ireland':
+            if year == 2020:
                 # Moved to Friday to mark 75th anniversary of VE Day.
                 self[date(year, MAY, 8)] = name
             else:
@@ -104,93 +160,27 @@ class UnitedKingdom(HolidayBase):
                     self[dt + rd(days=+1)] = name
 
         # Spring bank holiday (last Monday in May)
-        if self.country != 'Ireland':
-            name = "Spring Bank Holiday"
-            if year == 2012:
-                self[date(year, JUN, 4)] = name
-            elif year >= 1971:
-                self[date(year, MAY, 31) + rd(weekday=MO(-1))] = name
-
-        # June bank holiday (first Monday in June)
-        if self.country == 'Ireland':
-            self[date(year, JUN, 1) + rd(weekday=MO)] = "June Bank Holiday"
-
-        # TT bank holiday (first Friday in June)
-        if self.country == 'Isle of Man':
-            self[date(year, JUN, 1) + rd(weekday=FR)] = "TT Bank Holiday"
-
-        # Tynwald Day
-        if self.country == 'Isle of Man':
-            self[date(year, JUL, 5)] = "Tynwald Day"
-
-        # Battle of the Boyne
-        if self.country in ('UK', 'Northern Ireland'):
-            name = "Battle of the Boyne"
-            if self.country == 'UK':
-                name += " [Northern Ireland]"
-            self[date(year, JUL, 12)] = name
-
-        # Summer bank holiday (first Monday in August)
-        if self.country in ('UK', 'Scotland', 'Ireland'):
-            name = "Summer Bank Holiday"
-            if self.country == 'UK':
-                name += " [Scotland]"
-            self[date(year, AUG, 1) + rd(weekday=MO)] = name
-
-        # Late Summer bank holiday (last Monday in August)
-        if self.country not in ('Scotland', 'Ireland') and year >= 1971:
-            name = "Late Summer Bank Holiday"
-            if self.country == 'UK':
-                name += " [England, Wales, Northern Ireland]"
-            self[date(year, AUG, 31) + rd(weekday=MO(-1))] = name
-
-        # October Bank Holiday (last Monday in October)
-        if self.country == 'Ireland':
-            name = "October Bank Holiday"
-            self[date(year, OCT, 31) + rd(weekday=MO(-1))] = name
-
-        # St. Andrew's Day
-        if self.country in ('UK', 'Scotland'):
-            name = "St. Andrew's Day"
-            if self.country == 'UK':
-                name += " [Scotland]"
-            self[date(year, NOV, 30)] = name
-
-        # Christmas Day
-        name = "Christmas Day"
-        self[date(year, DEC, 25)] = name
-        if self.observed and date(year, DEC, 25).weekday() == SAT:
-            self[date(year, DEC, 27)] = name + " (Observed)"
-        elif self.observed and date(year, DEC, 25).weekday() == SUN:
-            self[date(year, DEC, 27)] = name + " (Observed)"
-
-        # Boxing Day
-        name = "Boxing Day"
-        if self.country == "Ireland":
-            name = "St. Stephen's Day"
-        self[date(year, DEC, 26)] = name
-        if self.observed and date(year, DEC, 26).weekday() == SAT:
-            self[date(year, DEC, 28)] = name + " (Observed)"
-        elif self.observed and date(year, DEC, 26).weekday() == SUN:
-            self[date(year, DEC, 28)] = name + " (Observed)"
+        name = "Spring Bank Holiday"
+        if year == 2012:
+            self[date(year, JUN, 4)] = name
+        elif year >= 1971:
+            self[date(year, MAY, 31) + rd(weekday=MO(-1))] = name
 
         # Special holidays
-        if self.country != 'Ireland':
-            if year == 1977:
-                self[date(year, JUN, 7)] = "Silver Jubilee of Elizabeth II"
-            elif year == 1981:
-                self[date(year, JUL, 29)] = "Wedding of Charles and Diana"
-            elif year == 1999:
-                self[date(year, DEC, 31)] = "Millennium Celebrations"
-            elif year == 2002:
-                self[date(year, JUN, 3)] = "Golden Jubilee of Elizabeth II"
-            elif year == 2011:
-                self[date(year, APR, 29)] = "Wedding of William and" \
-                    " Catherine"
-            elif year == 2012:
-                self[date(year, JUN, 5)] = "Diamond Jubilee of Elizabeth II"
-            elif year == 2022:
-                self[date(year, JUN, 3)] = "Platinum Jubilee of Elizabeth II"
+        if year == 1977:
+            self[date(year, JUN, 7)] = "Silver Jubilee of Elizabeth II"
+        elif year == 1981:
+            self[date(year, JUL, 29)] = "Wedding of Charles and Diana"
+        elif year == 1999:
+            self[date(year, DEC, 31)] = "Millennium Celebrations"
+        elif year == 2002:
+            self[date(year, JUN, 3)] = "Golden Jubilee of Elizabeth II"
+        elif year == 2011:
+            self[date(year, APR, 29)] = "Wedding of William and Catherine"
+        elif year == 2012:
+            self[date(year, JUN, 5)] = "Diamond Jubilee of Elizabeth II"
+        elif year == 2022:
+            self[date(year, JUN, 3)] = "Platinum Jubilee of Elizabeth II"
 
 
 class UK(UnitedKingdom):

--- a/tests.py
+++ b/tests.py
@@ -3216,6 +3216,41 @@ class TestIreland(unittest.TestCase):
         self.assertIn('2020-12-26', self.holidays)  # Boxing Day
         self.assertIn('2020-12-28', self.holidays)  # Boxing Day (Observed)
 
+    def test_may_day(self):
+        # Specific Ireland "May Day"
+        for dt in [date(1978, 5, 1), date(1979, 5, 7), date(1980, 5, 5),
+                   date(1995, 5, 8), date(1999, 5, 3), date(2000, 5, 1),
+                   date(2010, 5, 3), date(2018, 5, 7), date(2019, 5, 6),
+                   date(2020, 5, 4)]:
+            self.assertIn(dt, self.holidays)
+            self.assertNotIn(dt + relativedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + relativedelta(days=+1), self.holidays)
+
+    def test_st_stephens_day(self):
+        # St. Stephen's Day
+        self.holidays.observed = False
+
+        for year in range(1900, 2100):
+            dt = date(year, 12, 26)
+            self.assertIn(dt, self.holidays)
+            self.assertNotIn(dt + relativedelta(days=+1), self.holidays)
+        self.assertNotIn(date(2009, 12, 28), self.holidays)
+        self.assertNotIn(date(2010, 12, 27), self.holidays)
+        self.holidays.observed = True
+        self.assertIn(date(2004, 12, 28), self.holidays)
+        self.assertIn(date(2010, 12, 28), self.holidays)
+        for year, day in enumerate([26, 26, 26, 28, 26,
+                                    26, 26, 26, 28, 28,
+                                    26, 26, 26, 26, 26,
+                                    26, 26, 26, 26, 26, 28],
+                                   2001):
+            dt = date(year, 12, day)
+            self.assertIn(dt, self.holidays, dt)
+            self.assertIn(
+                self.holidays[dt], 
+                ["St. Stephen's Day", "St. Stephen's Day (Observed)"]
+            )
+
 
 class TestES(unittest.TestCase):
 


### PR DESCRIPTION
To follow the homogeneous use in the rest of the Countries, I propose to modify the value of 'country' by the Alpha-2 code of the ISO-3166 standard.

https://www.iso.org/glossary-for-iso-3166.html