### PR TITLE
Add Observed support for Juneteenth Day

### DIFF
--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -364,6 +364,10 @@ class UnitedStates(HolidayBase):
         # Juneteenth Day
         if year > 2020:
             self[date(year, JUN, 19)] = "Juneteenth National Independence Day"
+            if self.observed and date(year, JUN, 19).weekday() == SAT:
+                self[date(year, JUN, 18)] = name + " (Observed)"
+            elif self.observed and date(year, JUN, 19).weekday() == SUN:
+                self[date(year, JUN, 20)] = name + " (Observed)"
 
         # Jefferson Davis Birthday
         name = "Jefferson Davis Birthday"

--- a/test/countries/test_united_states.py
+++ b/test/countries/test_united_states.py
@@ -42,6 +42,9 @@ class TestUS(unittest.TestCase):
             self.assertNotIn(date(year, 6, 19), self.holidays)
         for year in range(2021, 2030):
             self.assertIn(date(year, 6, 19), self.holidays)
+        self.holidays.observed = True
+        self.assertIn(date(2021, 6, 18), self.holidays)
+        self.assertIn(date(2022, 6, 20), self.holidays)
 
     def test_epiphany(self):
         pr_holidays = holidays.US(state="PR")


### PR DESCRIPTION
Like other US holidays, if `Juneteenth National Independence Day` falls on a Saturday, it will be observed on Friday (and for Sunday it will be observed on Monday). Added the support for that and appropriate tests.