### PR TITLE
Strip leading whitespace Botswana holiday movement

### DIFF
--- a/holidays/countries/botswana.py
+++ b/holidays/countries/botswana.py
@@ -100,7 +100,7 @@ class Botswana(HolidayBase):
                 # Add an (Observed) for the one that is not (Observed)
                 for i in self.get(k).split(","):
                     if " (Observed)" not in i:
-                        self[k + rd(days=1)] = i + " (Observed)"
+                        self[k + rd(days=1)] = i.lstrip() + " (Observed)"
 
         # Once off ad-hoc holidays
         self[date(2019, JUL, 2)] = "Public Holiday"


### PR DESCRIPTION
If a public holiday falls on an observed holiday, that public holiday is observed the next day. 
To implement this get the public holidays after adding the observed holidays and then splitting strings where more than one holidays falls on a date.
Added .lstrip() to this in order to remove the leading space