### PR TITLE
Fix .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-*	text=lf
-*.bat	text eol=crlf
+*       text eol=lf
+*.bat   text eol=crlf


### PR DESCRIPTION
Fixed `.gitattributes` file (had incorrect syntax) so I can work on this in Windows without end-of-line conversion issues.