### PR TITLE
Refactor lunisolar and islamic calendar

### DIFF
--- a/holidays/countries/burundi.py
+++ b/holidays/countries/burundi.py
@@ -18,7 +18,7 @@ from dateutil.relativedelta import relativedelta as rd
 from holidays.constants import SUN
 from holidays.constants import JAN, FEB, APR, MAY, JUL, AUG, OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
-from holidays.utils import get_gre_date
+from holidays.utils import islamic_to_gre
 
 
 class Burundi(HolidayBase):
@@ -72,7 +72,7 @@ class Burundi(HolidayBase):
 
         # Eid Al Adha- Feast of the Sacrifice
         # date of observance is announced yearly
-        for date_obs in get_gre_date(year, 12, 10):
+        for date_obs in islamic_to_gre(year, 12, 10):
             hol_date = date_obs
             self[hol_date] = "Eid Al Adha"
             self[hol_date + rd(days=1)] = "Eid Al Adha"

--- a/holidays/countries/china.py
+++ b/holidays/countries/china.py
@@ -14,10 +14,10 @@
 from datetime import date
 
 from dateutil.relativedelta import relativedelta as rd
-from korean_lunar_calendar import KoreanLunarCalendar
 
 from holidays.constants import JAN, APR, MAY, OCT
 from holidays.holiday_base import HolidayBase
+from holidays.utils import ChineseLuniSolar
 
 
 class China(HolidayBase):
@@ -28,25 +28,22 @@ class China(HolidayBase):
     def __init__(self, **kwargs):
         self.country = "CN"
         HolidayBase.__init__(self, **kwargs)
-        self.lunar_cal = KoreanLunarCalendar()
+        self.cnls = ChineseLuniSolar()
 
     def _populate(self, year):
         # New Year's Day
         if year > 1949:
             self[date(year, JAN, 1)] = "New Year's Day"
             self[date(year, MAY, 1)] = "Labour Day"
-            self[
-                self.get_solar_date(year, 1, 1)
-            ] = "Chinese New Year (Spring Festival)"
-            self[
-                self.get_solar_date(year, 1, 2)
-            ] = "Chinese New Year (Spring Festival)"
+            hol_date = self.cnls.lunar_n_y_date(year)
+            self[hol_date] = "Chinese New Year (Spring Festival)"
+            self[hol_date + rd(days=+1)] = "Chinese New Year (Spring Festival)"
             self[date(year, OCT, 1)] = "National Day"
             self[date(year, OCT, 2)] = "National Day"
         if year > 2007:
             self[date(year, APR, 5)] = "Tomb-Sweeping Day"
-            self[self.get_solar_date(year, 5, 5)] = "Dragon Boat Festival"
-            self[self.get_solar_date(year, 8, 15)] = "Mid-Autumn Festival"
+            self[self.cnls.lunar_to_gre(year, 5, 5)] = "Dragon Boat Festival"
+            self[self.cnls.lunar_to_gre(year, 8, 15)] = "Mid-Autumn Festival"
         if (year > 1999) and (year <= 2007):
             self[date(year, MAY, 2)] = "Labour Day"
             self[date(year, MAY, 3)] = "Labour Day"
@@ -57,23 +54,12 @@ class China(HolidayBase):
             self[date(year, MAY, 3)] = "Labour Day"
         if (year > 2007) and (year <= 2013):
             self[
-                self.get_solar_date(year, 1, 1) + rd(days=-1)
+                self.cnls.lunar_to_gre(year, 1, 1) + rd(days=-1)
             ] = "Chinese New Year (Spring Festival)"
         elif year > 1949:
             self[
-                self.get_solar_date(year, 1, 3)
+                self.cnls.lunar_to_gre(year, 1, 3)
             ] = "Chinese New Year (Spring Festival)"
-
-    def get_solar_date(self, year, month, day):
-        """
-        convert lunar calendar date to solar
-        """
-        self.lunar_cal.setLunarDate(year, month, day, False)
-        return date(
-            self.lunar_cal.solarYear,
-            self.lunar_cal.solarMonth,
-            self.lunar_cal.solarDay,
-        )
 
 
 class CN(China):

--- a/holidays/countries/djibouti.py
+++ b/holidays/countries/djibouti.py
@@ -18,7 +18,7 @@ from dateutil.relativedelta import relativedelta as rd
 from holidays.constants import FRI, SAT
 from holidays.constants import JAN, MAY, JUN
 from holidays.holiday_base import HolidayBase
-from holidays.utils import get_gre_date
+from holidays.utils import islamic_to_gre
 
 WEEKEND = (FRI, SAT)
 
@@ -73,7 +73,7 @@ class Djibouti(HolidayBase):
 
         # Isra wal Miraj
         # The night journey of the prophet Muhammad
-        for date_obs in get_gre_date(year, 7, 27):
+        for date_obs in islamic_to_gre(year, 7, 27):
             hol_date = date_obs
             self[hol_date] = "Isra wal Miraj"
 
@@ -82,26 +82,26 @@ class Djibouti(HolidayBase):
         # having the Holiday on Weekend does change the number of days,
         # deceided to leave it since marking a Weekend as a holiday
         # wouldn't do much harm.
-        for date_obs in get_gre_date(year, 10, 1):
+        for date_obs in islamic_to_gre(year, 10, 1):
             hol_date = date_obs
             self[hol_date] = "Eid al-Fitr"
             self[hol_date + rd(days=1)] = "Eid al-Fitr deuxième jour"
 
         # Arafat & Eid al-Adha - Scarfice Festive
         # date of observance is announced yearly
-        for date_obs in get_gre_date(year, 12, 9):
+        for date_obs in islamic_to_gre(year, 12, 9):
             hol_date = date_obs
             self[hol_date] = "Arafat"
             self[hol_date + rd(days=1)] = "Eid al-Adha"
             self[hol_date + rd(days=2)] = "Eid al-Adha deuxième jour"
 
         # Islamic New Year - (hijari_year, 1, 1)
-        for date_obs in get_gre_date(year, 1, 1):
+        for date_obs in islamic_to_gre(year, 1, 1):
             hol_date = date_obs
             self[hol_date] = "Nouvel an musulman"
 
         # Prophet Muhammad's Birthday - (hijari_year, 3, 12)
-        for date_obs in get_gre_date(year, 3, 12):
+        for date_obs in islamic_to_gre(year, 3, 12):
             hol_date = date_obs
             self[hol_date] = "Naissance du prophet Muhammad"
 

--- a/holidays/countries/egypt.py
+++ b/holidays/countries/egypt.py
@@ -18,7 +18,7 @@ from dateutil.relativedelta import relativedelta as rd
 from holidays.constants import FRI, SAT
 from holidays.constants import JAN, APR, MAY, JUN, JUL, OCT
 from holidays.holiday_base import HolidayBase
-from holidays.utils import get_gre_date
+from holidays.utils import islamic_to_gre
 
 WEEKEND = (FRI, SAT)
 
@@ -100,7 +100,7 @@ class Egypt(HolidayBase):
         # having the Holiday on Weekend does change the number of days,
         # deceided to leave it since marking a Weekend as a holiday
         # wouldn't do much harm.
-        for date_obs in get_gre_date(year, 10, 1):
+        for date_obs in islamic_to_gre(year, 10, 1):
             hol_date = date_obs
             self[hol_date] = "Eid al-Fitr"
             self[hol_date + rd(days=1)] = "Eid al-Fitr Holiday"
@@ -108,7 +108,7 @@ class Egypt(HolidayBase):
 
         # Arafat Day & Eid al-Adha - Scarfice Festive
         # date of observance is announced yearly
-        for date_obs in get_gre_date(year, 12, 9):
+        for date_obs in islamic_to_gre(year, 12, 9):
             hol_date = date_obs
             self[hol_date] = "Arafat Day"
             self[hol_date + rd(days=1)] = "Eid al-Adha"
@@ -116,12 +116,12 @@ class Egypt(HolidayBase):
             self[hol_date + rd(days=3)] = "Eid al-Adha Holiday"
 
         # Islamic New Year - (hijari_year, 1, 1)
-        for date_obs in get_gre_date(year, 1, 1):
+        for date_obs in islamic_to_gre(year, 1, 1):
             hol_date = date_obs
             self[hol_date] = "Islamic New Year"
 
         # Prophet Muhammad's Birthday - (hijari_year, 3, 12)
-        for date_obs in get_gre_date(year, 3, 12):
+        for date_obs in islamic_to_gre(year, 3, 12):
             hol_date = date_obs
             self[hol_date] = "Prophet Muhammad's Birthday"
 

--- a/holidays/countries/hongkong.py
+++ b/holidays/countries/hongkong.py
@@ -19,6 +19,7 @@ from dateutil.relativedelta import relativedelta as rd, FR, SA, MO
 from holidays.constants import JAN, APR, MAY, JUL, SEP, OCT, DEC
 from holidays.constants import MON, TUE, WED, THU, FRI, SAT, SUN
 from holidays.holiday_base import HolidayBase
+from holidays.utils import ChineseLuniSolar
 
 
 class HongKong(HolidayBase):
@@ -29,6 +30,7 @@ class HongKong(HolidayBase):
     def __init__(self, **kwargs):
         self.country = "HK"
         HolidayBase.__init__(self, **kwargs)
+        self.cnls = ChineseLuniSolar()
 
     def _populate(self, year):
 
@@ -54,7 +56,7 @@ class HongKong(HolidayBase):
         second_day_lunar = "The second day of Lunar New Year"
         third_day_lunar = "The third day of Lunar New Year"
         fourth_day_lunar = "The fourth day of Lunar New Year"
-        dt = self.get_solar_date(year, 1, 1)
+        dt = self.cnls.lunar_n_y_date(year)
         new_year_date = date(dt.year, dt.month, dt.day)
         if self.observed:
             self[new_year_date] = name
@@ -86,8 +88,8 @@ class HongKong(HolidayBase):
 
         # Ching Ming Festival
         name = "Ching Ming Festival"
-        if self.isLeapYear(year) or (
-            self.isLeapYear(year - 1) and year > 2008
+        if self.is_leap_year(year) or (
+            self.is_leap_year(year - 1) and year > 2008
         ):
             ching_ming_date = date(year, APR, 4)
         else:
@@ -124,7 +126,7 @@ class HongKong(HolidayBase):
 
         # Birthday of the Buddha
         name = "Birthday of the Buddha"
-        dt = self.get_solar_date(year, 4, 8)
+        dt = self.cnls.lunar_to_gre(year, 4, 8)
         buddha_date = date(dt.year, dt.month, dt.day)
         if self.observed:
             if buddha_date.weekday() == SUN:
@@ -147,7 +149,7 @@ class HongKong(HolidayBase):
 
         # Tuen Ng Festival
         name = "Tuen Ng Festival"
-        dt = self.get_solar_date(year, 5, 5)
+        dt = self.cnls.lunar_to_gre(year, 5, 5)
         tuen_ng_date = date(dt.year, dt.month, dt.day)
         if self.observed:
             if tuen_ng_date.weekday() == SUN:
@@ -179,7 +181,7 @@ class HongKong(HolidayBase):
 
         # Chinese Mid-Autumn Festival
         name = "Chinese Mid-Autumn Festival"
-        dt = self.get_solar_date(year, 8, 15)
+        dt = self.cnls.lunar_to_gre(year, 8, 15)
         mid_autumn_date = date(dt.year, dt.month, dt.day)
         if self.observed:
             if mid_autumn_date.weekday() == SAT:
@@ -208,7 +210,7 @@ class HongKong(HolidayBase):
 
         # Chung Yeung Festival
         name = "Chung Yeung Festival"
-        dt = self.get_solar_date(year, 9, 9)
+        dt = self.cnls.lunar_to_gre(year, 9, 9)
         chung_yeung_date = date(dt.year, dt.month, dt.day)
         if self.observed:
             if chung_yeung_date.weekday() == SUN:
@@ -238,7 +240,7 @@ class HongKong(HolidayBase):
             self[christmas_date] = name
             self[christmas_date + rd(days=+1)] = day_following + name
 
-    def isLeapYear(self, year):
+    def is_leap_year(self, year):
         if year % 4 != 0:
             return False
         elif year % 100 != 0:
@@ -250,252 +252,6 @@ class HongKong(HolidayBase):
 
     def first_lower(self, s):
         return s[0].lower() + s[1:]
-
-    # Store the number of days per year from 1901 to 2099, and the number of
-    # days from the 1st to the 13th to store the monthly (including the month
-    # of the month), 1 means that the month is 30 days. 0 means the month is
-    # 29 days. The 12th to 15th digits indicate the month of the next month.
-    # If it is 0x0F, it means that there is no leap month.
-    g_lunar_month_days = [
-        0xF0EA4,
-        0xF1D4A,
-        0x52C94,
-        0xF0C96,
-        0xF1536,
-        0x42AAC,
-        0xF0AD4,
-        0xF16B2,
-        0x22EA4,
-        0xF0EA4,  # 1901-1910
-        0x6364A,
-        0xF164A,
-        0xF1496,
-        0x52956,
-        0xF055A,
-        0xF0AD6,
-        0x216D2,
-        0xF1B52,
-        0x73B24,
-        0xF1D24,  # 1911-1920
-        0xF1A4A,
-        0x5349A,
-        0xF14AC,
-        0xF056C,
-        0x42B6A,
-        0xF0DA8,
-        0xF1D52,
-        0x23D24,
-        0xF1D24,
-        0x61A4C,  # 1921-1930
-        0xF0A56,
-        0xF14AE,
-        0x5256C,
-        0xF16B4,
-        0xF0DA8,
-        0x31D92,
-        0xF0E92,
-        0x72D26,
-        0xF1526,
-        0xF0A56,  # 1931-1940
-        0x614B6,
-        0xF155A,
-        0xF0AD4,
-        0x436AA,
-        0xF1748,
-        0xF1692,
-        0x23526,
-        0xF152A,
-        0x72A5A,
-        0xF0A6C,  # 1941-1950
-        0xF155A,
-        0x52B54,
-        0xF0B64,
-        0xF1B4A,
-        0x33A94,
-        0xF1A94,
-        0x8152A,
-        0xF152E,
-        0xF0AAC,
-        0x6156A,  # 1951-1960
-        0xF15AA,
-        0xF0DA4,
-        0x41D4A,
-        0xF1D4A,
-        0xF0C94,
-        0x3192E,
-        0xF1536,
-        0x72AB4,
-        0xF0AD4,
-        0xF16D2,  # 1961-1970
-        0x52EA4,
-        0xF16A4,
-        0xF164A,
-        0x42C96,
-        0xF1496,
-        0x82956,
-        0xF055A,
-        0xF0ADA,
-        0x616D2,
-        0xF1B52,  # 1971-1980
-        0xF1B24,
-        0x43A4A,
-        0xF1A4A,
-        0xA349A,
-        0xF14AC,
-        0xF056C,
-        0x60B6A,
-        0xF0DAA,
-        0xF1D92,
-        0x53D24,  # 1981-1990
-        0xF1D24,
-        0xF1A4C,
-        0x314AC,
-        0xF14AE,
-        0x829AC,
-        0xF06B4,
-        0xF0DAA,
-        0x52D92,
-        0xF0E92,
-        0xF0D26,  # 1991-2000
-        0x42A56,
-        0xF0A56,
-        0xF14B6,
-        0x22AB4,
-        0xF0AD4,
-        0x736AA,
-        0xF1748,
-        0xF1692,
-        0x53526,
-        0xF152A,  # 2001-2010
-        0xF0A5A,
-        0x4155A,
-        0xF156A,
-        0x92B54,
-        0xF0BA4,
-        0xF1B4A,
-        0x63A94,
-        0xF1A94,
-        0xF192A,
-        0x42A5C,  # 2011-2020
-        0xF0AAC,
-        0xF156A,
-        0x22B64,
-        0xF0DA4,
-        0x61D52,
-        0xF0E4A,
-        0xF0C96,
-        0x5192E,
-        0xF1956,
-        0xF0AB4,  # 2021-2030
-        0x315AC,
-        0xF16D2,
-        0xB2EA4,
-        0xF16A4,
-        0xF164A,
-        0x63496,
-        0xF1496,
-        0xF0956,
-        0x50AB6,
-        0xF0B5A,  # 2031-2040
-        0xF16D4,
-        0x236A4,
-        0xF1B24,
-        0x73A4A,
-        0xF1A4A,
-        0xF14AA,
-        0x5295A,
-        0xF096C,
-        0xF0B6A,
-        0x31B54,  # 2041-2050
-        0xF1D92,
-        0x83D24,
-        0xF1D24,
-        0xF1A4C,
-        0x614AC,
-        0xF14AE,
-        0xF09AC,
-        0x40DAA,
-        0xF0EAA,
-        0xF0E92,  # 2051-2060
-        0x31D26,
-        0xF0D26,
-        0x72A56,
-        0xF0A56,
-        0xF14B6,
-        0x52AB4,
-        0xF0AD4,
-        0xF16CA,
-        0x42E94,
-        0xF1694,  # 2061-2070
-        0x8352A,
-        0xF152A,
-        0xF0A5A,
-        0x6155A,
-        0xF156A,
-        0xF0B54,
-        0x4174A,
-        0xF1B4A,
-        0xF1A94,
-        0x3392A,  # 2071-2080
-        0xF192C,
-        0x7329C,
-        0xF0AAC,
-        0xF156A,
-        0x52B64,
-        0xF0DA4,
-        0xF1D4A,
-        0x41C94,
-        0xF0C96,
-        0x8192E,  # 2081-2090
-        0xF0956,
-        0xF0AB6,
-        0x615AC,
-        0xF16D4,
-        0xF0EA4,
-        0x42E4A,
-        0xF164A,
-        0xF1516,
-        0x22936,  # 2090-2099
-    ]
-    # Define range of years
-    START_YEAR, END_YEAR = 1901, 1900 + len(g_lunar_month_days)
-    # 1901 The 1st day of the 1st month of the Gregorian calendar is 1901/2/19
-    LUNAR_START_DATE, SOLAR_START_DATE = (1901, 1, 1), datetime(1901, 2, 19)
-    # The Gregorian date for December 30, 2099 is 2100/2/8
-    LUNAR_END_DATE, SOLAR_END_DATE = (2099, 12, 30), datetime(2100, 2, 18)
-
-    def get_leap_month(self, lunar_year):
-        return (
-            self.g_lunar_month_days[lunar_year - self.START_YEAR] >> 16
-        ) & 0x0F
-
-    def lunar_month_days(self, lunar_year, lunar_month):
-        return 29 + (
-            (
-                self.g_lunar_month_days[lunar_year - self.START_YEAR]
-                >> lunar_month
-            )
-            & 0x01
-        )
-
-    def lunar_year_days(self, year):
-        days = 0
-        months_day = self.g_lunar_month_days[year - self.START_YEAR]
-        for i in range(1, 13 if self.get_leap_month(year) == 0x0F else 14):
-            day = 29 + ((months_day >> i) & 0x01)
-            days += day
-        return days
-
-    # Calculate the Gregorian date according to the lunar calendar
-    def get_solar_date(self, year, month, day):
-        span_days = 0
-        for y in range(self.START_YEAR, year):
-            span_days += self.lunar_year_days(y)
-        leap_month = self.get_leap_month(year)
-        for m in range(1, month + (month > leap_month)):
-            span_days += self.lunar_month_days(year, m)
-        span_days += day - 1
-        return self.SOLAR_START_DATE + timedelta(span_days)
 
 
 class HK(HongKong):

--- a/holidays/countries/malaysia.py
+++ b/holidays/countries/malaysia.py
@@ -44,7 +44,7 @@ from holidays.constants import (
 )
 from holidays.constants import SUN
 from holidays.holiday_base import HolidayBase
-from holidays.utils import get_gre_date
+from holidays.utils import islamic_to_gre
 
 
 class Malaysia(HolidayBase):
@@ -76,224 +76,25 @@ class Malaysia(HolidayBase):
         # New Year's Day
         self[date(year, JAN, 1)] = "New Year's Day"
 
-        if year > 2010:
-            self[date(year, SEP, 16)] = "Malaysia Day"
+        # Birthday of the Prophet Muhammad (s.a.w.).
+        # a.k.a. Hari Keputeraan Nabi Muhammad (Sabah Act)
+        for hol_date in islamic_to_gre(year, 3, 13):
+            self[
+                hol_date
+            ] = "Maulidur Rasul (Birthday of the Prophet Muhammad)"
 
-        # Chinese New Year (two days)
+        # Hari Kebangsaan or National Day.
+        self[date(year, AUG, 31)] = "National Day"
+
+        # Chinese New Year (one day in the States of Kelantan and Terengganu,
+        # two days in the other States).
         hol_date = self.get_lunar_n_y_date(year)
         self[hol_date] = "Chinese New Year"
-        self[hol_date + rd(days=+1)] = "Chinese New Year Holiday"
+        if self.state != "KTN" and self.state != "TRG":
+            self[hol_date + rd(days=+1)] = "Chinese New Year Holiday"
 
-        if self.state == "NSN":
-            self[
-                date(year, JAN, 14)
-            ] = "Birthday of the Sultan of Negeri Sembilan"
-
-        # Thaipusam is an annual Hindu festival,
-        # bserved on the day of the first full moon
-        # during the Tamil month of Thai
-        # TODO  This dates are hardcore we need to
-        # find a way to calculate it dynamically
-        dates_obs = {
-            2018: [(JAN, 31)],
-            2019: [(JAN, 21)],
-            2020: [(FEB, 8)],
-            2021: [(JAN, 28)],
-            2022: [(JAN, 18)],
-            2023: [(FEB, 4)],
-            2024: [(JAN, 25)],
-            2025: [(FEB, 11)],
-            2026: [(FEB, 1)],
-            2027: [(JAN, 22)],
-        }
-        if year in dates_obs:
-            if self.state in ("KUL", "PJY", "JHR", "NSN", "PRK", "PNG", "SGR"):
-                for date_obs in dates_obs[year]:
-                    hol_date = date(year, *date_obs)
-                    self[hol_date] = "Thaipusam"
-
-        if self.state in ("KUL", "LBN", "PJY"):
-            if year > 1973:
-                self[date(year, FEB, 1)] = "Federal Territory Day"
-
-        if self.state == "TRG":
-            self[
-                date(year, MAR, 4)
-            ] = "Anniversary of the Installation of the Sultan of Terengganu"
-            self[date(year, APR, 26)] = "Birthday of the Sultan of Terengganu"
-
-        if self.state == "JHR":
-            if year > 2014:
-                self[date(year, MAR, 23)] = "Birthday of the Sultan of Johor"
-
-        if self.state == "MLK":
-            self[
-                date(year, APR, 15)
-            ] = "Declaration of Malacca as a Historical City in Melaka"
-            second_fri = self.get_second_friday(year, 10)
-            self[
-                date(year, OCT, second_fri)
-            ] = "Birthday of the Governor of Melaka"
-
-        if self.state == "PRK":
-            if year > 2016:
-                first_fri = self.get_first_friday(year, 11)
-                self[
-                    date(year, NOV, first_fri)
-                ] = "Birthday of the Sultan of Perak"
-            else:
-                # This Holiday used to be  on 27th untill 2017
-                # https://www.officeholidays.com/holidays/malaysia/birthday-of-the-sultan-of-perak
-                self[date(year, NOV, 27)] = "Birthday of the Sultan of Perak"
-
-        if self.state == "KTN":
-            self[date(year, NOV, 11)] = "Birthday of the Sultan of Kelantan"
-            self[
-                date(year, NOV, 12)
-            ] = "Birthday of the Sultan of Kelantan Holiday"
-
-        if self.state == "SGR":
-            self[date(year, DEC, 11)] = "Birthday of The Sultan of Selangor"
-
-        if self.state in ("LBN", "SBH"):
-            self[date(year, MAY, 30)] = "Pesta Kaamatan"
-            self[date(year, MAY, 31)] = "Pesta Kaamatan (Second day)"
-
-        if self.state == "SWK":
-            self[date(year, JUN, 1)] = "Gawai Dayak"
-            self[date(year, JUN, 2)] = "Gawai Dayak (Second day)"
-            # Find the second satruday of Oct
-            # for the birthday of the Governor
-            second_sat = self.get_second_saturday(year, 10)
-            self[
-                date(year, OCT, second_sat)
-            ] = "Birthday of the Governor of Sarawak"
-            if year > 2016:
-                self[date(year, JUL, 22)] = "Sarawak Day"
-
-        if self.state == "SBH":
-            # Find the first satruday of Oct
-            # for Birthday of the Governor
-            first_sat = self.get_first_saturday(year, 10)
-            self[
-                date(year, OCT, first_sat)
-            ] = "Birthday of the Governor of Sabah"
-            if year > 2018:
-                self[date(year, DEC, 24)] = "Christmas Eve"
-
-        if self.state == "PNG":
-            self[date(year, JUL, 7)] = "George Town Heritage Day"
-            # Find the second satruday of July
-            # for the birthday of the Governor
-            second_sat = self.get_second_saturday(year, 7)
-            self[
-                date(year, JUL, second_sat)
-            ] = "Birthday of the Governor of Penang"
-
-        # Hari Raya Aidilfitri
-        # aka Eid al-Fitr
-        # date of observance is announced yearly
-        dates_obs = {
-            2001: [(DEC, 16)],
-            2002: [(DEC, 6)],
-            2003: [(NOV, 25)],
-            2004: [(NOV, 14)],
-            2005: [(NOV, 3)],
-            2006: [(OCT, 24)],
-            2007: [(OCT, 13)],
-            2008: [(OCT, 1)],
-            2009: [(SEP, 20)],
-            2010: [(SEP, 10)],
-            2011: [(AUG, 30)],
-            2012: [(AUG, 19)],
-            2013: [(AUG, 8)],
-            2014: [(JUL, 28)],
-            2015: [(JUL, 17)],
-            2016: [(JUL, 6)],
-            2017: [(JUN, 25)],
-            2018: [(JUN, 15)],
-            2019: [(JUN, 5)],
-            2020: [(MAY, 24)],
-            2021: [(MAY, 13)],
-            2022: [(MAY, 2)],
-        }
-        if year in dates_obs:
-            for date_obs in dates_obs[year]:
-                hol_date = date(year, *date_obs)
-                self[hol_date] = "Hari Raya Aidilfitri"
-                hol_date += rd(days=+1)
-                self[hol_date] = "Hari Raya Aidilfitri Holiday"
-
-        else:
-            for date_obs in self.get_hrp_date(year):
-                hol_date = date_obs
-                self[hol_date] = "Hari Raya Aidilfitri* (*estimated)"
-                # Second day of Hari Raya Puasa (up to and including 1968)
-                if year <= 1968:
-                    hol_date += rd(days=+1)
-                    self[hol_date] = (
-                        "Second day of Hari Raya Aidilfitri*" " (*estimated)"
-                    )
-
-        # Hari Raya Haji
-        # aka Eid al-Adha
-        # date of observance is announced yearly
-        dates_obs = {
-            2001: [(MAR, 6)],
-            2002: [(FEB, 23)],
-            2003: [(FEB, 12)],
-            2004: [(FEB, 1)],
-            2005: [(JAN, 21)],
-            2006: [(JAN, 10)],
-            2007: [(DEC, 20)],
-            2008: [(DEC, 8)],
-            2009: [(NOV, 27)],
-            2010: [(NOV, 17)],
-            2011: [(NOV, 6)],
-            2012: [(OCT, 26)],
-            2013: [(OCT, 15)],
-            2014: [(OCT, 5)],
-            2015: [(SEP, 24)],
-            2016: [(SEP, 12)],
-            2017: [(SEP, 1)],
-            2018: [(AUG, 22)],
-            2019: [(AUG, 11)],
-            2020: [(JUL, 31)],
-            2021: [(JUL, 20)],
-            2022: [(JUL, 9)],
-        }
-        if year in dates_obs:
-            for date_obs in dates_obs[year]:
-                hol_date = date(year, *date_obs)
-                self[hol_date] = "Hari Raya Haji"
-                if self.state == "TRG":
-                    # The Arafat Day is one day before Eid al-Adha
-                    self[hol_date - rd(days=1)] = "Arafat Day"
-                if self.state in ("KDH", "KTN" "PLS"):
-                    # The Arafat Day is one day before Eid al-Adha
-                    self[hol_date + rd(days=1)] = "Hari Raya Haji Holiday"
-
-        else:
-            for date_obs in self.get_hrh_date(year):
-                hol_date = date_obs
-                self[hol_date] = "Hari Raya Haji* (*estimated)"
-
-        # Holy Saturday (up to and including 1968)
-        if year <= 1968:
-            self[easter(year) + rd(weekday=SA(-1))] = "Holy Saturday"
-
-        # Good Friday
-        self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
-
-        # Easter Monday
-        if year <= 1968:
-            self[easter(year) + rd(weekday=MO(1))] = "Easter Monday"
-
-        # Labour Day
-        self[date(year, MAY, 1)] = "Labour Day"
-
-        # Vesak Day
-        # date of observance is announced yearly
+        # Wesak Day.
+        # Date of observance is announced yearly
         # https://en.wikipedia.org/wiki/Vesak#Dates_of_observance
         dates_obs = {
             2001: (MAY, 7),
@@ -326,11 +127,113 @@ class Malaysia(HolidayBase):
             hol_date = self.get_vesak_date(year)
             self[hol_date] = "Vesak Day* (*estimated; ~10% chance +/- 1 day)"
 
-        # National Day
-        self[date(year, AUG, 31)] = "National Day"
+        # Birthday of [His Majesty] the Yang di-Pertuan Agong.
+        first_mon_jun = rrule(
+            MONTHLY,
+            dtstart=date(year, JUN, 1),
+            count=1,
+            bysetpos=1,
+            byweekday=MO,
+        )[0]
+        self[first_mon_jun] = "Birthday of SPB Yang di-Pertuan Agong"
 
-        # Deepavali
-        # aka Diwali
+        # Hari Raya Puasa (2 days).
+        # aka Eid al-Fitr;
+        # exact date of observance is announced yearly
+        dates_obs = {
+            2001: [(DEC, 16)],
+            2002: [(DEC, 6)],
+            2003: [(NOV, 25)],
+            2004: [(NOV, 14)],
+            2005: [(NOV, 3)],
+            2006: [(OCT, 24)],
+            2007: [(OCT, 13)],
+            2008: [(OCT, 1)],
+            2009: [(SEP, 20)],
+            2010: [(SEP, 10)],
+            2011: [(AUG, 30)],
+            2012: [(AUG, 19)],
+            2013: [(AUG, 8)],
+            2014: [(JUL, 28)],
+            2015: [(JUL, 17)],
+            2016: [(JUL, 6)],
+            2017: [(JUN, 25)],
+            2018: [(JUN, 15)],
+            2019: [(JUN, 5)],
+            2020: [(MAY, 24)],
+            2021: [(MAY, 13)],
+            2022: [(MAY, 2)],
+        }
+        if year in dates_obs:
+            for date_obs in dates_obs[year]:
+                hol_date = date(year, *date_obs)
+                self[hol_date] = "Hari Raya Puasa"
+                # Second day of Hari Raya Puasa (up to and including 1968)
+                # Removed since we don't have Hari Raya Puasa dates for the
+                # the years <= 1968:
+                # if year <= 1968:
+                #     self[hol_date + rd(days=+1),
+                #                  "Second day of Hari Raya Puasa")
+        else:
+            for date_obs in islamic_to_gre(year, 10, 1):
+                hol_date = date_obs
+                self[hol_date] = "Hari Raya Puasa* (*estimated)"
+                # Second day of Hari Raya Puasa (up to and including 1968)
+                if year <= 1968:
+                    hol_date += rd(days=+1)
+                    self[hol_date] = (
+                        "Second day of Hari Raya Puasa*" " (*estimated)"
+                    )
+
+        # The last two days in May (Pesta Kaamatan).
+        # (Sarawak Act)
+        if self.state in ("LBN", "SBH"):
+            self[date(year, MAY, 30)] = "Pesta Kaamatan"
+            self[date(year, MAY, 31)] = "Pesta Kaamatan (Second day)"
+
+        # Hari Raya Haji (two days in the States of Kelantan and Terengganu,
+        # one day in the other States).
+        dates_obs = {
+            2001: [(MAR, 6)],
+            2002: [(FEB, 23)],
+            2003: [(FEB, 12)],
+            2004: [(FEB, 1)],
+            2005: [(JAN, 21)],
+            2006: [(JAN, 10)],
+            2007: [(DEC, 20)],
+            2008: [(DEC, 8)],
+            2009: [(NOV, 27)],
+            2010: [(NOV, 17)],
+            2011: [(NOV, 6)],
+            2012: [(OCT, 26)],
+            2013: [(OCT, 15)],
+            2014: [(OCT, 5)],
+            2015: [(SEP, 24)],
+            2016: [(SEP, 12)],
+            2017: [(SEP, 1)],
+            2018: [(AUG, 22)],
+            2019: [(AUG, 11)],
+            2020: [(JUL, 31)],
+            2021: [(JUL, 20)],
+            2022: [(JUL, 9)],
+        }
+        if year in dates_obs:
+            for date_obs in dates_obs[year]:
+                hol_date = date(year, *date_obs)
+                self[hol_date] = "Hari Raya Haji"
+                if self.state == "TRG":
+                    # The Arafat Day is one day before Eid al-Adha
+                    self[hol_date - rd(days=1)] = "Arafat Day"
+                if self.state in ("KDH", "KTN", "PLS"):
+                    # The Arafat Day is one day before Eid al-Adha
+                    self[hol_date + rd(days=1)] = "Hari Raya Haji Holiday"
+        else:
+            for date_obs in self.get_hrh_date(year):
+                hol_date = date_obs
+                self[hol_date] = "Hari Raya Haji* (*estimated)"
+
+        # Deepavali.
+        # aka Diwali;
         # date of observance is announced yearly
         dates_obs = {
             2001: (NOV, 14),
@@ -363,14 +266,46 @@ class Malaysia(HolidayBase):
             hol_date = self.get_s_diwali_date(year)
             self[hol_date] = "Deepavali* (*estimated; rarely on day after)"
 
-        # Christmas Day
+        # Christmas day.
         self[date(year, DEC, 25)] = "Christmas Day"
 
-        # Malaysia General Election Holiday
+        # Malaysia Day.
+        self[date(year, SEP, 16)] = "Malaysia Day"
+
+        # ---------------------------------------------------------#
+        # Holidays from the Sarawak Ordinance (not included above) #
+        # ---------------------------------------------------------#
+        if self.state == "SWK":
+            # Dayak Festival Day (the first day of June) and the following day.
+            self[date(year, JUN, 1)] = "Gawai Dayak"
+            self[date(year, JUN, 2)] = "Gawai Dayak (Second day)"
+
+            # The first day of May—Worker’s Celebration Day.
+
+            # Birthday of Tuan Yang Terutama Yang di-Pertua Negeri Sarawak (the
+            # second Saturday of September).
+            second_sat_sep = rrule(
+                MONTHLY,
+                dtstart=date(year, SEP, 1),
+                count=1,
+                bysetpos=2,
+                byweekday=SA,
+            )[0]
+            self[second_sat_sep] = "Birthday of the Governor of Sarawak"
+
+            # Sarawak Independence Day
+            if year > 2016:
+                self[date(year, JUL, 22)] = "Sarawak Day"
+
+        # ------------------------------#
+        # Other holidays (decrees etc.) #
+        # ------------------------------#
+
+        # Malaysia General Election Holiday.
         dates_obs = {
             # The years 1955 1959 1995 seems to have the elections
             # one weekday but I am not sure if they were marked as
-            # Holidays
+            # holidays.
             1999: (NOV, 29),
             2018: (MAY, 9),
         }
@@ -378,6 +313,218 @@ class Malaysia(HolidayBase):
             self[
                 date(year, *dates_obs[year])
             ] = "Malaysia General Election Holiday"
+
+        # Awal Muharram.
+        for hol_date in islamic_to_gre(year, 1, 2):
+            self[hol_date] = "Awal Muharram (Hijri New Year)"
+
+        # Labour Day.
+        self[date(year, MAY, 1)] = "Labour Day"
+
+        # ---------------------------------#
+        # State holidays (multiple states) #
+        # ---------------------------------#
+
+        # 1 January (TODO or the following day if the 1 January should fall on a
+        # weekly holiday in any State or in the Federal Territory).
+        if self.state in (
+            "KUL",
+            "LBN",
+            "MLK",
+            "NSN",
+            "PHG",
+            "PNG",
+            "PRK",
+            "PJY",
+            "SBH",
+            "SWK",
+            "SGR",
+        ):
+            self[date(year, JAN, 1)] = "New Year's Day"
+
+        # 1 July (TODO or the following day if the 1 July should fall on a
+        # weekly holiday in any State or in the Federal Territory).
+        if self.state == "NSN":
+            self[
+                date(year, JAN, 14)
+            ] = "Birthday of the Sultan of Negeri Sembilan"
+
+        # Isra and Miraj.
+        if self.state in ("KDH", "NSN", "PLS", "TRG"):
+            for hol_date in islamic_to_gre(year, 7, 28):
+                self[hol_date] = "Isra and Miraj"
+
+        # Beginning of Ramadan.
+        if self.state in ("JHR", "KDH", "MLK"):
+            for hol_date in islamic_to_gre(year, 9, 2):
+                self[hol_date] = "Begining of Ramadan"
+
+        # Nuzul Al-Quran Day.
+        if self.state and self.state not in (
+            "JHR",
+            "KDH",
+            "MLK",
+            "SBH",
+            "SWK",
+            "TRG",
+        ):
+            for hol_date in islamic_to_gre(year, 9, 17):
+                self[hol_date] = "Nuzul Al-Quran Day"
+        if self.state == "TRG":
+            for hol_date in islamic_to_gre(year, 9, 18):
+                self[hol_date] = "Nuzul Al-Quran Day"
+
+        # Hari Raya Aidilfitri.
+        # aka Eid al-Fitr;
+        # date of observance is announced yearly
+        dates_obs = {
+            2001: [(DEC, 16)],
+            2002: [(DEC, 6)],
+            2003: [(NOV, 25)],
+            2004: [(NOV, 14)],
+            2005: [(NOV, 3)],
+            2006: [(OCT, 24)],
+            2007: [(OCT, 13)],
+            2008: [(OCT, 1)],
+            2009: [(SEP, 20)],
+            2010: [(SEP, 10)],
+            2011: [(AUG, 30)],
+            2012: [(AUG, 19)],
+            2013: [(AUG, 8)],
+            2014: [(JUL, 28)],
+            2015: [(JUL, 17)],
+            2016: [(JUL, 6)],
+            2017: [(JUN, 25)],
+            2018: [(JUN, 15)],
+            2019: [(JUN, 5)],
+            2020: [(MAY, 24)],
+            2021: [(MAY, 13)],
+            2022: [(MAY, 2)],
+        }
+        if year in dates_obs:
+            for date_obs in dates_obs[year]:
+                hol_date = date(year, *date_obs)
+                self[hol_date] = "Hari Raya Aidilfitri"
+                hol_date += rd(days=+1)
+                self[hol_date] = "Hari Raya Aidilfitri Holiday"
+        else:
+            for date_obs in islamic_to_gre(year, 10, 1):
+                hol_date = date_obs
+                self[hol_date] = "Hari Raya Aidilfitri* (*estimated)"
+                hol_date += rd(days=+1)
+                self[hol_date] = (
+                    "Hari Raya Aidilfitri Holiday*" " (*estimated)"
+                )
+
+        # Good Friday.
+        if self.state in ("SBH", "SWK"):
+            self[easter(year) + rd(weekday=FR(-1))] = "Good Friday"
+
+        # Thaipusam.
+        # An annual Hindu festival observed on the day of the first full moon
+        # during the Tamil month of Thai
+        if self.state in ("JHR", "KUL", "NSN", "PJY", "PNG", "PRK", "SGR"):
+            # TODO  This dates are hardcore we need to
+            # find a way to calculate it dynamically
+            dates_obs = {
+                2018: [(JAN, 31)],
+                2019: [(JAN, 21)],
+                2020: [(FEB, 8)],
+                2021: [(JAN, 28)],
+                2022: [(JAN, 18)],
+                2023: [(FEB, 4)],
+                2024: [(JAN, 25)],
+                2025: [(FEB, 11)],
+                2026: [(FEB, 1)],
+                2027: [(JAN, 22)],
+            }
+            if year in dates_obs:
+                for date_obs in dates_obs[year]:
+                    hol_date = date(year, *date_obs)
+                    self[hol_date] = "Thaipusam"
+
+        # Federal Territory Day.
+        if self.state in ("KUL", "LBN", "PJY"):
+            if year > 1973:
+                self[date(year, FEB, 1)] = "Federal Territory Day"
+
+        # State holidays (single state)
+        # -----------------------------
+
+        if self.state == "JHR":
+            if year > 2014:
+                self[date(year, MAR, 23)] = "Birthday of the Sultan of Johor"
+
+        elif self.state == "KTN":
+            self[date(year, NOV, 11)] = "Birthday of the Sultan of Kelantan"
+
+            self[
+                date(year, NOV, 12)
+            ] = "Birthday of the Sultan of Kelantan Holiday"
+
+        elif self.state == "MLK":
+            self[
+                date(year, APR, 15)
+            ] = "Declaration of Malacca as a Historical City in Melaka"
+
+            second_fri_oct = rrule(
+                MONTHLY,
+                dtstart=date(year, OCT, 1),
+                count=1,
+                bysetpos=2,
+                byweekday=FR,
+            )[0]
+            self[second_fri_oct] = "Birthday of the Governor of Melaka"
+
+        elif self.state == "PRK":
+            if year > 2016:
+                first_fri_nov = rrule(
+                    MONTHLY,
+                    dtstart=date(year, NOV, 1),
+                    count=1,
+                    bysetpos=1,
+                    byweekday=FR,
+                )[0]
+                self[first_fri_nov] = "Birthday of the Sultan of Perak"
+            else:
+                # This Holiday used to be on 27th until 2017
+                # https://www.officeholidays.com/holidays/malaysia/birthday-of-the-sultan-of-perak
+                self[date(year, NOV, 27)] = "Birthday of the Sultan of Perak"
+
+        elif self.state == "PNG":
+            self[date(year, JUL, 7)] = "George Town Heritage Day"
+
+            second_sat_jul = rrule(
+                MONTHLY,
+                dtstart=date(year, JUL, 1),
+                count=1,
+                bysetpos=2,
+                byweekday=SA,
+            )[0]
+            self[second_sat_jul] = "Birthday of the Governor of Penang"
+
+        elif self.state == "SGR":
+            self[date(year, DEC, 11)] = "Birthday of The Sultan of Selangor"
+
+        elif self.state == "SBH":
+            first_sat_oct = rrule(
+                MONTHLY,
+                dtstart=date(year, OCT, 1),
+                count=1,
+                bysetpos=1,
+                byweekday=SA,
+            )[0]
+            self[first_sat_oct] = "Birthday of the Governor of Sabah"
+
+            if year > 2018:
+                self[date(year, DEC, 24)] = "Christmas Eve"
+
+        elif self.state == "TRG":
+            self[
+                date(year, MAR, 4)
+            ] = "Anniversary of the Installation of the Sultan of Terengganu"
+
+            self[date(year, APR, 26)] = "Birthday of the Sultan of Terengganu"
 
         # Check for holidays that fall on a Sunday and
         # implement Section 3 of Malaysian Holidays Act:
@@ -392,355 +539,6 @@ class Malaysia(HolidayBase):
                 while in_lieu_date in self:
                     in_lieu_date += rd(days=+1)
                 self[in_lieu_date] = hol_name + " [In lieu]"
-
-    def get_first_friday(self, year, month):
-        """Get the first friday of a specific Year and month.
-
-        Args:
-            Year (String): The desired Year.
-            Month (int): The desired Month.
-
-        Returns:
-            int: The day of the first friday.
-        """
-        d = date(year, month, 1)
-        while d.month == month:
-            if d.weekday() == 4:
-                break
-            d += timedelta(days=1)
-        return d.day
-
-    def get_second_friday(self, year, month):
-        """Get the second friday of a specific Year and month.
-
-        Args:
-            Year (String): The desired Year.
-            Month (int): The desired Month.
-
-        Returns:
-            int: The day of the second friday.
-        """
-
-        d = date(year, month, 1)
-        desired_day = []
-        while d.month == month:
-            if d.weekday() == 4:  # friday is the fourth day
-                desired_day.append(d.day)
-                if len(desired_day) > 1:
-                    break  # get only the day we need
-            d += timedelta(days=1)
-        return desired_day[1]
-
-    def get_first_saturday(self, year, month):
-        """Get the first Saturday of a specific Year and month.
-
-        Args:
-            Year (String): The desired Year.
-            Month (int): The desired Month.
-
-        Returns:
-            int: The day of the first Saturday.
-        """
-
-        d = date(year, month, 1)
-        while d.month == month:
-            if d.weekday() == 5:
-                break
-
-            d += timedelta(days=1)
-        return d.day
-
-    def get_second_saturday(self, year, month):
-        """Get the second Saturday of a specific Year and month.
-
-        Args:
-            Year (String): The desired Year.
-            Month (int): The desired Month.
-
-        Returns:
-            int: The day of the second Saturday.
-        """
-        d = date(year, month, 1)
-        desired_day = []
-        while d.month == month:
-            if d.weekday() == 5:  # Saturday
-                desired_day.append(d.day)
-                if len(desired_day) > 1:
-                    break  # get only the day we need
-            d += timedelta(days=1)
-        return desired_day[1]
-
-    # The below is used to calculate lunar new year (i.e. Chinese new year)
-    # Code borrowed from Hong Kong entry as of 16-Nov-19
-    # Should probably be a function available to multiple countries
-
-    # Store the number of days per year from 1901 to 2099, and the number of
-    # days from the 1st to the 13th to store the monthly (including the month
-    # of the month), 1 means that the month is 30 days. 0 means the month is
-    # 29 days. The 12th to 15th digits indicate the month of the next month.
-    # If it is 0x0F, it means that there is no leap month.
-    g_lunar_month_days = [
-        0xF0EA4,
-        0xF1D4A,
-        0x52C94,
-        0xF0C96,
-        0xF1536,
-        0x42AAC,
-        0xF0AD4,
-        0xF16B2,
-        0x22EA4,
-        0xF0EA4,  # 1901-1910
-        0x6364A,
-        0xF164A,
-        0xF1496,
-        0x52956,
-        0xF055A,
-        0xF0AD6,
-        0x216D2,
-        0xF1B52,
-        0x73B24,
-        0xF1D24,  # 1911-1920
-        0xF1A4A,
-        0x5349A,
-        0xF14AC,
-        0xF056C,
-        0x42B6A,
-        0xF0DA8,
-        0xF1D52,
-        0x23D24,
-        0xF1D24,
-        0x61A4C,  # 1921-1930
-        0xF0A56,
-        0xF14AE,
-        0x5256C,
-        0xF16B4,
-        0xF0DA8,
-        0x31D92,
-        0xF0E92,
-        0x72D26,
-        0xF1526,
-        0xF0A56,  # 1931-1940
-        0x614B6,
-        0xF155A,
-        0xF0AD4,
-        0x436AA,
-        0xF1748,
-        0xF1692,
-        0x23526,
-        0xF152A,
-        0x72A5A,
-        0xF0A6C,  # 1941-1950
-        0xF155A,
-        0x52B54,
-        0xF0B64,
-        0xF1B4A,
-        0x33A94,
-        0xF1A94,
-        0x8152A,
-        0xF152E,
-        0xF0AAC,
-        0x6156A,  # 1951-1960
-        0xF15AA,
-        0xF0DA4,
-        0x41D4A,
-        0xF1D4A,
-        0xF0C94,
-        0x3192E,
-        0xF1536,
-        0x72AB4,
-        0xF0AD4,
-        0xF16D2,  # 1961-1970
-        0x52EA4,
-        0xF16A4,
-        0xF164A,
-        0x42C96,
-        0xF1496,
-        0x82956,
-        0xF055A,
-        0xF0ADA,
-        0x616D2,
-        0xF1B52,  # 1971-1980
-        0xF1B24,
-        0x43A4A,
-        0xF1A4A,
-        0xA349A,
-        0xF14AC,
-        0xF056C,
-        0x60B6A,
-        0xF0DAA,
-        0xF1D92,
-        0x53D24,  # 1981-1990
-        0xF1D24,
-        0xF1A4C,
-        0x314AC,
-        0xF14AE,
-        0x829AC,
-        0xF06B4,
-        0xF0DAA,
-        0x52D92,
-        0xF0E92,
-        0xF0D26,  # 1991-2000
-        0x42A56,
-        0xF0A56,
-        0xF14B6,
-        0x22AB4,
-        0xF0AD4,
-        0x736AA,
-        0xF1748,
-        0xF1692,
-        0x53526,
-        0xF152A,  # 2001-2010
-        0xF0A5A,
-        0x4155A,
-        0xF156A,
-        0x92B54,
-        0xF0BA4,
-        0xF1B4A,
-        0x63A94,
-        0xF1A94,
-        0xF192A,
-        0x42A5C,  # 2011-2020
-        0xF0AAC,
-        0xF156A,
-        0x22B64,
-        0xF0DA4,
-        0x61D52,
-        0xF0E4A,
-        0xF0C96,
-        0x5192E,
-        0xF1956,
-        0xF0AB4,  # 2021-2030
-        0x315AC,
-        0xF16D2,
-        0xB2EA4,
-        0xF16A4,
-        0xF164A,
-        0x63496,
-        0xF1496,
-        0xF0956,
-        0x50AB6,
-        0xF0B5A,  # 2031-2040
-        0xF16D4,
-        0x236A4,
-        0xF1B24,
-        0x73A4A,
-        0xF1A4A,
-        0xF14AA,
-        0x5295A,
-        0xF096C,
-        0xF0B6A,
-        0x31B54,  # 2041-2050
-        0xF1D92,
-        0x83D24,
-        0xF1D24,
-        0xF1A4C,
-        0x614AC,
-        0xF14AE,
-        0xF09AC,
-        0x40DAA,
-        0xF0EAA,
-        0xF0E92,  # 2051-2060
-        0x31D26,
-        0xF0D26,
-        0x72A56,
-        0xF0A56,
-        0xF14B6,
-        0x52AB4,
-        0xF0AD4,
-        0xF16CA,
-        0x42E94,
-        0xF1694,  # 2061-2070
-        0x8352A,
-        0xF152A,
-        0xF0A5A,
-        0x6155A,
-        0xF156A,
-        0xF0B54,
-        0x4174A,
-        0xF1B4A,
-        0xF1A94,
-        0x3392A,  # 2071-2080
-        0xF192C,
-        0x7329C,
-        0xF0AAC,
-        0xF156A,
-        0x52B64,
-        0xF0DA4,
-        0xF1D4A,
-        0x41C94,
-        0xF0C96,
-        0x8192E,  # 2081-2090
-        0xF0956,
-        0xF0AB6,
-        0x615AC,
-        0xF16D4,
-        0xF0EA4,
-        0x42E4A,
-        0xF164A,
-        0xF1516,
-        0x22936,  # 2090-2099
-    ]
-    # Define range of years
-    START_YEAR, END_YEAR = 1901, 1900 + len(g_lunar_month_days)
-    # 1901 The 1st day of the 1st month of the Gregorian calendar is 1901/2/19
-    LUNAR_START_DATE, SOLAR_START_DATE = (1901, 1, 1), date(1901, 2, 19)
-    # The Gregorian date for December 30, 2099 is 2100/2/8
-    LUNAR_END_DATE, SOLAR_END_DATE = (2099, 12, 30), date(2100, 2, 18)
-
-    def get_leap_month(self, lunar_year):
-        return (
-            self.g_lunar_month_days[lunar_year - self.START_YEAR] >> 16
-        ) & 0x0F
-
-    def lunar_month_days(self, lunar_year, lunar_month):
-        return 29 + (
-            (
-                self.g_lunar_month_days[lunar_year - self.START_YEAR]
-                >> lunar_month
-            )
-            & 0x01
-        )
-
-    def lunar_year_days(self, year):
-        days = 0
-        months_day = self.g_lunar_month_days[year - self.START_YEAR]
-        for i in range(1, 13 if self.get_leap_month(year) == 0x0F else 14):
-            day = 29 + ((months_day >> i) & 0x01)
-            days += day
-        return days
-
-    # Calculate Gregorian date of lunar new year
-    def get_lunar_n_y_date(self, year):
-        span_days = 0
-        for y in range(self.START_YEAR, year):
-            span_days += self.lunar_year_days(y)
-        # Always in first month (by definition)
-        # leap_month = self.get_leap_month(year)
-        # for m in range(1, 1 + (1 > leap_month)):
-        #     span_days += self.lunar_month_days(year, m)
-        return self.SOLAR_START_DATE + timedelta(span_days)
-
-    # Estimate Gregorian date of Vesak
-    def get_vesak_date(self, year):
-        span_days = 0
-        for y in range(self.START_YEAR, year):
-            span_days += self.lunar_year_days(y)
-        leap_month = self.get_leap_month(year)
-        for m in range(1, 4 + (4 > leap_month)):
-            span_days += self.lunar_month_days(year, m)
-        span_days += 14
-        return self.SOLAR_START_DATE + timedelta(span_days)
-
-    # Estimate Gregorian date of Southern India Diwali
-    def get_s_diwali_date(self, year):
-        span_days = 0
-        for y in range(self.START_YEAR, year):
-            span_days += self.lunar_year_days(y)
-        leap_month = self.get_leap_month(year)
-        for m in range(1, 10 + (10 > leap_month)):
-            span_days += self.lunar_month_days(year, m)
-        span_days -= 2
-        return self.SOLAR_START_DATE + timedelta(span_days)
 
     # Estimate Gregorian date(s) of Hara Rasa Puasa
     def get_hrp_date(self, year):

--- a/holidays/countries/morocco.py
+++ b/holidays/countries/morocco.py
@@ -17,7 +17,7 @@ from dateutil.relativedelta import relativedelta as rd
 from holidays.constants import SAT, SUN
 from holidays.constants import JAN, MAR, MAY, JUL, AUG, NOV
 from holidays.holiday_base import HolidayBase
-from holidays.utils import get_gre_date
+from holidays.utils import islamic_to_gre
 
 WEEKEND = (SAT, SUN)
 
@@ -108,25 +108,25 @@ class Morocco(HolidayBase):
         # having the Holiday on Weekend does change the number of days,
         # deceided to leave it since marking a Weekend as a holiday
         # wouldn't do much harm.
-        for date_obs in get_gre_date(year, 10, 1):
+        for date_obs in islamic_to_gre(year, 10, 1):
             hol_date = date_obs
             self[hol_date] = "Eid al-Fitr"
             self[hol_date + rd(days=1)] = "Eid al-Fitr"
 
         # Eid al-Adha - Sacrifice Festive
         # date of observance is announced yearly
-        for date_obs in get_gre_date(year, 12, 10):
+        for date_obs in islamic_to_gre(year, 12, 10):
             hol_date = date_obs
             self[hol_date] = "Eid al-Adha"
             self[hol_date + rd(days=1)] = "Eid al-Adha"
 
         # Islamic New Year - (hijari_year, 1, 1)
-        for date_obs in get_gre_date(year, 1, 1):
+        for date_obs in islamic_to_gre(year, 1, 1):
             hol_date = date_obs
             self[hol_date] = "1er Moharram"
 
         # Prophet Muhammad's Birthday - (hijari_year, 3, 12)
-        for date_obs in get_gre_date(year, 3, 12):
+        for date_obs in islamic_to_gre(year, 3, 12):
             hol_date = date_obs
             self[hol_date] = "Aid al Mawlid Annabawi"
             self[hol_date + rd(days=1)] = "Aid al Mawlid Annabawi"

--- a/holidays/countries/nigeria.py
+++ b/holidays/countries/nigeria.py
@@ -14,7 +14,7 @@
 from datetime import date
 
 from dateutil.easter import easter
-from holidays.utils import get_gre_date
+from holidays.utils import islamic_to_gre
 from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUN, OCT, DEC
@@ -49,7 +49,7 @@ class Nigeria(HolidayBase):
             # Eid al-Fitr - Feast Festive
             # This is an estimate
             # date of observance is announced yearly
-            for date_obs in get_gre_date(year, 10, 1):
+            for date_obs in islamic_to_gre(year, 10, 1):
                 hol_date = date_obs
                 self[hol_date] = "Eid al-Fitr"
                 self[hol_date + rd(days=1)] = "Eid al-Fitr Holiday"
@@ -57,7 +57,7 @@ class Nigeria(HolidayBase):
             # Arafat Day & Eid al-Adha - Scarfice Festive
             # This is an estimate
             # date of observance is announced yearly
-            for date_obs in get_gre_date(year, 12, 10):
+            for date_obs in islamic_to_gre(year, 12, 10):
                 hol_date = date_obs
                 self[hol_date] = "Eid al-Adha"
                 self[hol_date + rd(days=1)] = "Eid al-Adha Holiday"

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -17,7 +17,7 @@ from dateutil.relativedelta import relativedelta as rd
 from holidays.constants import FRI, SAT
 from holidays.constants import SEP
 from holidays.holiday_base import HolidayBase
-from holidays.utils import get_gre_date
+from holidays.utils import islamic_to_gre
 
 # Weekend used to be THU, FRI before June 28th, 2013
 WEEKEND = (FRI, SAT)
@@ -51,7 +51,7 @@ class SaudiArabia(HolidayBase):
         # or from 1/10 to 4/10 depending on observed Islamic calendar)
 
         holiday_name = "Eid al-Fitr Holiday"
-        for hijri_date in get_gre_date(year, 9, 29):
+        for hijri_date in islamic_to_gre(year, 9, 29):
             self[hijri_date + rd(days=1)] = holiday_name
             self[hijri_date + rd(days=2)] = holiday_name
             self[hijri_date + rd(days=3)] = holiday_name
@@ -71,7 +71,7 @@ class SaudiArabia(HolidayBase):
         # Arafat Day & Eid al-Adha
         # date of observance is announced yearly
         holiday_name = "Eid al-Adha Holiday"
-        for hijri_date in get_gre_date(year, 12, 9):
+        for hijri_date in islamic_to_gre(year, 12, 9):
             self[hijri_date] = holiday_name
             self[hijri_date + rd(days=1)] = holiday_name
             self[hijri_date + rd(days=2)] = holiday_name

--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -11,7 +11,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
 
 from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd, SA, FR, MO
@@ -31,33 +31,47 @@ from holidays.constants import (
 )
 from holidays.constants import SUN
 from holidays.holiday_base import HolidayBase
-from holidays.utils import get_gre_date
+from holidays.utils import islamic_to_gre, ChineseLuniSolar
 
 
 class Singapore(HolidayBase):
+    """
+    Singapore holidays.
+    ===================
 
-    # Holidays Act: https://sso.agc.gov.sg/Act/HA1998
-    # https://www.mom.gov.sg/employment-practices/public-holidays
-    # https://en.wikipedia.org/wiki/Public_holidays_in_Singapore
+    **Limitations**
 
-    # Holidays prior to 1969 (Act 24 of 1968—Holidays (Amendment) Act 1968)
-    # are estimated.
+    - Prior to 1969 (Act 24 of 1968—Holidays (Amendment) Act 1968): holidays are
+      estimated.
+    - Prior to 2000: holidays may not be accurate.
+    - 2022 and later: the following four moving date holidays (whose exact
+      date is announced yearly) are estimated, and so denoted:
 
-    # Holidays prior to 2000 may not be accurate.
+      - Hari Raya Puasa*
+      - Hari Raya Haji*
+      - Vesak Day
+      - Deepavali
+    *only if the ``hijri-converter`` library is installed, otherwise a warning
+    is raised that this holiday is missing. ``hijri-converter`` requires
+    Python >= 3.6.
 
-    # Holidays after 2022: the following four moving date holidays whose exact
-    # date is announced yearly are estimated (and so denoted):
-    # - Hari Raya Puasa*
-    # - Hari Raya Haji*
-    # - Vesak Day
-    # - Deepavali
-    # *only if hijri-converter library is installed, otherwise a warning is
-    #  raised that this holiday is missing. hijri-converter requires
-    #  Python >= 3.6
+    **Sources**:
+
+    - `Holidays Act <https://sso.agc.gov.sg/Act/HA1998>`__
+    - `Ministry of Manpower <https://www.mom.gov.sg/employment-practices/public-holidays>`__
+
+    **References**:
+
+    - `Wikipedia <https://en.wikipedia.org/wiki/Public_holidays_in_Singapore>`__
+
+    **Maintainer**:
+    Mike Borsetti, mike@borsetti.com
+    """
 
     def __init__(self, **kwargs):
         self.country = "SG"
         HolidayBase.__init__(self, **kwargs)
+        self.cnls = ChineseLuniSolar()
 
     def _populate(self, year):
 
@@ -65,7 +79,7 @@ class Singapore(HolidayBase):
         self[date(year, JAN, 1)] = "New Year's Day"
 
         # Chinese New Year (two days)
-        hol_date = self.get_lunar_n_y_date(year)
+        hol_date = self.cnls.lunar_n_y_date(year)
         self[hol_date] = "Chinese New Year"
         self[hol_date + rd(days=+1)] = "Chinese New Year"
 
@@ -107,7 +121,7 @@ class Singapore(HolidayBase):
                 #     self[hol_date + rd(days=+1),
                 #                  "Second day of Hari Raya Puasa")
         else:
-            for date_obs in self.get_hrp_date(year):
+            for date_obs in islamic_to_gre(year, 10, 1):
                 hol_date = date_obs
                 self[hol_date] = "Hari Raya Puasa* (*estimated)"
                 # Second day of Hari Raya Puasa (up to and including 1968)
@@ -149,7 +163,7 @@ class Singapore(HolidayBase):
                 hol_date = date(year, *date_obs)
                 self[hol_date] = "Hari Raya Haji"
         else:
-            for date_obs in self.get_hrh_date(year):
+            for date_obs in islamic_to_gre(year, 12, 10):
                 hol_date = date_obs
                 self[hol_date] = "Hari Raya Haji* (*estimated)"
 
@@ -198,7 +212,7 @@ class Singapore(HolidayBase):
             hol_date = date(year, *dates_obs[year])
             self[hol_date] = "Vesak Day"
         else:
-            hol_date = self.get_vesak_date(year)
+            hol_date = self.cnls.vesak_date(year)
             self[hol_date] = "Vesak Day* (*estimated; ~10% chance +/- 1 day)"
 
         # National Day
@@ -235,7 +249,7 @@ class Singapore(HolidayBase):
             hol_date = date(year, *dates_obs[year])
             self[hol_date] = "Deepavali"
         else:
-            hol_date = self.get_s_diwali_date(year)
+            hol_date = self.cnls.s_diwali_date(year)
             self[hol_date] = "Deepavali* (*estimated; rarely on day after)"
 
         # Christmas Day
@@ -273,286 +287,6 @@ class Singapore(HolidayBase):
                 while in_lieu_date in self:
                     in_lieu_date += rd(days=+1)
                 self[in_lieu_date] = hol_name + " [In lieu]"
-
-    # The below is used to calculate lunar new year (i.e. Chinese new year)
-    # Code borrowed from Hong Kong entry as of 16-Nov-19
-    # Should probably be a function available to multiple countries
-
-    # Store the number of days per year from 1901 to 2099, and the number of
-    # days from the 1st to the 13th to store the monthly (including the month
-    # of the month), 1 means that the month is 30 days. 0 means the month is
-    # 29 days. The 12th to 15th digits indicate the month of the next month.
-    # If it is 0x0F, it means that there is no leap month.
-    g_lunar_month_days = [
-        0xF0EA4,
-        0xF1D4A,
-        0x52C94,
-        0xF0C96,
-        0xF1536,
-        0x42AAC,
-        0xF0AD4,
-        0xF16B2,
-        0x22EA4,
-        0xF0EA4,  # 1901-1910
-        0x6364A,
-        0xF164A,
-        0xF1496,
-        0x52956,
-        0xF055A,
-        0xF0AD6,
-        0x216D2,
-        0xF1B52,
-        0x73B24,
-        0xF1D24,  # 1911-1920
-        0xF1A4A,
-        0x5349A,
-        0xF14AC,
-        0xF056C,
-        0x42B6A,
-        0xF0DA8,
-        0xF1D52,
-        0x23D24,
-        0xF1D24,
-        0x61A4C,  # 1921-1930
-        0xF0A56,
-        0xF14AE,
-        0x5256C,
-        0xF16B4,
-        0xF0DA8,
-        0x31D92,
-        0xF0E92,
-        0x72D26,
-        0xF1526,
-        0xF0A56,  # 1931-1940
-        0x614B6,
-        0xF155A,
-        0xF0AD4,
-        0x436AA,
-        0xF1748,
-        0xF1692,
-        0x23526,
-        0xF152A,
-        0x72A5A,
-        0xF0A6C,  # 1941-1950
-        0xF155A,
-        0x52B54,
-        0xF0B64,
-        0xF1B4A,
-        0x33A94,
-        0xF1A94,
-        0x8152A,
-        0xF152E,
-        0xF0AAC,
-        0x6156A,  # 1951-1960
-        0xF15AA,
-        0xF0DA4,
-        0x41D4A,
-        0xF1D4A,
-        0xF0C94,
-        0x3192E,
-        0xF1536,
-        0x72AB4,
-        0xF0AD4,
-        0xF16D2,  # 1961-1970
-        0x52EA4,
-        0xF16A4,
-        0xF164A,
-        0x42C96,
-        0xF1496,
-        0x82956,
-        0xF055A,
-        0xF0ADA,
-        0x616D2,
-        0xF1B52,  # 1971-1980
-        0xF1B24,
-        0x43A4A,
-        0xF1A4A,
-        0xA349A,
-        0xF14AC,
-        0xF056C,
-        0x60B6A,
-        0xF0DAA,
-        0xF1D92,
-        0x53D24,  # 1981-1990
-        0xF1D24,
-        0xF1A4C,
-        0x314AC,
-        0xF14AE,
-        0x829AC,
-        0xF06B4,
-        0xF0DAA,
-        0x52D92,
-        0xF0E92,
-        0xF0D26,  # 1991-2000
-        0x42A56,
-        0xF0A56,
-        0xF14B6,
-        0x22AB4,
-        0xF0AD4,
-        0x736AA,
-        0xF1748,
-        0xF1692,
-        0x53526,
-        0xF152A,  # 2001-2010
-        0xF0A5A,
-        0x4155A,
-        0xF156A,
-        0x92B54,
-        0xF0BA4,
-        0xF1B4A,
-        0x63A94,
-        0xF1A94,
-        0xF192A,
-        0x42A5C,  # 2011-2020
-        0xF0AAC,
-        0xF156A,
-        0x22B64,
-        0xF0DA4,
-        0x61D52,
-        0xF0E4A,
-        0xF0C96,
-        0x5192E,
-        0xF1956,
-        0xF0AB4,  # 2021-2030
-        0x315AC,
-        0xF16D2,
-        0xB2EA4,
-        0xF16A4,
-        0xF164A,
-        0x63496,
-        0xF1496,
-        0xF0956,
-        0x50AB6,
-        0xF0B5A,  # 2031-2040
-        0xF16D4,
-        0x236A4,
-        0xF1B24,
-        0x73A4A,
-        0xF1A4A,
-        0xF14AA,
-        0x5295A,
-        0xF096C,
-        0xF0B6A,
-        0x31B54,  # 2041-2050
-        0xF1D92,
-        0x83D24,
-        0xF1D24,
-        0xF1A4C,
-        0x614AC,
-        0xF14AE,
-        0xF09AC,
-        0x40DAA,
-        0xF0EAA,
-        0xF0E92,  # 2051-2060
-        0x31D26,
-        0xF0D26,
-        0x72A56,
-        0xF0A56,
-        0xF14B6,
-        0x52AB4,
-        0xF0AD4,
-        0xF16CA,
-        0x42E94,
-        0xF1694,  # 2061-2070
-        0x8352A,
-        0xF152A,
-        0xF0A5A,
-        0x6155A,
-        0xF156A,
-        0xF0B54,
-        0x4174A,
-        0xF1B4A,
-        0xF1A94,
-        0x3392A,  # 2071-2080
-        0xF192C,
-        0x7329C,
-        0xF0AAC,
-        0xF156A,
-        0x52B64,
-        0xF0DA4,
-        0xF1D4A,
-        0x41C94,
-        0xF0C96,
-        0x8192E,  # 2081-2090
-        0xF0956,
-        0xF0AB6,
-        0x615AC,
-        0xF16D4,
-        0xF0EA4,
-        0x42E4A,
-        0xF164A,
-        0xF1516,
-        0x22936,  # 2090-2099
-    ]
-    # Define range of years
-    START_YEAR, END_YEAR = 1901, 1900 + len(g_lunar_month_days)
-    # 1901 The 1st day of the 1st month of the Gregorian calendar is 1901/2/19
-    LUNAR_START_DATE, SOLAR_START_DATE = (1901, 1, 1), date(1901, 2, 19)
-    # The Gregorian date for December 30, 2099 is 2100/2/8
-    LUNAR_END_DATE, SOLAR_END_DATE = (2099, 12, 30), date(2100, 2, 18)
-
-    def get_leap_month(self, lunar_year):
-        return (
-            self.g_lunar_month_days[lunar_year - self.START_YEAR] >> 16
-        ) & 0x0F
-
-    def lunar_month_days(self, lunar_year, lunar_month):
-        return 29 + (
-            (
-                self.g_lunar_month_days[lunar_year - self.START_YEAR]
-                >> lunar_month
-            )
-            & 0x01
-        )
-
-    def lunar_year_days(self, year):
-        days = 0
-        months_day = self.g_lunar_month_days[year - self.START_YEAR]
-        for i in range(1, 13 if self.get_leap_month(year) == 0x0F else 14):
-            day = 29 + ((months_day >> i) & 0x01)
-            days += day
-        return days
-
-    # Calculate Gregorian date of lunar new year
-    def get_lunar_n_y_date(self, year):
-        span_days = 0
-        for y in range(self.START_YEAR, year):
-            span_days += self.lunar_year_days(y)
-        # Always in first month (by definition)
-        # leap_month = self.get_leap_month(year)
-        # for m in range(1, 1 + (1 > leap_month)):
-        #     span_days += self.lunar_month_days(year, m)
-        return self.SOLAR_START_DATE + timedelta(span_days)
-
-    # Estimate Gregorian date of Vesak
-    def get_vesak_date(self, year):
-        span_days = 0
-        for y in range(self.START_YEAR, year):
-            span_days += self.lunar_year_days(y)
-        leap_month = self.get_leap_month(year)
-        for m in range(1, 4 + (4 > leap_month)):
-            span_days += self.lunar_month_days(year, m)
-        span_days += 14
-        return self.SOLAR_START_DATE + timedelta(span_days)
-
-    # Estimate Gregorian date of Southern India Diwali
-    def get_s_diwali_date(self, year):
-        span_days = 0
-        for y in range(self.START_YEAR, year):
-            span_days += self.lunar_year_days(y)
-        leap_month = self.get_leap_month(year)
-        for m in range(1, 10 + (10 > leap_month)):
-            span_days += self.lunar_month_days(year, m)
-        span_days -= 2
-        return self.SOLAR_START_DATE + timedelta(span_days)
-
-    # Estimate Gregorian date(s) of Hara Rasa Puasa
-    def get_hrp_date(self, year):
-        return get_gre_date(year, 10, 1)
-
-    # Estimate Gregorian date(s) of Hara Rasa Haji
-    def get_hrh_date(self, year):
-        return get_gre_date(year, 12, 10)
 
 
 class SG(Singapore):

--- a/holidays/countries/turkey.py
+++ b/holidays/countries/turkey.py
@@ -15,7 +15,7 @@ from datetime import date
 from dateutil.relativedelta import relativedelta as rd
 from holidays.constants import JAN, APR, MAY, JUL, AUG, OCT
 from holidays.holiday_base import HolidayBase
-from holidays.utils import get_gre_date
+from holidays.utils import islamic_to_gre
 
 
 class Turkey(HolidayBase):
@@ -55,7 +55,7 @@ class Turkey(HolidayBase):
 
         # Ramadan Feast
         # Date of observance is announced yearly, This is an estimate.
-        for date_obs in get_gre_date(year, 10, 1):
+        for date_obs in islamic_to_gre(year, 10, 1):
             hol_date = date_obs
             self[hol_date] = "Ramadan Feast"
             self[hol_date + rd(days=1)] = "Ramadan Feast Holiday"
@@ -63,7 +63,7 @@ class Turkey(HolidayBase):
 
         # Sacrifice Feast
         # Date of observance is announced yearly, This is an estimate.
-        for date_obs in get_gre_date(year, 12, 10):
+        for date_obs in islamic_to_gre(year, 12, 10):
             hol_date = date_obs
             self[hol_date] = "Sacrifice Feast"
             self[hol_date + rd(days=1)] = "Sacrifice Feast Holiday"

--- a/holidays/countries/united_arab_emirates.py
+++ b/holidays/countries/united_arab_emirates.py
@@ -17,7 +17,7 @@ from dateutil.relativedelta import relativedelta as rd
 from holidays.constants import FRI, SAT
 from holidays.constants import JAN, APR, MAY, JUN, JUL, AUG, SEP, NOV, DEC
 from holidays.holiday_base import HolidayBase
-from holidays.utils import get_gre_date
+from holidays.utils import islamic_to_gre
 
 WEEKEND = (FRI, SAT)
 
@@ -86,7 +86,7 @@ class UnitedArabEmirates(HolidayBase):
                 self[hol_date + rd(days=1)] = "{} Holiday".format(fitr)
                 self[hol_date + rd(days=2)] = "{} Holiday".format(fitr)
         else:
-            for date_obs in get_gre_date(year, 10, 1):
+            for date_obs in islamic_to_gre(year, 10, 1):
                 hol_date = date_obs
                 self[hol_date] = "{}* (*estimated)".format(fitr)
                 self[
@@ -113,7 +113,7 @@ class UnitedArabEmirates(HolidayBase):
                 self[hol_date + rd(days=2)] = "{} Holiday".format(adha)
                 self[hol_date + rd(days=3)] = "{} Holiday".format(adha)
         else:
-            for date_obs in get_gre_date(year, 12, 9):
+            for date_obs in islamic_to_gre(year, 12, 9):
                 hol_date = date_obs
                 self[hol_date] = "{}* (*estimated)".format(hajj)
                 self[hol_date + rd(days=1)] = "{}* (*estimated)".format(adha)
@@ -137,7 +137,7 @@ class UnitedArabEmirates(HolidayBase):
                 hol_date = date(year, *date_obs)
                 self[hol_date] = new_hijri_year
         else:
-            for date_obs in get_gre_date(year, 1, 1):
+            for date_obs in islamic_to_gre(year, 1, 1):
                 hol_date = date_obs
                 self[hol_date] = "{}* (*estimated)".format(new_hijri_year)
 
@@ -150,7 +150,7 @@ class UnitedArabEmirates(HolidayBase):
                     hol_date = date(year, *date_obs)
                     self[hol_date] = ascension
             else:
-                for date_obs in get_gre_date(year, 7, 27):
+                for date_obs in islamic_to_gre(year, 7, 27):
                     hol_date = date_obs
                     self[hol_date] = "{}* (*estimated)".format(ascension)
 
@@ -167,7 +167,7 @@ class UnitedArabEmirates(HolidayBase):
                     hol_date = date(year, *date_obs)
                     self[hol_date] = mawlud
             else:
-                for date_obs in get_gre_date(year, 3, 12):
+                for date_obs in islamic_to_gre(year, 3, 12):
                     hol_date = date_obs
                     self[hol_date] = "{}* (*estimated)".format(mawlud)
 

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -12,10 +12,11 @@
 #  License: MIT (see LICENSE file)
 
 import inspect
+from functools import lru_cache
 from typing import Iterable, List, Optional, Type, Union
 
 import holidays
-from datetime import date
+from datetime import date, timedelta
 from hijri_converter import convert
 
 
@@ -75,21 +76,383 @@ def CountryHoliday(
     return country_holiday
 
 
-def get_gre_date(year: int, Hmonth: int, Hday: int) -> List[date]:
+def islamic_to_gre(Gyear: int, Hmonth: int, Hday: int) -> List[date]:
     """
-    Return the gregorian dates within the gregorian year given of all instances
-    of month and date of the islamic calendar.
+    Find the Gregorian dates within the Gregorian year of all instances of
+    Islamic calendar month and day.
 
-    :param year: The gregorian year.
-    :param Hmonth: The hijri month.
-    :param Hday: The hijri day.
-    :return: list of gregorian dates within the year matching the hijri day
+    :param year: The Gregorian year.
+    :param Hmonth: The Hijri (Islamic) month.
+    :param Hday: The Hijri (Islamic) day.
+    :return: list of Gregorian dates within the year matching the hijri day
        month.
     """
-    Hyear = convert.Gregorian(year, 1, 1).to_hijri().datetuple()[0]
+    Hyear = convert.Gregorian(Gyear, 1, 1).to_hijri().datetuple()[0]
     gres = [
         convert.Hijri(y, Hmonth, Hday).to_gregorian()
         for y in range(Hyear - 1, Hyear + 2)
     ]
-    gre_dates = [date(*gre.datetuple()) for gre in gres if gre.year == year]
+    gre_dates = [date(*gre.datetuple()) for gre in gres if gre.year == Gyear]
     return gre_dates
+
+
+class ChineseLuniSolar:
+    def __init__(self):
+        """
+        This class has functions that generate Gregorian dates for holidays
+        based on the Chinese lunisolar calendar.
+
+        Usage example:
+        >>> from holidays.utils import ChineseLuniSolar
+        >>> cnls = ChineseLuniSolar()
+        >>> print(cnls.lunar_n_y_date(2010))
+        2010-02-14
+
+        See https://en.wikipedia.org/wiki/Chinese_New_Year#Dates_in_Chinese_lunisolar_calendar # noqa: E501
+        """
+
+        # A binary representation starting from year 1901 of the number of
+        # days per year, and the number of days from the 1st to the 13th to
+        # store the monthly (including the month of the month). 1 means that
+        # the month is 30 days. 0 means the month is 29 days.
+        # The 12th to 15th digits indicate the month of the next month.
+        # If it is 0x0F, it means that there is no leap month.
+        self.G_LUNAR_MONTH_DAYS = [
+            0xF0EA4,  # 1901
+            0xF1D4A,
+            0x52C94,
+            0xF0C96,
+            0xF1536,
+            0x42AAC,
+            0xF0AD4,
+            0xF16B2,
+            0x22EA4,
+            0xF0EA4,  # 1911
+            0x6364A,
+            0xF164A,
+            0xF1496,
+            0x52956,
+            0xF055A,
+            0xF0AD6,
+            0x216D2,
+            0xF1B52,
+            0x73B24,
+            0xF1D24,  # 1921
+            0xF1A4A,
+            0x5349A,
+            0xF14AC,
+            0xF056C,
+            0x42B6A,
+            0xF0DA8,
+            0xF1D52,
+            0x23D24,
+            0xF1D24,
+            0x61A4C,  # 1931
+            0xF0A56,
+            0xF14AE,
+            0x5256C,
+            0xF16B4,
+            0xF0DA8,
+            0x31D92,
+            0xF0E92,
+            0x72D26,
+            0xF1526,
+            0xF0A56,  # 1941
+            0x614B6,
+            0xF155A,
+            0xF0AD4,
+            0x436AA,
+            0xF1748,
+            0xF1692,
+            0x23526,
+            0xF152A,
+            0x72A5A,
+            0xF0A6C,  # 1951
+            0xF155A,
+            0x52B54,
+            0xF0B64,
+            0xF1B4A,
+            0x33A94,
+            0xF1A94,
+            0x8152A,
+            0xF152E,
+            0xF0AAC,
+            0x6156A,  # 1961
+            0xF15AA,
+            0xF0DA4,
+            0x41D4A,
+            0xF1D4A,
+            0xF0C94,
+            0x3192E,
+            0xF1536,
+            0x72AB4,
+            0xF0AD4,
+            0xF16D2,  # 1971
+            0x52EA4,
+            0xF16A4,
+            0xF164A,
+            0x42C96,
+            0xF1496,
+            0x82956,
+            0xF055A,
+            0xF0ADA,
+            0x616D2,
+            0xF1B52,  # 1981
+            0xF1B24,
+            0x43A4A,
+            0xF1A4A,
+            0xA349A,
+            0xF14AC,
+            0xF056C,
+            0x60B6A,
+            0xF0DAA,
+            0xF1D92,
+            0x53D24,  # 1991
+            0xF1D24,
+            0xF1A4C,
+            0x314AC,
+            0xF14AE,
+            0x829AC,
+            0xF06B4,
+            0xF0DAA,
+            0x52D92,
+            0xF0E92,
+            0xF0D26,  # 2001
+            0x42A56,
+            0xF0A56,
+            0xF14B6,
+            0x22AB4,
+            0xF0AD4,
+            0x736AA,
+            0xF1748,
+            0xF1692,
+            0x53526,
+            0xF152A,  # 2011
+            0xF0A5A,
+            0x4155A,
+            0xF156A,
+            0x92B54,
+            0xF0BA4,
+            0xF1B4A,
+            0x63A94,
+            0xF1A94,
+            0xF192A,
+            0x42A5C,  # 2021
+            0xF0AAC,
+            0xF156A,
+            0x22B64,
+            0xF0DA4,
+            0x61D52,
+            0xF0E4A,
+            0xF0C96,
+            0x5192E,
+            0xF1956,
+            0xF0AB4,  # 2031
+            0x315AC,
+            0xF16D2,
+            0xB2EA4,
+            0xF16A4,
+            0xF164A,
+            0x63496,
+            0xF1496,
+            0xF0956,
+            0x50AB6,
+            0xF0B5A,  # 2041
+            0xF16D4,
+            0x236A4,
+            0xF1B24,
+            0x73A4A,
+            0xF1A4A,
+            0xF14AA,
+            0x5295A,
+            0xF096C,
+            0xF0B6A,
+            0x31B54,  # 2051
+            0xF1D92,
+            0x83D24,
+            0xF1D24,
+            0xF1A4C,
+            0x614AC,
+            0xF14AE,
+            0xF09AC,
+            0x40DAA,
+            0xF0EAA,
+            0xF0E92,  # 2061
+            0x31D26,
+            0xF0D26,
+            0x72A56,
+            0xF0A56,
+            0xF14B6,
+            0x52AB4,
+            0xF0AD4,
+            0xF16CA,
+            0x42E94,
+            0xF1694,  # 2071
+            0x8352A,
+            0xF152A,
+            0xF0A5A,
+            0x6155A,
+            0xF156A,
+            0xF0B54,
+            0x4174A,
+            0xF1B4A,
+            0xF1A94,
+            0x3392A,  # 2081
+            0xF192C,
+            0x7329C,
+            0xF0AAC,
+            0xF156A,
+            0x52B64,
+            0xF0DA4,
+            0xF1D4A,
+            0x41C94,
+            0xF0C96,
+            0x8192E,  # 2091
+            0xF0956,
+            0xF0AB6,
+            0x615AC,
+            0xF16D4,
+            0xF0EA4,
+            0x42E4A,
+            0xF164A,
+            0xF1516,
+            0x22936,  # 2100
+        ]
+        # Define range of years covered
+        self.START_YEAR = 1901
+        self.END_YEAR = 2099
+        # The 1st day of the 1st month of the Gregorian calendar is 1901/2/19
+        self.LUNAR_START_DATE = ((1901, 1, 1),)
+        self.SOLAR_START_DATE = date(1901, 2, 19)
+        # The Gregorian date for December 30, 2099 is 2100/2/8
+        self.LUNAR_END_DATE = (2099, 12, 30)
+        self.SOLAR_END_DATE = date(2100, 2, 18)
+
+    @lru_cache()
+    def _get_leap_month(self, lunar_year: int) -> int:
+        """
+        Returns the leap month in the year.
+
+        :param lunar_year: The lunar year.
+        :return: The number of the leap month if one, otherwise 15.
+        """
+        return (
+            self.G_LUNAR_MONTH_DAYS[lunar_year - self.START_YEAR] >> 16
+        ) & 0x0F
+
+    def _lunar_month_days(self, lunar_year: int, lunar_month: int) -> int:
+        """
+        Return the number of days in the lunar month.
+
+        :param lunar_year: The lunar year.
+        :param lunar_month: The month of the lunar year.
+        :return: The number of days in the lunar month.
+        """
+        return 29 + (
+            (
+                self.G_LUNAR_MONTH_DAYS[lunar_year - self.START_YEAR]
+                >> lunar_month
+            )
+            & 0x01
+        )
+
+    def _lunar_year_days(self, year: int) -> int:
+        """
+        Return the number of days in the lunar year.
+        :param year: The lunar year.
+        :return: The number of days in the lunar year.
+        """
+        days = 0
+        months_day = self.G_LUNAR_MONTH_DAYS[year - self.START_YEAR]
+        for i in range(1, 13 if self._get_leap_month(year) == 0x0F else 14):
+            day = 29 + ((months_day >> i) & 0x01)
+            days += day
+        return days
+
+    @lru_cache()
+    def _span_days(self, year: int) -> int:
+        """
+        Return the number of days since self.SOLAR_START_DATE to the beginning
+        of the year.
+
+        :param year: The year.
+        :return: The number of days since self.SOLAR_START_DATE.
+        """
+        span_days = 0
+        for y in range(self.START_YEAR, year):
+            span_days += self._lunar_year_days(y)
+        return span_days
+
+    def lunar_n_y_date(self, year: int) -> date:
+        """
+        Return Gregorian date of Chinese Lunar New Year.
+
+        :param year: The Gregorian year.
+        :return: The Date of Chinese Lunar New Year.
+        """
+        # The Chinese calendar defines the lunar month containing the winter
+        # solstice as the eleventh month, which means that Chinese New Year
+        # usually falls on the second new moon after the winter solstice
+        # (rarely the third if an intercalary month intervenes). In more
+        # than 96 percent of the years, Chinese New Year's Day is the closest
+        # date to a new moon to lichun (Chinese: 立春; "start of spring") on 4
+        # or 5 February, and the first new moon after dahan (Chinese: 大寒;
+        # "major cold"). In the Gregorian calendar, the Chinese New Year begins
+        # at the new moon that falls between 21 January and 20 February.
+
+        span_days = self._span_days(year)
+        # Always in first month (by definition)
+        # leap_month = self._get_leap_month(year)
+        # for m in range(1, 1 + (1 > leap_month)):
+        #     span_days += self._lunar_month_days(year, m)
+        return self.SOLAR_START_DATE + timedelta(span_days)
+
+    def lunar_to_gre(
+        self, year: int, month: int, day: int, leap: bool = True
+    ) -> date:
+        """Return Gregorian date of a given Chinese Lunar date.
+
+        :param year: The Chinese Lunar year.
+        :param year: The Chinese Lunar month.
+        :param year: The Chinese Lunar day.
+        :return: The Gregorian date.
+        """
+        span_days = self._span_days(year)
+        leap_month = self._get_leap_month(year) if leap else 15
+        for m in range(1, month + (month > leap_month)):
+            span_days += self._lunar_month_days(year, m)
+        span_days += day - 1
+        return self.SOLAR_START_DATE + timedelta(span_days)
+
+    def vesak_date(self, year: int) -> date:
+        """Return the estimated Gregorian date of Vesak.
+
+        https://en.wikipedia.org/wiki/Vesak#Dates_of_observance
+
+        :param year: The Gregorian year.
+        :return: Estimated Gregorian date of Vesak.
+        """
+        span_days = self._span_days(year)
+        leap_month = self._get_leap_month(year)
+        for m in range(1, 4 + (4 > leap_month)):
+            span_days += self._lunar_month_days(year, m)
+        span_days += 14
+        return self.SOLAR_START_DATE + timedelta(span_days)
+
+    def s_diwali_date(self, year: int) -> date:
+        """Return the estimated Gregorian date of Southern India (Tamil) Diwali.
+
+        The date of Amāvásyā (new moon) of Kārttikai (corresponding with the
+        months of November/December in the Gregorian Calendar).
+
+        https://en.wikipedia.org/wiki/Diwali
+
+        :param year: The Gregorian year.
+        :return: Estimated Gregorian date of Southern India Diwali.
+        """
+        span_days = self._span_days(year)
+        leap_month = self._get_leap_month(year)
+        for m in range(1, 10 + (10 > leap_month)):
+            span_days += self._lunar_month_days(year, m)
+        span_days -= 2
+        return self.SOLAR_START_DATE + timedelta(span_days)

--- a/test/countries/test_hongkong.py
+++ b/test/countries/test_hongkong.py
@@ -23,8 +23,8 @@ class TestHongKong(unittest.TestCase):
         self.holidays = holidays.HK()
 
     def test_common(self):
-        self.assertTrue(self.holidays.isLeapYear(2000))
-        self.assertFalse(self.holidays.isLeapYear(2100))
+        self.assertTrue(self.holidays.is_leap_year(2000))
+        self.assertFalse(self.holidays.is_leap_year(2100))
         holidaysNoObserved = holidays.HK(observed=False)
         self.assertEqual(
             holidaysNoObserved[date(2019, 1, 1)], "The first day of January"


### PR DESCRIPTION
Prep work for Malaysia holidays cleanup.

- Refactored Chinese lunisolar calendar calculation into the new `LuniSolar `class shared in utils.py. This lengthy code was duplicated in Hong Kong (where it originates from before I copied it), Singapore, and now Malaysia.
- Used the new `LuniSolar `class for China holidays (instead of Korean (!))
- Renamed the shared function `get_gre_date)` (the original name I gave it) to `islamic_to_gre`, which is less confusing as we are now dealing with multiple calendars in utils.py.
- Renamed `isLeapYear` function in HongKong to the Pythonic `is_leap_year`
- A few docstring updates here and there