### PR TITLE
Use setup.cfg only pattern instead of bump2version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,8 @@ repos:
     hooks:
       - id: rstcheck
         additional_dependencies: [rstcheck]
+
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.16.0
+    hooks:
+      - id: setup-cfg-fmt

--- a/holidays/countries/jamaica.py
+++ b/holidays/countries/jamaica.py
@@ -24,7 +24,7 @@ class Jamaica(HolidayBase):
     # https://en.wikipedia.org/wiki/Public_holidays_in_Jamaica
 
     def __init__(self, **kwargs):
-        self.country = 'JM'
+        self.country = "JM"
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
@@ -33,7 +33,7 @@ class Jamaica(HolidayBase):
         name = "New Year's Day"
         _date = date(year, JAN, 1)
         if self.observed and _date.weekday() == SUN:
-            self[_date + rd(weekday=MO(+1))] = name + ' (Observed)'
+            self[_date + rd(weekday=MO(+1))] = name + " (Observed)"
         else:
             self[_date] = name
 
@@ -47,7 +47,7 @@ class Jamaica(HolidayBase):
         name = "Labour Day"
         _date = date(year, MAY, 23)
         if self.observed and _date.weekday() == SUN:
-            self[_date + rd(weekday=MO)] = name + ' (Observed)'
+            self[_date + rd(weekday=MO)] = name + " (Observed)"
         else:
             self[_date] = name
 
@@ -58,7 +58,7 @@ class Jamaica(HolidayBase):
         name = "Emancipation Day"
         _date = date(year, AUG, 1)
         if self.observed and _date.weekday() == SUN:
-            self[_date + rd(weekday=MO)] = name + ' (Observed)'
+            self[_date + rd(weekday=MO)] = name + " (Observed)"
         else:
             self[_date] = name
 

--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -100,7 +100,12 @@ class SouthAfrica(HolidayBase):
         # As of 1995/1/1, whenever a public holiday falls on a Sunday,
         # it rolls over to the following Monday
         for k, v in list(self.items()):
-            if self.observed and year > 1994 and k.weekday() == SUN and k.year == year:
+            if (
+                self.observed
+                and year > 1994
+                and k.weekday() == SUN
+                and k.year == year
+            ):
                 add_days = 1
                 while self.get(k + rd(days=add_days)) is not None:
                     add_days += 1

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -14,5 +14,4 @@ flake8
 
 #deployment
 pip>=19.2.3
-bump2version
 wheel>=0.33.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,15 +1,46 @@
-[bumpversion]
-current_version = 0.10.5.3
-commit = True
-tag = True
+[metadata]
+name = holidays
+version = attr: holidays.__version__
+description = Generate and work with holidays in Python
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+url = https://github.com/dr-prodigy/python-holidays
+author = ryanss
+author_email = ryanssdev@icloud.com
+maintainer = dr-prodigy
+maintainer_email = maurizio.montel@gmail.com
+license = MIT
+license_file = LICENSE
+platforms = any
+classifiers =
+    Development Status :: 4 - Beta
+    Intended Audience :: Developers
+    License :: OSI Approved :: MIT License
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+    Topic :: Office/Business :: Scheduling
+    Topic :: Software Development :: Libraries :: Python Modules
+    Topic :: Software Development :: Localization
 
-[bumpversion:file:setup.py]
-search = version='{current_version}',
-replace = version='{new_version}',
-
-[bumpversion:file:holidays/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
+[options]
+packages =
+    holidays
+    holidays/countries
+install_requires =
+    convertdate>=2.3.0
+    hijri_converter
+    korean_lunar_calendar
+    python-dateutil
+    six
+python_requires = >=3.6
 
 [flake8]
 extend-ignore = E203,F401,W503,W504
@@ -17,5 +48,4 @@ exclude = __init__.py,*.pyc,tests.py
 paths = ./holidays/ ./tests/
 
 [rstcheck]
-# This is needed since the comments in 'More Examples' make it invalid python code
 ignore_language = python

--- a/setup.py
+++ b/setup.py
@@ -10,58 +10,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import codecs
-import re
 
-try:
-    from setuptools import setup
-except ImportError:
-    from distutils.core import setup
+from setuptools import setup
 
-
-with codecs.open("holidays/__init__.py", "r", "utf-8") as fd:
-    version = re.search(
-        r'^__version__\s*=\s*[\'"]([^\'"]*)[\'"]', fd.read(), re.MULTILINE
-    ).group(1)
-
-if not version:
-    raise RuntimeError("Cannot find version information")
-
-setup(
-    name="holidays",
-    version=version,
-    author="ryanss",
-    author_email="ryanssdev@icloud.com",
-    maintainer="dr-prodigy",
-    maintainer_email="maurizio.montel@gmail.com",
-    url="https://github.com/dr-prodigy/python-holidays",
-    packages=["holidays", "holidays/countries"],
-    license="MIT",
-    description="Generate and work with holidays in Python",
-    long_description=codecs.open("README.rst", encoding="utf-8").read(),
-    install_requires=[
-        "python-dateutil",
-        "six",
-        "convertdate>=2.3.0",
-        "korean_lunar_calendar",
-        "hijri_converter",
-    ],
-    platforms="any",
-    classifiers=[
-        "Development Status :: 4 - Beta",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-        "Topic :: Office/Business :: Scheduling",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Software Development :: Localization",
-    ],
-)
+setup()


### PR DESCRIPTION
[As mentioned](https://github.com/dr-prodigy/python-holidays/pull/404#issuecomment-811237868), using a `setup.cfg` only pattern has the benefit (as does `bump2version`) that you only have to manage the version string in one place but in contrast to `bump2version` you don't need to take care of all the version parsing, replacing and especially that bug with the trailing whitespace which together with `pre-commit` nullifies all the benefits of `bump2version`.

### How a typical release workflow would look like
1. Change the version  string of `__version__` in `holidays/.__init__.py` to the desired value (push or PR)
2. Create a new release in the [release tab](https://github.com/dr-prodigy/python-holidays/releases), this will also create a tag
3. Wait for the CI to publish it to PyPi 🎉 

Here is also [proof that the release works](https://test.pypi.org/project/holidays/) as desired, with a quick release in the [PyPi test server](https://packaging.python.org/guides/using-testpypi/)

closes #404 closes #452