### PR TITLE
Fix jp holidays

### DIFF
--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -131,6 +131,9 @@ class Japan(HolidayBase):
         self[date(year, NOV, 23)] = "勤労感謝の日"
 
         # Regarding the Emperor of Heisei
+        if year == 1959:
+            # Marriage ceremony
+            self[date(year, APR, 10)] = "結婚の儀"
         if 1989 <= year <= 2018:
             # Heisei Emperor's Birthday
             self[date(year, DEC, 23)] = "天皇誕生日"

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -71,6 +71,10 @@ class Japan(HolidayBase):
         else:
             self[date(year, APR, 29)] = "昭和の日"
 
+        # State Funeral of Emperor Shōwa
+        if year == 1989:
+            self[date(year, FEB, 24)] = "大喪の礼"
+
         # Constitution Memorial Day
         self[date(year, MAY, 3)] = "憲法記念日"
 

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -275,6 +275,7 @@ class Japan(HolidayBase):
                 5,
                 6,
                 (
+                    1974,
                     1985,
                     1991,
                     1996,

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -53,7 +53,8 @@ class Japan(HolidayBase):
             self[date(year, JAN, 1) + rd(weekday=MO(+2))] = "成人の日"
 
         # Foundation Day
-        self[date(year, FEB, 11)] = "建国記念の日"
+        if year >= 1967:
+            self[date(year, FEB, 11)] = "建国記念の日"
 
         # Reiwa Emperor's Birthday
         if year >= 2020:

--- a/test/countries/test_japan.py
+++ b/test/countries/test_japan.py
@@ -157,3 +157,5 @@ class TestJapan(unittest.TestCase):
         self.assertRaises(
             NotImplementedError, lambda: date(2100, 1, 1) in self.holidays
         )
+    def test_showa_emperor_holidays(self):
+        self.assertIn(date(1989, 2, 24), self.holidays)

--- a/test/countries/test_japan.py
+++ b/test/countries/test_japan.py
@@ -143,6 +143,13 @@ class TestJapan(unittest.TestCase):
         self.assertNotIn(date(2019, 12, 23), self.holidays)
         self.assertIn(date(2020, 2, 23), self.holidays)
 
+    def test_showa_emperor_holidays(self):
+        self.assertIn(date(1989, 2, 24), self.holidays)
+
+    def test_heisei_emperor_holidays(self):
+        self.assertIn(date(1959, 4, 10), self.holidays)
+        self.assertIn(date(1990, 11, 12), self.holidays)
+
     def test_reiwa_emperor_holidays(self):
         self.assertIn(date(1993, 6, 9), self.holidays)
         self.assertIn(date(2019, 4, 30), self.holidays)

--- a/test/countries/test_japan.py
+++ b/test/countries/test_japan.py
@@ -39,7 +39,9 @@ class TestJapan(unittest.TestCase):
         self.assertNotIn(date(2030, 1, 15), self.holidays)
 
     def test_foundation_day(self):
-        self.assertIn(date(1949, 2, 11), self.holidays)
+        self.assertNotIn(date(1949, 2, 11), self.holidays)
+        self.assertNotIn(date(1966, 2, 11), self.holidays)
+        self.assertIn(date(1967, 2, 11), self.holidays)
         self.assertIn(date(2017, 2, 11), self.holidays)
         self.assertIn(date(2050, 2, 11), self.holidays)
 

--- a/test/countries/test_japan.py
+++ b/test/countries/test_japan.py
@@ -164,5 +164,3 @@ class TestJapan(unittest.TestCase):
         self.assertRaises(
             NotImplementedError, lambda: date(2100, 1, 1) in self.holidays
         )
-    def test_showa_emperor_holidays(self):
-        self.assertIn(date(1989, 2, 24), self.holidays)


### PR DESCRIPTION
Thank you for your great work.

I fixed data for Japan according to the [Japanese Cabinet Office's data](https://www8.cao.go.jp/chosei/shukujitsu/syukujitsu.csv).

- remove foundation day before 1967
- add a substitute holiday (1974-05-06).
- add public holidays (1959-04-10, 1989-02-24)
