### PR TITLE
numpy iterable compatibility

### DIFF
--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -174,7 +174,7 @@ class HolidayBase(dict):
         self.expand = expand
         if isinstance(years, int):
             years = [years]
-        self.years = set(years) if years else set()
+        self.years = set(years) if years is not None else set()
         if not getattr(self, "prov", False):
             self.prov = prov
         self.state = state


### PR DESCRIPTION
Fix for #527 (assuming the `array` in the code posted was `numpy.array`).  

`years` is typed as Iterable, so a `numpy.array` should be accepted.

If I inadvertently introduced the issue, apologies.

before:
```
import holidays
import numpy
print(holidays.__version__)
years = numpy.array([2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021])
holidays.CZ(years=years)
0.11.3
Traceback (most recent call last):
  File "C:\Program Files\Python\Python39\lib\site-packages\IPython\core\interactiveshell.py", line 3444, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-2-b11133d668e1>", line 5, in <module>
    holidays.CZ(years=years)
  File "C:\Users\user\Documents\python\git_repos\python-holidays\holidays\countries\czechia.py", line 29, in __init__
    HolidayBase.__init__(self, **kwargs)
  File "C:\Users\user\Documents\python\git_repos\python-holidays\holidays\holiday_base.py", line 177, in __init__
    self.years = set(years) if years else set()
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

```
after:
```
import holidays
import numpy
print(holidays.__version__)
years = numpy.array([2011, 2012, 2013, 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021])
holidays.CZ(years=years)
0.11.3
Out[4]: 
{datetime.date(2016, 1, 1): 'Den obnovy samostatného českého státu',
...
```