### PR TITLE
Remove commas from UK holidays

### DIFF
--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -114,7 +114,7 @@ class UnitedKingdom(HolidayBase):
         if self.country != "Scotland":
             name = "Easter Monday"
             if self.country == "UK":
-                name += " [England, Wales, Northern Ireland]"
+                name += " [England/Wales/Northern Ireland]"
             self[easter(year) + rd(weekday=MO)] = name
 
         # May Day bank holiday (first Monday in May)
@@ -154,7 +154,7 @@ class UnitedKingdom(HolidayBase):
         if self.country not in ("Scotland") and year >= 1971:
             name = "Late Summer Bank Holiday"
             if self.country == "UK":
-                name += " [England, Wales, Northern Ireland]"
+                name += " [England/Wales/Northern Ireland]"
             self[date(year, AUG, 31) + rd(weekday=MO(-1))] = name
 
         # Boxing Day

--- a/test/countries/test_united_kingdom.py
+++ b/test/countries/test_united_kingdom.py
@@ -247,6 +247,7 @@ class TestIsleOfMan(unittest.TestCase):
         self.assertIn("2018-06-01", self.holidays)
         self.assertIn("2018-07-05", self.holidays)
 
+
 class TestNorthernIreland(unittest.TestCase):
     def setUp(self):
         self.holidays = holidays.NorthernIreland()

--- a/test/countries/test_united_kingdom.py
+++ b/test/countries/test_united_kingdom.py
@@ -94,7 +94,7 @@ class TestUK(unittest.TestCase):
             date(1999, 5, 3),
             date(2000, 5, 1),
             date(2010, 5, 3),
-            date(2011, 5, 9),
+            date(2016, 5, 2),
             date(2018, 5, 7),
             date(2019, 5, 6),
             date(2020, 5, 8),

--- a/test/countries/test_united_kingdom.py
+++ b/test/countries/test_united_kingdom.py
@@ -213,8 +213,10 @@ class TestUK(unittest.TestCase):
             "Easter Monday [England/Wales/Northern Ireland]",
             "May Day",
             "Spring Bank Holiday",
+            "Late Summer Bank Holiday [England/Wales/Northern Ireland]",
             "Christmas Day",
             "Boxing Day",
+            "St. Patrick's Day [Northern Ireland]",
         ]
         for holiday in all_holidays:
             self.assertIn(holiday, uk_2015.values())
@@ -244,3 +246,11 @@ class TestIsleOfMan(unittest.TestCase):
     def test_2018(self):
         self.assertIn("2018-06-01", self.holidays)
         self.assertIn("2018-07-05", self.holidays)
+
+class TestNorthernIreland(unittest.TestCase):
+    def setUp(self):
+        self.holidays = holidays.NorthernIreland()
+
+    def test_2018(self):
+        self.assertIn("2018-03-17", self.holidays)
+        self.assertIn("2018-07-12", self.holidays)

--- a/test/countries/test_united_kingdom.py
+++ b/test/countries/test_united_kingdom.py
@@ -94,6 +94,7 @@ class TestUK(unittest.TestCase):
             date(1999, 5, 3),
             date(2000, 5, 1),
             date(2010, 5, 3),
+            date(2011, 5, 9),
             date(2018, 5, 7),
             date(2019, 5, 6),
             date(2020, 5, 8),

--- a/test/countries/test_united_kingdom.py
+++ b/test/countries/test_united_kingdom.py
@@ -210,7 +210,7 @@ class TestUK(unittest.TestCase):
         all_holidays = [
             "New Year's Day",
             "Good Friday",
-            "Easter Monday [England, Wales, Northern Ireland]",
+            "Easter Monday [England/Wales/Northern Ireland]",
             "May Day",
             "Spring Bank Holiday",
             "Christmas Day",


### PR DESCRIPTION
The `get_list` method assumes that commas are not used in the names of individual holidays, by splitting overlapping holidays according to commas:
https://github.com/dr-prodigy/python-holidays/blob/cb875fb87e91f8c555966659bca1636519c47d6f/holidays/holiday_base.py#L144-L145

Violations of this assumption have come up before in #295 and #351 and been fixed by removing the comma.

There are some commas in UK holiday names causing the same problem:
```Python
import datetime
import holidays

uk_holidays = holidays.UK(years=[2021])
x = uk_holidays.get_list(datetime.date(2021, 8, 30))
print(x)
# ['Late Summer Bank Holiday [England', 'Wales', 'Northern Ireland]']
```
where it is split into a 3-element list instead of being a single element.

This fixes it by removing the commas. After the fix, the code above prints `['Late Summer Bank Holiday [England/Wales/Northern Ireland]']` as expected.