### PR TITLE
Fix Juneteenth name bug

### DIFF
--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -368,7 +368,8 @@ class UnitedStates(HolidayBase):
 
         # Juneteenth Day
         if year > 2020:
-            self[date(year, JUN, 19)] = "Juneteenth National Independence Day"
+            name = "Juneteenth National Independence Day"
+            self[date(year, JUN, 19)] = name
             if self.observed and date(year, JUN, 19).weekday() == SAT:
                 self[date(year, JUN, 18)] = name + " (Observed)"
             elif self.observed and date(year, JUN, 19).weekday() == SUN:


### PR DESCRIPTION
Fixes https://github.com/dr-prodigy/python-holidays/issues/594

Before:
```
>>> us_holidays=holidays.UnitedStates()
>>> us_holidays.get('June 20, 2022')
'Confederate Memorial Day (Observed)'
```

After:
```
>>> us_holidays=holidays.UnitedStates()
>>> us_holidays.get('June 20, 2022')
'Juneteenth National Independence Day (Observed)'
```