### PR TITLE
New `get_supported_countries` function

### DIFF
--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -19,6 +19,7 @@ from typing import Iterable, List, Mapping, Optional, Type, Union
 import holidays
 from hijri_converter import convert
 
+
 def list_supported_countries() -> List[str]:
     """List all supported countries, including their ISO 3166-1 Alpha country
     codes (Alpha-2 and Alpha-3).

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -19,9 +19,6 @@ from typing import Iterable, List, Mapping, Optional, Type, Union
 import holidays
 from hijri_converter import convert
 
-import dataclasses
-
-
 def list_supported_countries() -> List[str]:
     """List all supported countries, including their ISO 3166-1 Alpha country
     codes (Alpha-2 and Alpha-3).

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -50,7 +50,7 @@ def get_supported_countries() -> Mapping[str, "CountryInfo"]:
     }
 
 
-@dataclasses.dataclass
+# @dataclasses.dataclass  # only for Python > 6. Can be added as a dependency
 class CountryInfo:
     """Container for country info."""
 

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -46,7 +46,7 @@ def get_supported_countries() -> Mapping[str, "CountryInfo"]:
         for k in countries
         if k.__module__.startswith(
             "holidays.countries"
-        )  # only subclasses from countries
+        )  # only subclasses from countries module
     }
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -34,8 +34,6 @@ class TestUtils(unittest.TestCase):
             for name in os.listdir("./holidays/countries")
             if not name.startswith("__")
         ]
-        print("g_s_c: %s" % list(self.g_s_c.keys()))
-        print("files: %s" % files)
         self.assertTrue(self.g_s_c)
         self.assertEqual(len(list(self.g_s_c.keys())), len(files))
 
@@ -55,7 +53,6 @@ class TestUtils(unittest.TestCase):
                 "AS",
                 "CN",
                 "CB",
-                "CE",
                 "CM",
                 "CL",
                 "CT",

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -29,7 +29,11 @@ class TestUtils(unittest.TestCase):
 
     @unittest.skip("Ireland file don't contains a direct HolidayBase subclass")
     def test_get_supported_countries(self):
-        files = [name for name in os.listdir('./holidays/countries') if not name.startswith("__")]
+        files = [
+            name
+            for name in os.listdir("./holidays/countries")
+            if not name.startswith("__")
+        ]
         print("g_s_c: %s" % list(self.g_s_c.keys()))
         print("files: %s" % files)
         self.assertTrue(self.g_s_c)
@@ -44,13 +48,30 @@ class TestUtils(unittest.TestCase):
         self.assertEqual(es_ci.name, "Spain")
         self.assertFalse(es_ci.states)
         self.assertCountEqual(
-            es_ci.provinces, 
-            ['AN', 'AR', 'AS', 'CN', 'CB', 'CE', 'CM', 'CL', 'CT', 'VC', 'EX', 'GA', 'IB', 'MD', 'MC', 'ML', 'NC', 'PV', 'RI']
+            es_ci.provinces,
+            [
+                "AN",
+                "AR",
+                "AS",
+                "CN",
+                "CB",
+                "CE",
+                "CM",
+                "CL",
+                "CT",
+                "VC",
+                "EX",
+                "GA",
+                "IB",
+                "MD",
+                "MC",
+                "ML",
+                "NC",
+                "PV",
+                "RI",
+            ],
         )
-        self.assertCountEqual(
-            es_ci.subcountries, 
-            es_ci.provinces
-        )
+        self.assertCountEqual(es_ci.subcountries, es_ci.provinces)
 
         us_ci = holidays.utils.CountryInfo(type(self.holidays))
         self.assertEqual(us_ci.name, "UnitedStates")

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+#  python-holidays
+#  ---------------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Author:  ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#           dr-prodigy <maurizio.montel@gmail.com> (c) 2017-2021
+#  Website: https://github.com/dr-prodigy/python-holidays
+#  License: MIT (see LICENSE file)
+
+import os
+import os.path
+import pickle
+import unittest
+from datetime import date, datetime, timedelta
+
+import holidays
+from dateutil.relativedelta import MO, relativedelta
+
+
+class TestUtils(unittest.TestCase):
+    def setUp(self):
+        self.holidays = holidays.UnitedStates()
+        self.g_s_c = holidays.utils.get_supported_countries()
+        self.l_s_c = holidays.utils.list_supported_countries()
+
+    @unittest.skip("Ireland file don't contains a direct HolidayBase subclass")
+    def test_get_supported_countries(self):
+        files = [name for name in os.listdir('./holidays/countries') if not name.startswith("__")]
+        print("g_s_c: %s" % list(self.g_s_c.keys()))
+        print("files: %s" % files)
+        self.assertTrue(self.g_s_c)
+        self.assertEqual(len(list(self.g_s_c.keys())), len(files))
+
+    def test_countries_exists(self):
+        for k in self.g_s_c:
+            self.assertIn(k, self.l_s_c)
+
+    def test_country_info(self):
+        es_ci = self.g_s_c["Spain"]
+        self.assertEqual(es_ci.name, "Spain")
+        self.assertFalse(es_ci.states)
+        self.assertCountEqual(
+            es_ci.provinces, 
+            ['AN', 'AR', 'AS', 'CN', 'CB', 'CE', 'CM', 'CL', 'CT', 'VC', 'EX', 'GA', 'IB', 'MD', 'MC', 'ML', 'NC', 'PV', 'RI']
+        )
+        self.assertCountEqual(
+            es_ci.subcountries, 
+            es_ci.provinces
+        )
+
+        us_ci = holidays.utils.CountryInfo(type(self.holidays))
+        self.assertEqual(us_ci.name, "UnitedStates")
+        self.assertTrue(us_ci.states)
+        self.assertFalse(us_ci.provinces)
+        self.assertCountEqual(us_ci.subcountries, us_ci.states)
+
+        pt_ci = self.g_s_c["Portugal"]
+        self.assertEqual(pt_ci.name, "Portugal")
+        self.assertFalse(pt_ci.states)
+        self.assertFalse(pt_ci.provinces)
+        self.assertFalse(pt_ci.subcountries)


### PR DESCRIPTION
This PR adds a new `get_supported_countries` function that has a different approach to the existing `list_supported_countries`.
This implementation search for the `HolidayBase` subclasses that are in the `holidays.countries` folder/module.
With this approach only first subclass is take in consideration.
The method returns a map the keys of which are the countries (large name) and as values a `CountryInfo` object created for this purpose.

This class exposes the following information about the countries supported by the library:
* `name`
* classes extending from class
* `states` (if you have)
* `provinces` (if you have)

Also a `subcountries` property has been added to return the list of `states` or `provinces` in a unified way.