### PR TITLE
Update colombian holidays

### DIFF
--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -95,15 +95,15 @@ class Colombia(HolidayBase):
         else:
             self[date(year, AUG, 15) + rd(weekday=MO)] = name + "(Observed)"
 
-        # Discovery of America
-        name = "Descubrimiento de América [Discovery of America]"
+        # Columbus Day
+        name = "Día de la Raza [Columbus Day]"
         if date(year, OCT, 12).weekday() == MON or not self.observed:
             self[date(year, OCT, 12)] = name
         else:
             self[date(year, OCT, 12) + rd(weekday=MO)] = name + "(Observed)"
 
         # All Saints’ Day
-        name = "Dia de Todos los Santos [All Saint's Day]"
+        name = "Día de Todos los Santos [All Saint's Day]"
         if date(year, NOV, 1).weekday() == MON or not self.observed:
             self[date(year, NOV, 1)] = name
         else:


### PR DESCRIPTION
- Update discovery of América to Columbus Day
- Use accented í for día

I'm colombian and we don't call that day "Discovery of America" but "Columbus day" and "Día de la raza" in Spanish.

Thanks!