### PR TITLE
add Juneteenth Observed holiday support

### DIFF
--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -365,6 +365,11 @@ class UnitedStates(HolidayBase):
         if year > 2020:
             self[date(year, JUN, 19)] = "Juneteenth National Independence Day"
 
+            if self.observed and date(year, JUN, 19).weekday() == SAT:
+                self[date(year, JUN, 18)] = name + " (Observed)"
+            elif self.observed and date(year, JUN, 19).weekday() == SUN:
+                self[date(year, JUN, 20)] = name + " (Observed)"
+
         # Jefferson Davis Birthday
         name = "Jefferson Davis Birthday"
         if self.state == "AL" and year >= 1890:

--- a/test/countries/test_united_states.py
+++ b/test/countries/test_united_states.py
@@ -681,8 +681,21 @@ class TestUS(unittest.TestCase):
             self.assertIn(date(year, 6, 19), tx_holidays)
 
     def test_juneteenth(self):
+        # Not recognized before 2021
         self.assertNotIn(date(2020, 6, 19), self.holidays)
         self.assertIn(date(2021, 6, 19), self.holidays)
+
+        juneteenth_observed = [
+            date(2021, 6, 18),  # Friday prior
+            date(2022, 6, 20),  # Monday following
+        ]
+        self.holidays.observed = True
+        for observed_holiday in juneteenth_observed:
+            self.assertIn(observed_holiday, self.holidays)
+
+        self.holidays.observed = False
+        for observed_holiday in juneteenth_observed:
+            self.assertNotIn(observed_holiday, self.holidays)
 
     def test_west_virginia_day(self):
         wv_holidays = holidays.US(state="WV")


### PR DESCRIPTION
Addresses #503 

This adds support for the observed occurrences of United States Juneeteenth (June 19) holiday.  2021 and 2022 both have observed dates - (2021/06/18, 2022/06/20).  This small snippet should future proof the observed dates.