### PR TITLE
Australia\QLD Royal Queensland Show holiday moved for 2021.

### DIFF
--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -227,6 +227,8 @@ class Australia(HolidayBase):
             name = "The Royal Queensland Show"
             if year == 2020:
                 self[date(year, AUG, 14)] = name
+            if year == 2021:
+                self[date(year, OCT, 29)] = name
             else:
                 self[
                     date(year, AUG, 5) + rd(weekday=FR) + rd(weekday=WE)

--- a/test/countries/test_australia.py
+++ b/test/countries/test_australia.py
@@ -289,8 +289,11 @@ class TestAU(unittest.TestCase):
             self.assertEqual(self.state_hols["VIC"][dt], "Melbourne Cup")
 
     def test_royal_queensland_show(self):
-        for year, day in enumerate([15, 14, 14, 11, 10, 16], 2018):
-            dt = date(year, 8, day)
+        for year, day in enumerate([15, 14, 14, 29, 10, 16], 2018):
+            if year != 2021:
+                dt = date(year, 8, day)
+            else:
+                dt = date(year, 10, day)
             self.assertIn(dt, self.state_hols["QLD"], dt)
             self.assertEqual(
                 self.state_hols["QLD"][dt], "The Royal Queensland Show"


### PR DESCRIPTION
The 2021 Royal Queensland Show (Ekka) holiday was moved to Friday 29 October.

See https://www.qld.gov.au/recreation/travel/holidays/public