### PR TITLE
Australia Vic Grand Final Day 2021 Special Case Added

### DIFF
--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -213,6 +213,9 @@ class Australia(HolidayBase):
             if year == 2020:
                 # Rescheduled due to COVID-19
                 self[date(year, OCT, 23)] = "Grand Final Day"
+            elif year == 2021:
+                # Rescheduled due to COVID-19
+                self[date(year, SEP, 25)] = "Grand Final Day"
             elif year >= 2015:
                 self[date(year, SEP, 24) + rd(weekday=FR)] = "Grand Final Day"
 

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -215,7 +215,7 @@ class Australia(HolidayBase):
                 self[date(year, OCT, 23)] = "Grand Final Day"
             elif year == 2021:
                 # Rescheduled due to COVID-19
-                self[date(year, SEP, 25)] = "Grand Final Day"
+                self[date(year, SEP, 24)] = "Grand Final Day"
             elif year >= 2015:
                 self[date(year, SEP, 24) + rd(weekday=FR)] = "Grand Final Day"
 

--- a/test/countries/test_australia.py
+++ b/test/countries/test_australia.py
@@ -277,7 +277,7 @@ class TestAU(unittest.TestCase):
         dt = date(2019, 9, 27)
         dt_2020 = date(2020, 10, 23)
         dt_2020_old = date(2020, 9, 25)
-        dt_2021 = date(2021, 9, 25)
+        dt_2021 = date(2021, 9, 24)
         self.assertIn(dt, self.state_hols["VIC"], dt)
         self.assertEqual(self.state_hols["VIC"][dt], "Grand Final Day")
         self.assertIn(dt_2020, self.state_hols["VIC"], dt_2020)

--- a/test/countries/test_australia.py
+++ b/test/countries/test_australia.py
@@ -277,11 +277,14 @@ class TestAU(unittest.TestCase):
         dt = date(2019, 9, 27)
         dt_2020 = date(2020, 10, 23)
         dt_2020_old = date(2020, 9, 25)
+        dt_2021 = date(2021, 9, 25)
         self.assertIn(dt, self.state_hols["VIC"], dt)
         self.assertEqual(self.state_hols["VIC"][dt], "Grand Final Day")
         self.assertIn(dt_2020, self.state_hols["VIC"], dt_2020)
         self.assertEqual(self.state_hols["VIC"][dt_2020], "Grand Final Day")
         self.assertNotIn(dt_2020_old, self.state_hols["VIC"], dt_2020_old)
+        self.assertIn(dt_2021, self.state_hols["VIC"], dt_2021)
+        self.assertEqual(self.state_hols["VIC"][dt_2021], "Grand Final Day")
 
     def test_melbourne_cup(self):
         for dt in [date(2014, 11, 4), date(2015, 11, 3), date(2016, 11, 1)]:


### PR DESCRIPTION
I have made a quick change to the Public Holiday generation algorithm for Australia which adds a special case for the 2021 grand final date being Friday 24/SEP/2021. Every year should be a special case for grand final day as it can change depending on the needs of the AFL and is not fixed. 
I have created a simple test case for this in the test_grand_final test function. 