### PR TITLE
Canada :: National Day for Truth and Reconciliation

### DIFF
--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -227,6 +227,11 @@ class Canada(HolidayBase):
         if year >= 1894:
             self[date(year, SEP, 1) + rd(weekday=MO)] = "Labour Day"
 
+        # National Day for Truth and Reconciliation
+        provinces = ("MB", "NS")
+        if self.prov in provinces and year >= 2021:
+            self[date(year, SEP, 30)] = "National Day for Truth and Reconciliation"
+
         # Thanksgiving
         if self.prov not in ("NB", "NS", "PE", "NL") and year >= 1931:
             if year == 1935:

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -290,6 +290,22 @@ class TestCA(unittest.TestCase):
             self.assertNotIn(dt + relativedelta(days=-1), self.holidays)
             self.assertNotIn(dt + relativedelta(days=+1), self.holidays)
 
+    def test_national_day_for_truth_and_reconciliation(self):
+        for dt in [
+            date(1991, 9, 30),
+            date(2020, 9, 30),
+        ]:
+            self.assertNotIn(dt, self.holidays)
+            self.assertNotIn(dt + relativedelta(days=-1), self.holidays)
+        mb_holidays = holidays.CA(prov="MB")
+        for dt in [
+            date(2021, 9, 30),
+            date(2030, 9, 30),
+        ]:
+            self.assertIn(dt, mb_holidays)
+            self.assertNotIn(dt + relativedelta(days=-1), mb_holidays)
+            self.assertNotIn(dt, self.holidays)
+
     def test_thanksgiving(self):
         ns_holidays = holidays.CA(prov="NB")
         for dt in [


### PR DESCRIPTION
earlier this year the government of Canada announced a new federal holiday, National Day for Truth and Reconciliation. for 2021, two provinces have adopted this day as an official holiday: Manitoba and Nova Scotia. i'd expect by next year more to follow and will update accordingly at that time.

🇨🇦 