### PR TITLE
New Zealand: Matariki

### DIFF
--- a/holidays/countries/new_zealand.py
+++ b/holidays/countries/new_zealand.py
@@ -16,7 +16,7 @@ from datetime import date
 from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd, MO, FR, WE, TU
 
-from holidays.constants import JAN, FEB, MAR, APR, JUN, SEP, OCT, NOV, DEC
+from holidays.constants import JAN, FEB, MAR, APR, JUN, JUL, SEP, OCT, NOV, DEC
 from holidays.constants import TUE, WED, THU, WEEKEND
 from holidays.holiday_base import HolidayBase
 
@@ -109,6 +109,71 @@ class NewZealand(HolidayBase):
         elif year > 1901:
             # http://paperspast.natlib.govt.nz/cgi-bin/paperspast?a=d&d=NZH19091110.2.67
             self[date(year, NOV, 9)] = name  # Edward VII
+
+        # Matariki
+        name = "Matariki"
+        if year == 2022:
+            self[date(year, JUN, 24)] = name
+        elif year == 2023:
+            self[date(year, JUL, 14)] = name
+        elif year == 2024:
+            self[date(year, JUN, 28)] = name
+        elif year == 2025:
+            self[date(year, JUN, 20)] = name
+        elif year == 2026:
+            self[date(year, JUL, 10)] = name
+        elif year == 2027:
+            self[date(year, JUN, 25)] = name
+        elif year == 2028:
+            self[date(year, JUL, 14)] = name
+        elif year == 2029:
+            self[date(year, JUL, 6)] = name
+        elif year == 2030:
+            self[date(year, JUN, 21)] = name
+        elif year == 2031:
+            self[date(year, JUL, 11)] = name
+        elif year == 2032:
+            self[date(year, JUL, 2)] = name
+        elif year == 2033:
+            self[date(year, JUN, 24)] = name
+        elif year == 2034:
+            self[date(year, JUL, 7)] = name
+        elif year == 2035:
+            self[date(year, JUN, 29)] = name
+        elif year == 2036:
+            self[date(year, JUL, 18)] = name
+        elif year == 2037:
+            self[date(year, JUL, 10)] = name
+        elif year == 2038:
+            self[date(year, JUN, 25)] = name
+        elif year == 2039:
+            self[date(year, JUL, 15)] = name
+        elif year == 2040:
+            self[date(year, JUL, 6)] = name
+        elif year == 2041:
+            self[date(year, JUL, 19)] = name
+        elif year == 2042:
+            self[date(year, JUL, 11)] = name
+        elif year == 2043:
+            self[date(year, JUL, 3)] = name
+        elif year == 2044:
+            self[date(year, JUN, 24)] = name
+        elif year == 2045:
+            self[date(year, JUL, 7)] = name
+        elif year == 2046:
+            self[date(year, JUN, 29)] = name
+        elif year == 2047:
+            self[date(year, JUL, 19)] = name
+        elif year == 2048:
+            self[date(year, JUL, 3)] = name
+        elif year == 2049:
+            self[date(year, JUN, 25)] = name
+        elif year == 2050:
+            self[date(year, JUL, 15)] = name
+        elif year == 2051:
+            self[date(year, JUN, 30)] = name
+        elif year == 2052:
+            self[date(year, JUN, 21)] = name
 
         # Labour Day
         name = "Labour Day"

--- a/test/countries/test_new_zealand.py
+++ b/test/countries/test_new_zealand.py
@@ -249,6 +249,46 @@ class TestNZ(unittest.TestCase):
             self.assertIn(dt, self.holidays, dt)
             self.assertEqual(self.holidays[dt], "Queen's Birthday")
 
+    def test_matariki(self):
+        for dt in [
+            date(2022, 6, 24),
+            date(2023, 7, 14),
+            date(2024, 6, 28),
+            date(2025, 6, 20),
+            date(2026, 7, 10),
+            date(2027, 6, 25),
+            date(2028, 7, 14),
+            date(2029, 7, 6),
+            date(2030, 6, 21),
+            date(2031, 7, 11),
+            date(2032, 7, 2),
+            date(2033, 6, 24),
+            date(2034, 7, 7),
+            date(2035, 6, 29),
+            date(2036, 7, 18),
+            date(2037, 7, 10),
+            date(2038, 6, 25),
+            date(2039, 7, 15),
+            date(2040, 7, 6),
+            date(2041, 7, 19),
+            date(2042, 7, 11),
+            date(2043, 7, 3),
+            date(2044, 6, 24),
+            date(2045, 7, 7),
+            date(2046, 6, 29),
+            date(2047, 7, 19),
+            date(2048, 7, 3),
+            date(2049, 6, 25),
+            date(2050, 7, 15),
+            date(2051, 6, 30),
+            date(2052, 6, 21)
+        ]:
+            self.assertIn(dt, self.holidays)
+            self.assertEqual(self.holidays[dt], "Matariki")
+            self.assertNotIn(dt + relativedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + relativedelta(days=+1), self.holidays)
+
+
     def test_labour_day(self):
         for year, day in enumerate(
             [


### PR DESCRIPTION
Add Matariki for New Zealand

Dates from here: https://www.mbie.govt.nz/assets/matariki-dates-2022-to-2052-matariki-advisory-group.pdf