### PR TITLE
Fix Spain Good Friday (#468)

### DIFF
--- a/holidays/countries/spain.py
+++ b/holidays/countries/spain.py
@@ -117,7 +117,7 @@ class Spain(HolidayBase):
             self._is_observed(date(year, MAR, 19), "San José")
         if self.prov and self.prov not in ["CT", "VC"]:
             self[easter(year) + rd(weeks=-1, weekday=TH)] = "Jueves Santo"
-            self[easter(year) + rd(weeks=-1, weekday=FR)] = "Viernes Santo"
+        self[easter(year) + rd(weeks=-1, weekday=FR)] = "Viernes Santo"
         if self.prov and self.prov in ["CT", "PV", "NC", "VC", "IB", "CM"]:
             self[easter(year) + rd(weekday=MO)] = "Lunes de Pascua"
         self._is_observed(date(year, MAY, 1), "Día del Trabajador")

--- a/test/countries/test_spain.py
+++ b/test/countries/test_spain.py
@@ -63,9 +63,7 @@ class TestES(unittest.TestCase):
             self.assertEqual(
                 date(2016, 3, 24) in prov_holidays, prov not in ["CT", "VC"]
             )
-            self.assertEqual(
-                date(2016, 3, 25) in prov_holidays, prov not in ["CT", "VC"]
-            )
+            assert date(2016, 3, 25) in prov_holidays
             self.assertEqual(
                 date(2016, 3, 28) in prov_holidays,
                 prov in ["CT", "PV", "NC", "VC", "IB", "CM"],


### PR DESCRIPTION
Hi @dr-prodigy 

AFAIK, _Good Friday_ (2021-04-02 this year) is one of the few **national** holidays in Spain, (and it's also defined as that in https://www.timeanddate.com/holidays/spain/good-friday), but in the library it is ~~strangely~~ excluded from 2 states ("CT", "VC")

This PR removes that scenario, adding it as holiday for the full country. 

Also closes #468 :)

More detailed info can be found in a table in this PDF from the Official Gazette about the holidays for 2021 (section 'ANEXO Año 2021'): https://www.boe.es/boe/dias/2020/11/02/pdfs/BOE-A-2020-13343.pdf 