### PR TITLE
Add public holidays of Tunisia

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -190,6 +190,7 @@ Sweden              SE/SWE    None
 Switzerland         CH/CHE    prov = AG, AR, AI, BL, BS, BE, FR, GE, GL, GR, JU, LU,
                               NE, NW, OW, SG, SH, SZ, SO, TG, TI, UR, VD, VS, ZG, ZH
 Turkey              TR/TUR    None
+Tunisia             TN/TUN    None
 Ukraine             UA/UKR    None
 UnitedArabEmirates  AE/ARE    None
 UnitedKingdom       GB/GBR/UK None

--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -84,7 +84,7 @@ from .swaziland import Swaziland, SZ, SZW
 from .sweden import Sweden, SE, SWE
 from .switzerland import Switzerland, CH, CHE
 from .turkey import Turkey, TR, TUR
-from .tunisia import Tunisia,TUN,TN
+from .tunisia import Tunisia, TUN, TN
 from .ukraine import Ukraine, UA, UKR
 from .united_arab_emirates import UnitedArabEmirates, AE, ARE
 from .united_kingdom import (

--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -84,6 +84,7 @@ from .swaziland import Swaziland, SZ, SZW
 from .sweden import Sweden, SE, SWE
 from .switzerland import Switzerland, CH, CHE
 from .turkey import Turkey, TR, TUR
+from .tunisia import Tunisia,TUN,TN
 from .ukraine import Ukraine, UA, UKR
 from .united_arab_emirates import UnitedArabEmirates, AE, ARE
 from .united_kingdom import (

--- a/holidays/countries/tunisia.py
+++ b/holidays/countries/tunisia.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+
+#  python-holidays
+#  ---------------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Author:  ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#           dr-prodigy <maurizio.montel@gmail.com> (c) 2017-2021
+#  Website: https://github.com/dr-prodigy/python-holidays
+#  License: MIT (see LICENSE file)
+
+from datetime import date
+
+from dateutil.easter import easter
+from dateutil.relativedelta import relativedelta as rd
+from holidays.constants import AUG, MAR, SAT,SUN
+from holidays.constants import JAN, APR, MAY, JUN, JUL, OCT
+from holidays.holiday_base import HolidayBase
+from holidays.utils import islamic_to_gre
+
+WEEKEND = (SAT,SUN)
+
+class Tunisia(HolidayBase):
+
+    # Holidays here are estimates, it is common for the day to be pushed
+    # if falls in a weekend, although not a rule that can be implemented.
+    # Holidays after 2020: the following four moving date holidays whose exact
+    # date is announced yearly are estimated (and so denoted):
+    # - Eid El Fetr*
+    # - Eid El Adha*
+    # - Arafat Day*
+    # - Moulad El Naby*
+    # *only if hijri-converter library is installed, otherwise a warning is
+    #  raised that this holiday is missing. hijri-converter requires
+    #  Python >= 3.6
+    # is_weekend function is there, however not activated for accuracy.
+
+    def __init__(self, **kwargs):
+        self.country = "TN"
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+
+        """
+        # Function to store the holiday name in the appropriate
+        # date and to shift the Public holiday in case it happens
+        # on a Saturday(Weekend)
+        # (NOT USED)
+        def is_weekend(self, hol_date, hol_name):
+            if hol_date.weekday() == FRI:
+                self[hol_date] = hol_name + " [Friday]"
+                self[hol_date + rd(days=+2)] = "Sunday following " + hol_name
+            else:
+                self[hol_date] = hol_name
+        """
+
+        # New Year's Day
+        self[date(year, JAN, 1)] = "New Year's Day"
+
+        # Revolution and Youth Day - January 14
+        self[date(year, JAN, 14)] = "Revolution and Youth Day - January 14"
+
+        # Independence Day
+        self[date(year, MAR, 20)] = "Independence Day"
+
+        # Martyrs' Day
+        self[date(year, APR, 9)] = "Martyrs' Day"
+
+        # Labour Day
+        self[date(year, MAY, 1)] = "Labour Day"
+
+        # Republic Day
+        self[date(year, JUL, 25)] = "Republic Day"
+
+        # Women's Day
+        self[date(year, AUG, 13)] = "Women's Day"
+
+        # Evacuation Day
+        self[date(year, OCT, 15)] = "Evacuation Day"
+
+
+        # Eid al-Fitr - Feast Festive
+        # date of observance is announced yearly, This is an estimate since
+        # having the Holiday on Weekend does change the number of days,
+        # deceided to leave it since marking a Weekend as a holiday
+        # wouldn't do much harm.
+        for date_obs in islamic_to_gre(year, 10, 1):
+            hol_date = date_obs
+            self[hol_date] = "Eid al-Fitr"
+            self[hol_date + rd(days=1)] = "Eid al-Fitr Holiday"
+            self[hol_date + rd(days=2)] = "Eid al-Fitr Holiday"
+
+        # Arafat Day & Eid al-Adha - Scarfice Festive
+        # date of observance is announced yearly
+        for date_obs in islamic_to_gre(year, 12, 9):
+            hol_date = date_obs
+            self[hol_date] = "Arafat Day"
+            self[hol_date + rd(days=1)] = "Eid al-Adha"
+            self[hol_date + rd(days=2)] = "Eid al-Adha Holiday"
+            self[hol_date + rd(days=3)] = "Eid al-Adha Holiday"
+
+        # Islamic New Year - (hijari_year, 1, 1)
+        for date_obs in islamic_to_gre(year, 1, 1):
+            hol_date = date_obs
+            self[hol_date] = "Islamic New Year"
+
+        # Prophet Muhammad's Birthday - (hijari_year, 3, 12)
+        for date_obs in islamic_to_gre(year, 3, 12):
+            hol_date = date_obs
+            self[hol_date] = "Prophet Muhammad's Birthday"
+
+class TN(Tunisia):
+    pass
+
+
+class TUN(Tunisia):
+    pass

--- a/holidays/countries/tunisia.py
+++ b/holidays/countries/tunisia.py
@@ -15,12 +15,13 @@ from datetime import date
 
 from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd
-from holidays.constants import AUG, MAR, SAT,SUN
+from holidays.constants import AUG, MAR, SAT, SUN
 from holidays.constants import JAN, APR, MAY, JUN, JUL, OCT
 from holidays.holiday_base import HolidayBase
 from holidays.utils import islamic_to_gre
 
-WEEKEND = (SAT,SUN)
+WEEKEND = (SAT, SUN)
+
 
 class Tunisia(HolidayBase):
 
@@ -80,7 +81,6 @@ class Tunisia(HolidayBase):
         # Evacuation Day
         self[date(year, OCT, 15)] = "Evacuation Day"
 
-
         # Eid al-Fitr - Feast Festive
         # date of observance is announced yearly, This is an estimate since
         # having the Holiday on Weekend does change the number of days,
@@ -110,6 +110,7 @@ class Tunisia(HolidayBase):
         for date_obs in islamic_to_gre(year, 3, 12):
             hol_date = date_obs
             self[hol_date] = "Prophet Muhammad's Birthday"
+
 
 class TN(Tunisia):
     pass

--- a/test/countries/test_tunisia.py
+++ b/test/countries/test_tunisia.py
@@ -14,9 +14,10 @@
 import unittest
 from datetime import date
 import holidays
+import sys
+
 
 class TestTunisia(unittest.TestCase):
-
     def setUp(self):
         self.holidays = holidays.TN()
 
@@ -29,7 +30,7 @@ class TestTunisia(unittest.TestCase):
             date(2021, 5, 1),
             date(2021, 7, 25),
             date(2021, 8, 13),
-            date(2021, 10, 15)
+            date(2021, 10, 15),
         ]
         for TN_hol in _holidays:
             self.assertIn(TN_hol, self.holidays)
@@ -40,16 +41,15 @@ class TestTunisia(unittest.TestCase):
 
             if importlib.util.find_spec("hijri_converter"):
                 self.holidays = holidays.TN(years=[2015])
-                
+
                 # eid_alfitr
                 self.assertIn(date(2015, 7, 17), self.holidays)
                 # eid_aladha
                 self.assertIn(date(2015, 9, 24), self.holidays)
                 # islamic_new_year
                 self.assertIn(date(2015, 10, 14), self.holidays)
-                
+
                 # eid_elfetr_2019
                 self.assertIn(date(2019, 6, 6), self.holidays)
                 # arafat_2019
                 self.assertIn(date(2019, 8, 11), self.holidays)
-

--- a/test/countries/test_tunisia.py
+++ b/test/countries/test_tunisia.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+
+#  python-holidays
+#  ---------------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Author:  ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#           dr-prodigy <maurizio.montel@gmail.com> (c) 2017-2021
+#  Website: https://github.com/dr-prodigy/python-holidays
+#  License: MIT (see LICENSE file)
+
+import unittest
+from datetime import date
+import holidays
+
+class TestTunisia(unittest.TestCase):
+
+    def setUp(self):
+        self.holidays = holidays.TN()
+
+    def test2021(self):
+        _holidays = [
+            date(2021, 1, 1),
+            date(2021, 1, 14),
+            date(2021, 3, 20),
+            date(2021, 4, 9),
+            date(2021, 5, 1),
+            date(2021, 7, 25),
+            date(2021, 8, 13),
+            date(2021, 10, 15)
+        ]
+        for TN_hol in _holidays:
+            self.assertIn(TN_hol, self.holidays)
+
+    def test_hijri_based(self):
+        if sys.version_info >= (3, 6):
+            import importlib.util
+
+            if importlib.util.find_spec("hijri_converter"):
+                self.holidays = holidays.TN(years=[2015])
+                
+                # eid_alfitr
+                self.assertIn(date(2015, 7, 17), self.holidays)
+                # eid_aladha
+                self.assertIn(date(2015, 9, 24), self.holidays)
+                # islamic_new_year
+                self.assertIn(date(2015, 10, 14), self.holidays)
+                
+                # eid_elfetr_2019
+                self.assertIn(date(2019, 6, 6), self.holidays)
+                # arafat_2019
+                self.assertIn(date(2019, 8, 11), self.holidays)
+


### PR DESCRIPTION
I have added the National public holidays of Tunisia.

The dates of the following holidays are announced yearly and estimated:
* Eid El Fetr
* Eid El Adha
* Arafat Day
* El Moulad