### PR TITLE
Add new Kenyan holiday and edit existing one

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ coverage.xml
 .idea
 .vscode/
 *.code-workspace
+Pipfile

--- a/holidays/countries/kenya.py
+++ b/holidays/countries/kenya.py
@@ -24,6 +24,7 @@ from holidays.holiday_base import HolidayBase
 class Kenya(HolidayBase):
     # https://en.wikipedia.org/wiki/Public_holidays_in_Kenya
     # http://kenyaembassyberlin.de/Public-Holidays-in-Kenya.48.0.html
+    # https://www.officeholidays.com/holidays/kenya/moi-day
     def __init__(self, **kwargs):
         self.country = "KE"
         HolidayBase.__init__(self, **kwargs)
@@ -33,10 +34,11 @@ class Kenya(HolidayBase):
         self[date(year, JAN, 1)] = "New Year's Day"
         self[date(year, MAY, 1)] = "Labour Day"
         self[date(year, JUN, 1)] = "Madaraka Day"
+        self[date(year, OCT, 10)] = "Huduma Day"
         self[date(year, OCT, 20)] = "Mashujaa Day"
         self[date(year, DEC, 12)] = "Jamhuri (Independence) Day"
         self[date(year, DEC, 25)] = "Christmas Day"
-        self[date(year, DEC, 26)] = "Boxing Day"
+        self[date(year, DEC, 26)] = "Utamaduni Day"
         for k, v in list(self.items()):
             if self.observed and k.weekday() == SUN:
                 self[k + rd(days=1)] = v + " (Observed)"

--- a/test/countries/test_kenya.py
+++ b/test/countries/test_kenya.py
@@ -33,11 +33,13 @@ class TestKenya(unittest.TestCase):
         self.assertIn(date(2019, 5, 1), self.holidays)
         # Madaraka Day
         self.assertIn(date(2019, 6, 1), self.holidays)
+        # Huduma Day
+        self.assertIn(date(2019, 10, 10), self.holidays)
         # Mashujaa Day
         self.assertIn(date(2019, 10, 20), self.holidays)
         # Jamhuri (Independence) Day
         self.assertIn(date(2019, 12, 12), self.holidays)
         # Christmas Day
         self.assertIn(date(2019, 12, 25), self.holidays)
-        # Boxing Day
+        # Utamaduni Day
         self.assertIn(date(2018, 12, 26), self.holidays)


### PR DESCRIPTION
## Description

- Added a new Kenyan Holiday I noticed missing Huduma (translated Service) day on the 10th of October. Reference for this change can be found [here](https://citizentv.co.ke/news/govt-renames-moi-day-to-huduma-day-boxing-day-to-utamaduni-day-309914/).
- Renamed the Boxing day holiday (26th December), which was officially changed to Utamaduni(translated Cultural) day. Reference for this change can be found [here](https://en.wikipedia.org/wiki/Public_holidays_in_Kenya) and also [here](https://www.tuko.co.ke/261515-gazetted-public-holidays-kenya.html#:~:text=Huduma%20Day%20%2D10th%20October&text=Huduma%20Day%20is%20a%20public,declaration%20of%20the%20new%20constitution.)