### PR TITLE
fixed easter&labour day for serbia 2021

### DIFF
--- a/holidays/countries/serbia.py
+++ b/holidays/countries/serbia.py
@@ -49,7 +49,10 @@ class Serbia(HolidayBase):
         self[date(year, MAY, 1)] = name
         self[date(year, MAY, 2)] = name
         if self.observed and date(year, MAY, 1).weekday() in WEEKEND:
-            self[date(year, MAY, 3)] = name + " (Observed)"
+            if date(year, MAY, 2) == easter(year, method=EASTER_ORTHODOX):
+                self[date(year, MAY, 4)] = name + " (Observed)"
+            else:
+                self[date(year, MAY, 3)] = name + " (Observed)"
         # Armistice day
         name = "Дан примирја у Првом светском рату"
         self[date(year, NOV, 11)] = name

--- a/test/countries/test_serbia.py
+++ b/test/countries/test_serbia.py
@@ -43,8 +43,14 @@ class TestSerbia(unittest.TestCase):
         self.assertIn(date(2016, 5, 1), self.holidays)
         self.assertIn(date(2016, 5, 2), self.holidays)
         self.assertIn(date(2016, 5, 3), self.holidays)
+        self.assertIn(date(2021, 5, 1), self.holidays)
+        self.assertIn(date(2021, 5, 2), self.holidays)
+        self.assertIn(date(2021, 5, 3), self.holidays)
+        self.assertIn(date(2021, 5, 4), self.holidays)
         self.holidays.observed = False
         self.assertNotIn(date(2016, 5, 3), self.holidays)
+        self.assertIn(date(2021, 5, 3), self.holidays)
+        self.assertNotIn(date(2021, 5, 4), self.holidays)
 
     def test_armistice_day(self):
         # If November 11th is in Weekend, test oberved


### PR DESCRIPTION
When one of the holiday days falls on Sunday, it is observed on next working day. Second day of Labour Day (May 2nd) is Sunday this year, which is also Orthodox Easter, so this year first working day is 4th of May.