### PR TITLE
give Korea liberation day an alt_holiday

### DIFF
--- a/holidays/countries/korea.py
+++ b/holidays/countries/korea.py
@@ -137,8 +137,13 @@ class Korea(HolidayBase):
         # Liberation Day
         name = "Liberation Day"
         libration_date = date(year, AUG, 15)
-        if self.observed and year >= 1945:
+        if year >= 1945:
             self[libration_date] = name
+            if self.observed and year >= 2021:
+                if libration_date.weekday() == SUN:
+                    self[libration_date + rd(days=+1)] = alt_holiday + name
+                if libration_date.weekday() == SAT:
+                    self[libration_date + rd(days=+2)] = alt_holiday + name
         else:
             pass
 

--- a/test/countries/test_korea.py
+++ b/test/countries/test_korea.py
@@ -243,6 +243,9 @@ class TestKorea(unittest.TestCase):
             self.assertEqual(
                 self.holidays[date(year, 8, 15)], "Liberation Day"
             )
+        self.assertEqual(
+            self.holidays[date(2021, 8, 16)], "Alternative holiday of Liberation Day"
+        )
 
     def test_chuseok(self):
         for year, month, day in [


### PR DESCRIPTION
https://www.officeholidays.com/holidays/south-korea/south-korea-liberation-day
https://www.koreatimes.co.kr/www/opinion/2021/07/202_310642.html

since 2021, the liberation day has alt holiday when it's on the weekend