### PR TITLE
Fix: parenthesised var was supposed to be 1-tuple?

### DIFF
--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -157,7 +157,7 @@ class UnitedKingdom(HolidayBase):
             self[date(year, MAY, 31) + rd(weekday=MO(-1))] = name
 
         # Late Summer bank holiday (last Monday in August)
-        if self.state not in ("Scotland") and year >= 1971:
+        if self.state not in ("Scotland",) and year >= 1971:
             name = "Late Summer Bank Holiday"
             if self.state == "UK":
                 name += " [England/Wales/Northern Ireland]"


### PR DESCRIPTION
Fixes error:

```
In [12]: holidays.CountryHoliday("GB", years=2022)
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-12-eba278880d13> in <module>
----> 1 holidays.CountryHoliday("GB", years=2022)

~/.pyenv/versions/3.8.12/envs/myproject/lib/python3.8/site-packages/holidays/countries/united_kingdom.py in _country_specific(self, year)
    158
    159         # Late Summer bank holiday (last Monday in August)
--> 160         if self.state not in ("Scotland") and year >= 1971:
    161             name = "Late Summer Bank Holiday"
    162             if self.state == "UK":

TypeError: 'in <string>' requires string as left operand, not NoneType
```