### PR TITLE
Added Singapore official holidays for 2022

### DIFF
--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -45,7 +45,7 @@ class Singapore(HolidayBase):
 
     # Holidays prior to 2000 may not be accurate.
 
-    # Holidays after 2021: the following four moving date holidays whose exact
+    # Holidays after 2022: the following four moving date holidays whose exact
     # date is announced yearly are estimated (and so denoted):
     # - Hari Raya Puasa*
     # - Hari Raya Haji*
@@ -94,6 +94,7 @@ class Singapore(HolidayBase):
             2019: [(JUN, 5)],
             2020: [(MAY, 24)],
             2021: [(MAY, 13)],
+            2022: [(MAY, 2)],
         }
         if year in dates_obs:
             for date_obs in dates_obs[year]:
@@ -141,6 +142,7 @@ class Singapore(HolidayBase):
             2019: [(AUG, 11)],
             2020: [(JUL, 31)],
             2021: [(JUL, 20)],
+            2022: [(JUL, 9)],
         }
         if year in dates_obs:
             for date_obs in dates_obs[year]:
@@ -190,6 +192,7 @@ class Singapore(HolidayBase):
             2019: (MAY, 19),
             2020: (MAY, 7),
             2021: (MAY, 26),
+            2022: (MAY, 15),
         }
         if year in dates_obs:
             hol_date = date(year, *dates_obs[year])
@@ -226,6 +229,7 @@ class Singapore(HolidayBase):
             2019: (OCT, 27),
             2020: (NOV, 14),
             2021: (NOV, 4),
+            2022: (NOV, 24),
         }
         if year in dates_obs:
             hol_date = date(year, *dates_obs[year])

--- a/test/countries/test_singapore.py
+++ b/test/countries/test_singapore.py
@@ -48,7 +48,7 @@ class TestSingapore(unittest.TestCase):
         self.assertIn(date(2018, 8, 22), self.holidays)
         self.assertIn(date(2018, 11, 6), self.holidays)
         self.assertIn(date(2018, 12, 25), self.holidays)
-        # total holidays (11 + 0 falling on a Sunday)
+        # 2018: total holidays (11 + 0 falling on a Sunday)
         self.assertEqual(len(holidays.Singapore(years=[2018])), 11 + 0)
         # 2019
         self.assertIn(date(2019, 1, 1), self.holidays)
@@ -62,7 +62,7 @@ class TestSingapore(unittest.TestCase):
         self.assertIn(date(2019, 8, 11), self.holidays)
         self.assertIn(date(2019, 10, 27), self.holidays)
         self.assertIn(date(2019, 12, 25), self.holidays)
-        # total holidays (11 + 3 falling on a Sunday)
+        # 2019: total holidays (11 + 3 falling on a Sunday)
         self.assertEqual(len(holidays.Singapore(years=[2019])), 11 + 3)
         # 2020
         self.assertIn(date(2020, 1, 1), self.holidays)
@@ -76,11 +76,43 @@ class TestSingapore(unittest.TestCase):
         self.assertIn(date(2020, 8, 9), self.holidays)
         self.assertIn(date(2020, 11, 14), self.holidays)
         self.assertIn(date(2020, 12, 25), self.holidays)
-        # total holidays (11 + 3 falling on a Sunday)
+        # 2020: total holidays (11 + 3 falling on a Sunday)
         self.assertEqual(len(holidays.Singapore(years=[2020])), 11 + 4)
-        # holidays estimated using lunar calendar
+        # 2021
+        self.assertIn(date(2021, 1, 1), self.holidays)
+        self.assertIn(date(2021, 2, 12), self.holidays)
+        self.assertIn(date(2021, 2, 13), self.holidays)
+        self.assertIn(date(2021, 4, 2), self.holidays)
+        self.assertIn(date(2021, 5, 1), self.holidays)
+        self.assertIn(date(2021, 5, 13), self.holidays)
         self.assertIn(date(2021, 5, 26), self.holidays)
+        self.assertIn(date(2021, 7, 20), self.holidays)
+        self.assertIn(date(2021, 8, 9), self.holidays)
         self.assertIn(date(2021, 11, 4), self.holidays)
+        self.assertIn(date(2021, 12, 25), self.holidays)
+        # 2021: total holidays (11)
+        self.assertEqual(len(holidays.Singapore(years=[2021])), 11)
+        # 2022
+        self.assertIn(date(2022, 1, 1), self.holidays)
+        self.assertIn(date(2022, 2, 1), self.holidays)
+        self.assertIn(date(2022, 2, 2), self.holidays)
+        self.assertIn(date(2022, 4, 15), self.holidays)
+        self.assertIn(date(2022, 5, 1), self.holidays)
+        self.assertIn(date(2022, 5, 2), self.holidays)
+        self.assertIn(date(2022, 5, 3), self.holidays)
+        self.assertIn(date(2022, 5, 15), self.holidays)
+        self.assertIn(date(2022, 5, 16), self.holidays)
+        self.assertIn(date(2022, 7, 9), self.holidays)
+        self.assertIn(date(2022, 8, 9), self.holidays)
+        self.assertIn(date(2022, 11, 24), self.holidays)
+        self.assertIn(date(2022, 12, 25), self.holidays)
+        self.assertIn(date(2022, 12, 26), self.holidays)
+        # 2022: total holidays (11 + 3 falling on a Sunday)
+        self.assertEqual(len(holidays.Singapore(years=[2022])), 11 + 3)
+
+        # holidays estimated using lunar calendar
+        self.assertIn(date(2023, 6, 2), self.holidays)  # Vesak Day
+        self.assertIn(date(2023, 11, 11), self.holidays)  # Deepavali
         # holidays estimated using library hijri-converter
         if sys.version_info >= (3, 6):
             import importlib.util
@@ -89,5 +121,9 @@ class TestSingapore(unittest.TestCase):
                 # <= 1968 holidays
                 self.assertIn(date(1968, 1, 2), self.holidays)
                 # 2021
-                self.assertIn(date(2021, 5, 13), self.holidays)
-                self.assertIn(date(2021, 7, 20), self.holidays)
+                self.assertIn(
+                    date(2023, 4, 21), self.holidays
+                )  # Hari Raya Puasa
+                self.assertIn(
+                    date(2023, 6, 28), self.holidays
+                )  # Hari Raya Haji


### PR DESCRIPTION
Freshly released per https://www.mom.gov.sg/employment-practices/public-holidays