### PR TITLE
Removed dependency on six

### DIFF
--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -13,7 +13,6 @@
 
 from datetime import timedelta, datetime, date
 
-import six
 from dateutil.parser import parse
 
 
@@ -61,7 +60,7 @@ class HolidayBase(dict):
             key = key
         elif isinstance(key, int) or isinstance(key, float):
             key = datetime.utcfromtimestamp(key).date()
-        elif isinstance(key, six.string_types):
+        elif isinstance(key, str):
             try:
                 key = parse(key).date()
             except (ValueError, OverflowError):

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,5 @@
 # package runtime requirements
 python-dateutil
-six
 convertdate>=2.3.0
 korean_lunar_calendar
 hijri_converter
@@ -12,6 +11,6 @@ coverage[toml]
 pre-commit
 flake8
 
-#deployment
+# deployment
 pip>=19.2.3
 wheel>=0.33.6

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,7 +39,6 @@ install_requires =
     hijri_converter
     korean_lunar_calendar
     python-dateutil
-    six
 python_requires = >=3.6
 
 [flake8]


### PR DESCRIPTION
We no longer support Python 2 so importing `six` no longer has any utility.

I have replaced the only instance of the module usage with the Python 3 equivalent (see https://six.readthedocs.io/#six.string_types) and have removed `six` as a project dependency.  Fixing typos (space missing) is a side benefit ;)