### PR TITLE
Correct 2022 Spring Bank Holiday

### DIFF
--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -147,6 +147,8 @@ class UnitedKingdom(HolidayBase):
         name = "Spring Bank Holiday"
         if year == 2012:
             self[date(year, JUN, 4)] = name
+        elif year == 2022:
+            self[date(year, JUN, 2)] = name
         elif year >= 1971:
             self[date(year, MAY, 31) + rd(weekday=MO(-1))] = name
 


### PR DESCRIPTION
The Spring Bank Holiday is normally the last Monday in May. In 2022 it is moving to 2nd June to allow for a four day weekend, as per https://www.gov.uk/bank-holidays