### PR TITLE
update convertdate

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     license='MIT',
     description='Generate and work with holidays in Python',
     long_description=codecs.open('README.rst', encoding='utf-8').read(),
-    install_requires=['python-dateutil', 'six', 'convertdate<=2.2.0',
+    install_requires=['python-dateutil', 'six', 'convertdate<=2.3.0',
                       'korean_lunar_calendar'],
     platforms='any',
     classifiers=[

--- a/tests.py
+++ b/tests.py
@@ -6112,6 +6112,10 @@ class TestEgypt(unittest.TestCase):
 
 
 class TestIsrael(unittest.TestCase):
+    def test_hebrew_jd_to_gregorian(self):
+        self.assertEqual(holidays.IL._to_ymd_tuple((1, 2, 3)), (1, 2, 3))
+        self.assertEqual(holidays.IL._to_ymd_tuple(2459246.5), (2021, 2, 1))
+
     def test_memorial_day(self):
         self._test_observed_holidays('Memorial Day')
 


### PR DESCRIPTION
Convertdate had a dependency cap (now removed) on pytz,
preventing downstream users from updating.
Convertdate 2.3.0 also introduced a breaking change to the
hebrew.to_jd_gregorianyear conversion - both return types
are now handled to support 2.2 and 2.3 being used downstream.