### PR TITLE
Update readme file: alphabetically order "prov/state" entries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,10 @@ specific date is a holiday as fast and flexible as possible.
 
 .. image:: http://img.shields.io/pypi/l/holidays.svg
     :target: https://github.com/dr-prodigy/python-holidays/blob/master/LICENSE
+    
+.. image:: https://img.shields.io/conda/v/conda-forge/holidays?color=blue&logo=anaconda
+    :target: https://anaconda.org/conda-forge/holidays
+    :alt: conda version
 
 
 Example Usage
@@ -89,6 +93,12 @@ If the above fails, please use easy_install instead:
 .. code-block:: bash
 
     $ easy_install holidays
+    
+Alternatively, you can install it with conda (Anaconda/Miniconda):
+
+.. code-block:: bash
+
+    $ conda install -c conda-forge holidays
 
 
 Available Countries

--- a/README.rst
+++ b/README.rst
@@ -17,10 +17,6 @@ specific date is a holiday as fast and flexible as possible.
 
 .. image:: http://img.shields.io/pypi/l/holidays.svg
     :target: https://github.com/dr-prodigy/python-holidays/blob/master/LICENSE
-    
-.. image:: https://img.shields.io/conda/v/conda-forge/holidays?color=blue&logo=anaconda
-    :target: https://anaconda.org/conda-forge/holidays
-    :alt: conda version
 
 
 Example Usage
@@ -93,12 +89,6 @@ If the above fails, please use easy_install instead:
 .. code-block:: bash
 
     $ easy_install holidays
-    
-Alternatively, you can install it with conda (Anaconda/Miniconda):
-
-.. code-block:: bash
-
-    $ conda install -c conda-forge holidays
 
 
 Available Countries

--- a/README.rst
+++ b/README.rst
@@ -130,8 +130,8 @@ France              FR/FRA    **Métropole** (default), Alsace-Moselle, Guadelou
                               Polynésie Française, Saint-Barthélémy, Saint-Martin,
                               Wallis-et-Futuna
 Georgia             GE/GEO
-Germany             DE/DEU    prov = BW, BY, BYP, BE, BB, HB, HH, HE, MV, NI, NW, RP, SL,
-                              SN, ST, SH, TH
+Germany             DE/DEU    prov = BB, BE, BW, BY, BYP, HB, HE, HH, MV, NI, NW, RP, SH,
+                              SL, SN, ST, TH
 Greece              GR/GRC    None
 Honduras            HN/HND    None
 HongKong            HK/HKG    None

--- a/README.rst
+++ b/README.rst
@@ -105,8 +105,8 @@ Austria             AT/AUT    prov = 1, 2, 3, 4, 5, 6, 7, 8, **9** (default)
 Bangladesh          BD/BDG    None
 Belarus             BY/BLR    None
 Belgium             BE/BEL    None
-Brazil              BR/BRA    state = AC, AL, AP, AM, BA, CE, DF, ES, GO, MA, MT, MS, MG,
-                              PA, PB, PE, PI, RJ, RN, RS, RO, RR, SC, SP, SE, TO
+Brazil              BR/BRA    state = AC, AL, AM, AP, BA, CE, DF, ES, GO, MA, MG, MS, MT,
+                              PA, PB, PE, PI, RJ, RN, RO, RR, RS, SC, SE, SP, TO
 Bulgaria            BG/BLG    None
 Burundi             BI/BDI    None
 Canada              CA/CAN    prov = AB, BC, MB, NB, NL, NS, NT, NU, **ON** (default),

--- a/README.rst
+++ b/README.rst
@@ -137,8 +137,8 @@ Honduras            HN/HND    None
 HongKong            HK/HKG    None
 Hungary             HU/HUN    None
 Iceland             IS/ISL    None
-India               IN/IND    prov = AS, SK, CG, KA, GJ, BR, RJ, OD, TN, AP, WB, KL, HR,
-                              MH, MP, UP, UK, TN
+India               IN/IND    prov = AP, AS, BR, CG, GJ, HR, KA, KL, MH, MP, OD, RJ, SK,
+                              TN, TN, UK, UP, WB
 Ireland             IE/IRL    None
 IsleOfMan                     None
 Israel              IL/ISR    None

--- a/README.rst
+++ b/README.rst
@@ -157,8 +157,8 @@ Mexico              MX/MEX    None
 Morocco             MA/MOR    None
 Mozambique          MZ/MOZ    None
 Netherlands         NL/NLD    None
-NewZealand          NZ/NZL    prov = NTL, AUK, TKI, HKB, WGN, MBH, NSN, CAN, STC, WTL,
-                              OTA, STL, CIT
+NewZealand          NZ/NZL    prov = AUK, CAN, CIT, HKB, MBH, NSN, NTL, OTA, STC, STL,
+                              TKI, WGN, WTL
 Nicaragua           NI/NIC    prov = MN
 Nigeria             NG/NGA    None
 NorthernIreland               None


### PR DESCRIPTION
This closes #484.

- [x] The changes are only in the [README](README.rst) file.

I used a convenience function for sorting, keeping it documented here for quick access.

```python
sortme = lambda p: ', '.join(sorted([str(x) for x in p.split(", ")]))

## For NewZealand
prov = "NTL, AUK, TKI, HKB, WGN, MBH, NSN, CAN, STC, WTL, OTA, STL, CIT"
sortme(prov)
# Output: 'AUK, CAN, CIT, HKB, MBH, NSN, NTL, OTA, STC, STL, TKI, WGN, WTL'
```