### PR TITLE
Add Juneteenth National Independence Day to US

### DIFF
--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -375,6 +375,10 @@ class UnitedStates(HolidayBase):
                 elif date(year, JUN, 11).weekday() == SUN:
                     self[date(year, JUN, 12)] = "Kamehameha Day (Observed)"
 
+        # Juneteenth National Independence Day
+        if year >= 2021:
+            self[date(year, JUN, 19)] = "Juneteenth National Independence Day"
+
         # Emancipation Day In Texas
         if self.state == "TX" and year >= 1980:
             self[date(year, JUN, 19)] = "Emancipation Day In Texas"

--- a/test/countries/test_united_states.py
+++ b/test/countries/test_united_states.py
@@ -667,9 +667,15 @@ class TestUS(unittest.TestCase):
     def test_emancipation_day_in_texas(self):
         tx_holidays = holidays.US(state="TX")
         self.assertNotIn(date(1979, 6, 19), tx_holidays)
-        for year in (1980, 2050):
+        for year in (1980, 2020):
             self.assertNotIn(date(year, 6, 19), self.holidays)
             self.assertIn(date(year, 6, 19), tx_holidays)
+        for year in (2021, 2050):
+            self.assertIn(date(year, 6, 19), tx_holidays)
+
+    def test_juneteenth(self):
+        self.assertNotIn(date(2020, 6, 19), self.holidays)
+        self.assertIn(date(2021, 6, 19), self.holidays)
 
     def test_west_virginia_day(self):
         wv_holidays = holidays.US(state="WV")


### PR DESCRIPTION
The US has passed a bill making Juneteenth National Independence Day a federal legal public holiday (June 19th). This PR adds the holiday.

Senate bill: https://www.congress.gov/bill/117th-congress/senate-bill/475/text

This change also updates tests for Emancipation Day in Texas beyond 2021, since it had asserted that there was no federal holiday on June 19th.

Closes #475