### PR TITLE
Do not expand into other years v2

### DIFF
--- a/holidays/countries/burundi.py
+++ b/holidays/countries/burundi.py
@@ -39,6 +39,15 @@ class Burundi(HolidayBase):
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
+
+        def _add_holiday(dt: date, hol: str) -> None:
+            """Only add if in current year; prevents adding holidays across
+            years (handles multi-day Islamic holidays that straddle Gregorian
+            years).
+            """
+            if dt.year == year:
+                self[dt] = hol
+
         # New Year's Day
         self[date(year, JAN, 1)] = "New Year's Day"
 
@@ -73,10 +82,11 @@ class Burundi(HolidayBase):
 
         # Eid Al Adha- Feast of the Sacrifice
         # date of observance is announced yearly
-        for date_obs in _islamic_to_gre(year, 12, 10):
-            hol_date = date_obs
-            self[hol_date] = "Eid Al Adha"
-            self[hol_date + rd(days=1)] = "Eid Al Adha"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 12, 10):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Eid Al Adha")
+                _add_holiday(hol_date + rd(days=1), "Eid Al Adha")
 
         # Assumption Day
         name = "Assumption Day"

--- a/holidays/countries/burundi.py
+++ b/holidays/countries/burundi.py
@@ -39,7 +39,6 @@ class Burundi(HolidayBase):
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
-
         def _add_holiday(dt: date, hol: str) -> None:
             """Only add if in current year; prevents adding holidays across
             years (handles multi-day Islamic holidays that straddle Gregorian

--- a/holidays/countries/djibouti.py
+++ b/holidays/countries/djibouti.py
@@ -62,6 +62,14 @@ class Djibouti(HolidayBase):
                 self[hol_date] = hol_name
         """
 
+        def _add_holiday(dt: date, hol: str) -> None:
+            """Only add if in current year; prevents adding holidays across
+            years (handles multi-day Islamic holidays that straddle Gregorian
+            years).
+            """
+            if dt.year == year:
+                self[dt] = hol
+
         # New Year's Day
         self[date(year, JAN, 1)] = "Nouvel an"
 
@@ -83,18 +91,24 @@ class Djibouti(HolidayBase):
         # having the Holiday on Weekend does change the number of days,
         # deceided to leave it since marking a Weekend as a holiday
         # wouldn't do much harm.
-        for date_obs in _islamic_to_gre(year, 10, 1):
-            hol_date = date_obs
-            self[hol_date] = "Eid al-Fitr"
-            self[hol_date + rd(days=1)] = "Eid al-Fitr deuxième jour"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 10, 1):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Eid al-Fitr")
+                _add_holiday(
+                    hol_date + rd(days=1), "Eid al-Fitr deuxième jour"
+                )
 
         # Arafat & Eid al-Adha - Scarfice Festive
         # date of observance is announced yearly
-        for date_obs in _islamic_to_gre(year, 12, 9):
-            hol_date = date_obs
-            self[hol_date] = "Arafat"
-            self[hol_date + rd(days=1)] = "Eid al-Adha"
-            self[hol_date + rd(days=2)] = "Eid al-Adha deuxième jour"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 12, 9):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Arafat")
+                _add_holiday(hol_date + rd(days=1), "Eid al-Adha")
+                _add_holiday(
+                    hol_date + rd(days=2), "Eid al-Adha deuxième jour"
+                )
 
         # Islamic New Year - (hijari_year, 1, 1)
         for date_obs in _islamic_to_gre(year, 1, 1):

--- a/holidays/countries/egypt.py
+++ b/holidays/countries/egypt.py
@@ -58,6 +58,14 @@ class Egypt(HolidayBase):
                 self[hol_date] = hol_name
         """
 
+        def _add_holiday(dt: date, hol: str) -> None:
+            """Only add if in current year; prevents adding holidays across
+            years (handles multi-day Islamic holidays that straddle Gregorian
+            years).
+            """
+            if dt.year == year:
+                self[dt] = hol
+
         # New Year's Day
         self[date(year, JAN, 1)] = "New Year's Day - Bank Holiday"
 
@@ -101,20 +109,22 @@ class Egypt(HolidayBase):
         # having the Holiday on Weekend does change the number of days,
         # deceided to leave it since marking a Weekend as a holiday
         # wouldn't do much harm.
-        for date_obs in _islamic_to_gre(year, 10, 1):
-            hol_date = date_obs
-            self[hol_date] = "Eid al-Fitr"
-            self[hol_date + rd(days=1)] = "Eid al-Fitr Holiday"
-            self[hol_date + rd(days=2)] = "Eid al-Fitr Holiday"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 10, 1):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Eid al-Fitr")
+                _add_holiday(hol_date + rd(days=1), "Eid al-Fitr Holiday")
+                _add_holiday(hol_date + rd(days=2), "Eid al-Fitr Holiday")
 
         # Arafat Day & Eid al-Adha - Scarfice Festive
         # date of observance is announced yearly
-        for date_obs in _islamic_to_gre(year, 12, 9):
-            hol_date = date_obs
-            self[hol_date] = "Arafat Day"
-            self[hol_date + rd(days=1)] = "Eid al-Adha"
-            self[hol_date + rd(days=2)] = "Eid al-Adha Holiday"
-            self[hol_date + rd(days=3)] = "Eid al-Adha Holiday"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 12, 9):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Arafat Day")
+                _add_holiday(hol_date + rd(days=1), "Eid al-Adha")
+                _add_holiday(hol_date + rd(days=2), "Eid al-Adha Holiday")
+                _add_holiday(hol_date + rd(days=3), "Eid al-Adha Holiday")
 
         # Islamic New Year - (hijari_year, 1, 1)
         for date_obs in _islamic_to_gre(year, 1, 1):

--- a/holidays/countries/morocco.py
+++ b/holidays/countries/morocco.py
@@ -61,6 +61,14 @@ class Morocco(HolidayBase):
                 self[hol_date] = hol_name
         """
 
+        def _add_holiday(dt: date, hol: str) -> None:
+            """Only add if in current year; prevents adding holidays across
+            years (handles multi-day Islamic holidays that straddle Gregorian
+            years).
+            """
+            if dt.year == year:
+                self[dt] = hol
+
         # New Year's Day
         self[date(year, JAN, 1)] = "Nouvel an - Premier janvier"
 
@@ -109,17 +117,19 @@ class Morocco(HolidayBase):
         # having the Holiday on Weekend does change the number of days,
         # deceided to leave it since marking a Weekend as a holiday
         # wouldn't do much harm.
-        for date_obs in _islamic_to_gre(year, 10, 1):
-            hol_date = date_obs
-            self[hol_date] = "Eid al-Fitr"
-            self[hol_date + rd(days=1)] = "Eid al-Fitr"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 10, 1):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Eid al-Fitr")
+                _add_holiday(hol_date + rd(days=1), "Eid al-Fitr")
 
         # Eid al-Adha - Sacrifice Festive
         # date of observance is announced yearly
-        for date_obs in _islamic_to_gre(year, 12, 10):
-            hol_date = date_obs
-            self[hol_date] = "Eid al-Adha"
-            self[hol_date + rd(days=1)] = "Eid al-Adha"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 12, 10):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Eid al-Adha")
+                _add_holiday(hol_date + rd(days=1), "Eid al-Adha")
 
         # Islamic New Year - (hijari_year, 1, 1)
         for date_obs in _islamic_to_gre(year, 1, 1):
@@ -127,10 +137,19 @@ class Morocco(HolidayBase):
             self[hol_date] = "1er Moharram"
 
         # Prophet Muhammad's Birthday - (hijari_year, 3, 12)
-        for date_obs in _islamic_to_gre(year, 3, 12):
-            hol_date = date_obs
-            self[hol_date] = "Aid al Mawlid Annabawi"
-            self[hol_date + rd(days=1)] = "Aid al Mawlid Annabawi"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 3, 12):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Aid al Mawlid Annabawi")
+                _add_holiday(hol_date + rd(days=1), "Aid al Mawlid Annabawi")
+
+        def _add_holiday(dt: date, hol: str) -> None:
+            """Only add if in current year; prevents adding holidays across
+            years (handles multi-day Islamic holidays that straddle Gregorian
+            years).
+            """
+            if dt.year == year:
+                self[dt] = hol
 
 
 class MA(Morocco):

--- a/holidays/countries/nigeria.py
+++ b/holidays/countries/nigeria.py
@@ -31,6 +31,15 @@ class Nigeria(HolidayBase):
 
     def _populate(self, year):
         if year > 1978:
+
+            def _add_holiday(dt: date, hol: str) -> None:
+                """Only add if in current year; prevents adding holidays across
+                years (handles multi-day Islamic holidays that straddle
+                Gregorian years).
+                """
+                if dt.year == year:
+                    self[dt] = hol
+
             # New Year's Day
             self[date(year, JAN, 1)] = "New Year's day"
 
@@ -50,18 +59,20 @@ class Nigeria(HolidayBase):
             # Eid al-Fitr - Feast Festive
             # This is an estimate
             # date of observance is announced yearly
-            for date_obs in _islamic_to_gre(year, 10, 1):
-                hol_date = date_obs
-                self[hol_date] = "Eid al-Fitr"
-                self[hol_date + rd(days=1)] = "Eid al-Fitr Holiday"
+            for yr in (year - 1, year):
+                for date_obs in _islamic_to_gre(year, 10, 1):
+                    hol_date = date_obs
+                    _add_holiday(hol_date, "Eid al-Fitr")
+                    _add_holiday(hol_date + rd(days=1), "Eid al-Fitr Holiday")
 
             # Arafat Day & Eid al-Adha - Scarfice Festive
             # This is an estimate
             # date of observance is announced yearly
-            for date_obs in _islamic_to_gre(year, 12, 10):
-                hol_date = date_obs
-                self[hol_date] = "Eid al-Adha"
-                self[hol_date + rd(days=1)] = "Eid al-Adha Holiday"
+            for yr in (year - 1, year):
+                for date_obs in _islamic_to_gre(year, 12, 10):
+                    hol_date = date_obs
+                    _add_holiday(hol_date, "Eid al-Adha")
+                    _add_holiday(hol_date + rd(days=1), "Eid al-Adha Holiday")
 
             # Independence Day
             self[date(year, OCT, 1)] = "National day"
@@ -94,6 +105,15 @@ class Nigeria(HolidayBase):
                 ):
                     # Add the (Observed) holiday
                     self[k + rd(days=2)] = v + " (Observed)"
+
+        def _add_holiday(dt: date, hol: str) -> None:
+            """Only add if in current year; prevents adding holidays across
+            years (handles multi-day Islamic holidays that straddle Gregorian
+            years).
+            """
+            if dt.year == year:
+                self[dt] = hol
+
 
 
 class NG(Nigeria):

--- a/holidays/countries/nigeria.py
+++ b/holidays/countries/nigeria.py
@@ -115,7 +115,6 @@ class Nigeria(HolidayBase):
                 self[dt] = hol
 
 
-
 class NG(Nigeria):
     pass
 

--- a/holidays/countries/nigeria.py
+++ b/holidays/countries/nigeria.py
@@ -60,7 +60,7 @@ class Nigeria(HolidayBase):
             # This is an estimate
             # date of observance is announced yearly
             for yr in (year - 1, year):
-                for date_obs in _islamic_to_gre(year, 10, 1):
+                for date_obs in _islamic_to_gre(yr, 10, 1):
                     hol_date = date_obs
                     _add_holiday(hol_date, "Eid al-Fitr")
                     _add_holiday(hol_date + rd(days=1), "Eid al-Fitr Holiday")
@@ -69,7 +69,7 @@ class Nigeria(HolidayBase):
             # This is an estimate
             # date of observance is announced yearly
             for yr in (year - 1, year):
-                for date_obs in _islamic_to_gre(year, 12, 10):
+                for date_obs in _islamic_to_gre(yr, 12, 10):
                     hol_date = date_obs
                     _add_holiday(hol_date, "Eid al-Adha")
                     _add_holiday(hol_date + rd(days=1), "Eid al-Adha Holiday")

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -14,13 +14,10 @@
 from datetime import date
 
 from dateutil.relativedelta import relativedelta as rd
-from holidays.constants import FRI, SAT
+from holidays.constants import FRI, SAT, THU
 from holidays.constants import SEP
 from holidays.holiday_base import HolidayBase
 from holidays.utils import _islamic_to_gre
-
-# Weekend used to be THU, FRI before June 28th, 2013
-WEEKEND = (FRI, SAT)
 
 
 class SaudiArabia(HolidayBase):
@@ -28,10 +25,11 @@ class SaudiArabia(HolidayBase):
     """
     There are only 3 official national holidays in Saudi:
     https://laboreducation.hrsd.gov.sa/en/gallery/274
+    https://laboreducation.hrsd.gov.sa/en/labor-education/322
     The national day holiday is based on the Georgian calendar while the
     other two holidays are based on the Islamic Calendar, and they are
     estimates as they announced each year and based on moon sightings;
-    which are:
+    they are:
         - Eid al-Fitr*
         - Eid al-Adha*
     * only if hijri-converter library is installed, otherwise a warning is
@@ -45,50 +43,70 @@ class SaudiArabia(HolidayBase):
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
-        observed_str = " (observed)"
-        # Eid al-Fitr Holiday
-        # The holiday defined from the four days after 29th of
-        # the 9th month of the Islamic calendar (either from 30/9 to 3/10
-        # or from 1/10 to 4/10 depending on observed Islamic calendar)
+        if year < 2013:
+            # Weekend used to be THU, FRI before June 28th, 2013
+            # On that year both Eids were after that date so the below works:
+            WEEKEND = (THU, FRI)
+        else:
+            WEEKEND = (FRI, SAT)
 
+        observed_str = " (observed)"
+
+        def _add_holiday(dt: date, hol: str) -> None:
+            """Only add if in current year; prevents adding holidays across
+            years (handles multi-day Islamic holidays that straddle Gregorian
+            years).
+            """
+            if dt.year == year:
+                self[dt] = hol
+
+        # Eid al-Fitr Holiday
+        # The holiday is a 4-day holiday starting on the day following the
+        # 29th day of Ramadan, the 9th month of the Islamic calendar.
+        # Observed days are added to make up for any days falling on a weekend.
+        # Holidays may straddle across Gregorian years, so we go back one year
+        # to pick up any such occurrence.
+        # Date of observance is announced yearly.
         holiday_name = "Eid al-Fitr Holiday"
-        for hijri_date in _islamic_to_gre(year, 9, 29):
-            self[hijri_date + rd(days=1)] = holiday_name
-            self[hijri_date + rd(days=2)] = holiday_name
-            self[hijri_date + rd(days=3)] = holiday_name
-            self[hijri_date + rd(days=4)] = holiday_name
-            if self.observed:
-                if (hijri_date + rd(days=1)).weekday() in WEEKEND:
-                    self[hijri_date + rd(days=5)] = holiday_name + observed_str
-                if (hijri_date + rd(days=2)).weekday() in WEEKEND:
-                    self[hijri_date + rd(days=5)] = holiday_name + observed_str
-                    self[hijri_date + rd(days=6)] = holiday_name + observed_str
-                if (hijri_date + rd(days=3)).weekday() in WEEKEND:
-                    self[hijri_date + rd(days=5)] = holiday_name + observed_str
-                    self[hijri_date + rd(days=6)] = holiday_name + observed_str
-                if (hijri_date + rd(days=4)).weekday() in WEEKEND:
-                    self[hijri_date + rd(days=6)] = holiday_name + observed_str
+        for yr in (year - 1, year):
+            for hijri_date in _islamic_to_gre(yr, 9, 29):
+                hijri_date += rd(days=1)
+                for dys in range(4):
+                    _add_holiday((hijri_date + rd(days=dys)), holiday_name)
+                if self.observed:
+                    weekend_days = sum(
+                        (hijri_date + rd(days=dys)).weekday() in WEEKEND
+                        for dys in range(4)
+                    )
+                    for dys in range(weekend_days):
+                        _add_holiday(
+                            hijri_date + rd(days=4 + dys),
+                            holiday_name + observed_str,
+                        )
 
         # Arafat Day & Eid al-Adha
-        # date of observance is announced yearly
+        # The holiday is a 4-day holiday starting on Arafat Day, the 10th of
+        # Dhu al-Hijjah, the 12th month of the Islamic calendar.
+        # Observed days are added to make up for any days falling on a weekend.
+        # Holidays may straddle across Gregorian years, so we go back one year
+        # to pick up any such occurrence.
+        # Date of observance is announced yearly.
         holiday_name = "Eid al-Adha Holiday"
-        for hijri_date in _islamic_to_gre(year, 12, 9):
-            self[hijri_date] = holiday_name
-            self[hijri_date + rd(days=1)] = holiday_name
-            self[hijri_date + rd(days=2)] = holiday_name
-            self[hijri_date + rd(days=3)] = holiday_name
-
-            if self.observed:
-                if hijri_date.weekday() in WEEKEND:
-                    self[hijri_date + rd(days=4)] = holiday_name + observed_str
-                if (hijri_date + rd(days=1)).weekday() in WEEKEND:
-                    self[hijri_date + rd(days=4)] = holiday_name + observed_str
-                    self[hijri_date + rd(days=5)] = holiday_name + observed_str
-                if (hijri_date + rd(days=2)).weekday() in WEEKEND:
-                    self[hijri_date + rd(days=4)] = holiday_name + observed_str
-                    self[hijri_date + rd(days=5)] = holiday_name + observed_str
-                if (hijri_date + rd(days=3)).weekday() in WEEKEND:
-                    self[hijri_date + rd(days=5)] = holiday_name + observed_str
+        for yr in (year - 1, year):
+            for hijri_date in _islamic_to_gre(yr, 12, 9):
+                _add_holiday(hijri_date, "Arafat Day Holiday")
+                for dys in range(1, 4):
+                    _add_holiday((hijri_date + rd(days=dys)), holiday_name)
+                if self.observed:
+                    weekend_days = sum(
+                        (hijri_date + rd(days=dys)).weekday() in WEEKEND
+                        for dys in range(4)
+                    )
+                    for dys in range(weekend_days):
+                        _add_holiday(
+                            hijri_date + rd(days=4 + dys),
+                            holiday_name + observed_str,
+                        )
 
         # National Day holiday (started at the year 2005).
         # Note: if national day happens within the Eid al-Fitr Holiday or

--- a/holidays/countries/tunisia.py
+++ b/holidays/countries/tunisia.py
@@ -57,6 +57,14 @@ class Tunisia(HolidayBase):
                 self[hol_date] = hol_name
         """
 
+        def _add_holiday(dt: date, hol: str) -> None:
+            """Only add if in current year; prevents adding holidays across
+            years (handles multi-day Islamic holidays that straddle Gregorian
+            years).
+            """
+            if dt.year == year:
+                self[dt] = hol
+
         # New Year's Day
         self[date(year, JAN, 1)] = "New Year's Day"
 
@@ -86,20 +94,22 @@ class Tunisia(HolidayBase):
         # having the Holiday on Weekend does change the number of days,
         # deceided to leave it since marking a Weekend as a holiday
         # wouldn't do much harm.
-        for date_obs in _islamic_to_gre(year, 10, 1):
-            hol_date = date_obs
-            self[hol_date] = "Eid al-Fitr"
-            self[hol_date + rd(days=1)] = "Eid al-Fitr Holiday"
-            self[hol_date + rd(days=2)] = "Eid al-Fitr Holiday"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 10, 1):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Eid al-Fitr")
+                _add_holiday(hol_date + rd(days=1), "Eid al-Fitr Holiday")
+                _add_holiday(hol_date + rd(days=2), "Eid al-Fitr Holiday")
 
         # Arafat Day & Eid al-Adha - Scarfice Festive
         # date of observance is announced yearly
-        for date_obs in _islamic_to_gre(year, 12, 9):
-            hol_date = date_obs
-            self[hol_date] = "Arafat Day"
-            self[hol_date + rd(days=1)] = "Eid al-Adha"
-            self[hol_date + rd(days=2)] = "Eid al-Adha Holiday"
-            self[hol_date + rd(days=3)] = "Eid al-Adha Holiday"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 12, 9):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Arafat Day")
+                _add_holiday(hol_date + rd(days=1), "Eid al-Adha")
+                _add_holiday(hol_date + rd(days=2), "Eid al-Adha Holiday")
+                _add_holiday(hol_date + rd(days=3), "Eid al-Adha Holiday")
 
         # Islamic New Year - (hijari_year, 1, 1)
         for date_obs in _islamic_to_gre(year, 1, 1):

--- a/holidays/countries/turkey.py
+++ b/holidays/countries/turkey.py
@@ -27,6 +27,13 @@ class Turkey(HolidayBase):
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
+        def _add_holiday(dt: date, hol: str) -> None:
+            """Only add if in current year; prevents adding holidays across
+            years (handles multi-day Islamic holidays that straddle Gregorian
+            years).
+            """
+            if dt.year == year:
+                self[dt] = hol
 
         # 1st of Jan
         self[date(year, JAN, 1)] = "New Year's Day"
@@ -55,20 +62,22 @@ class Turkey(HolidayBase):
 
         # Ramadan Feast
         # Date of observance is announced yearly, This is an estimate.
-        for date_obs in _islamic_to_gre(year, 10, 1):
-            hol_date = date_obs
-            self[hol_date] = "Ramadan Feast"
-            self[hol_date + rd(days=1)] = "Ramadan Feast Holiday"
-            self[hol_date + rd(days=2)] = "Ramadan Feast Holiday"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 10, 1):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Ramadan Feast")
+                _add_holiday(hol_date + rd(days=1), "Ramadan Feast Holiday")
+                _add_holiday(hol_date + rd(days=2), "Ramadan Feast Holiday")
 
         # Sacrifice Feast
         # Date of observance is announced yearly, This is an estimate.
-        for date_obs in _islamic_to_gre(year, 12, 10):
-            hol_date = date_obs
-            self[hol_date] = "Sacrifice Feast"
-            self[hol_date + rd(days=1)] = "Sacrifice Feast Holiday"
-            self[hol_date + rd(days=2)] = "Sacrifice Feast Holiday"
-            self[hol_date + rd(days=3)] = "Sacrifice Feast Holiday"
+        for yr in (year - 1, year):
+            for date_obs in _islamic_to_gre(yr, 12, 10):
+                hol_date = date_obs
+                _add_holiday(hol_date, "Sacrifice Feast")
+                _add_holiday(hol_date + rd(days=1), "Sacrifice Feast Holiday")
+                _add_holiday(hol_date + rd(days=2), "Sacrifice Feast Holiday")
+                _add_holiday(hol_date + rd(days=3), "Sacrifice Feast Holiday")
 
 
 class TR(Turkey):

--- a/holidays/countries/united_arab_emirates.py
+++ b/holidays/countries/united_arab_emirates.py
@@ -52,6 +52,13 @@ class UnitedArabEmirates(HolidayBase):
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
+        def _add_holiday(dt: date, hol: str) -> None:
+            """Only add if in current year; prevents adding holidays across
+            years (handles multi-day Islamic holidays that straddle Gregorian
+            years).
+            """
+            if dt.year == year:
+                self[dt] = hol
 
         # New Year's Day
         self[date(year, JAN, 1)] = "New Year's Day"
@@ -86,15 +93,18 @@ class UnitedArabEmirates(HolidayBase):
                 self[hol_date + rd(days=1)] = "{} Holiday".format(fitr)
                 self[hol_date + rd(days=2)] = "{} Holiday".format(fitr)
         else:
-            for date_obs in _islamic_to_gre(year, 10, 1):
-                hol_date = date_obs
-                self[hol_date] = "{}* (*estimated)".format(fitr)
-                self[
-                    hol_date + rd(days=1)
-                ] = "{} Holiday* (*estimated)".format(fitr)
-                self[
-                    hol_date + rd(days=2)
-                ] = "{} Holiday* (*estimated)".format(fitr)
+            for yr in (year - 1, year):
+                for date_obs in _islamic_to_gre(yr, 10, 1):
+                    hol_date = date_obs
+                    _add_holiday(hol_date, "{}* (*estimated)".format(fitr))
+                    _add_holiday(
+                        hol_date + rd(days=1),
+                        "{} Holiday* (*estimated)".format(fitr),
+                    )
+                    _add_holiday(
+                        hol_date + rd(days=2),
+                        "{} Holiday* (*estimated)".format(fitr),
+                    )
 
         # Arafat Day & Eid al-Adha
         dates_obs = {
@@ -113,16 +123,21 @@ class UnitedArabEmirates(HolidayBase):
                 self[hol_date + rd(days=2)] = "{} Holiday".format(adha)
                 self[hol_date + rd(days=3)] = "{} Holiday".format(adha)
         else:
-            for date_obs in _islamic_to_gre(year, 12, 9):
-                hol_date = date_obs
-                self[hol_date] = "{}* (*estimated)".format(hajj)
-                self[hol_date + rd(days=1)] = "{}* (*estimated)".format(adha)
-                self[
-                    hol_date + rd(days=2)
-                ] = "{}* Holiday* (*estimated)".format(adha)
-                self[
-                    hol_date + rd(days=3)
-                ] = "{} Holiday* (*estimated)".format(adha)
+            for yr in (year - 1, year):
+                for date_obs in _islamic_to_gre(yr, 12, 9):
+                    hol_date = date_obs
+                    _add_holiday(hol_date, "{}* (*estimated)".format(hajj))
+                    _add_holiday(
+                        hol_date + rd(days=1), "{}* (*estimated)".format(adha)
+                    )
+                    _add_holiday(
+                        hol_date + rd(days=2),
+                        "{}* Holiday* (*estimated)".format(adha),
+                    )
+                    _add_holiday(
+                        hol_date + rd(days=3),
+                        "{} Holiday* (*estimated)".format(adha),
+                    )
 
         # Islamic New Year - (hijari_year, 1, 1)
         dates_obs = {

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -171,7 +171,7 @@ class HolidayBase(dict):
         if not getattr(self, "prov", False):
             self.prov = prov
         self.state = state
-        for year in self.years.copy():
+        for year in self.years:
             self._populate(year)
 
     def __setattr__(self, key: str, value: Any) -> None:

--- a/test/countries/test_azerbaijan.py
+++ b/test/countries/test_azerbaijan.py
@@ -62,3 +62,8 @@ class TestAzerbaijan(unittest.TestCase):
                 self.assertIn(date(2020, 7, 31), self.holidays)
                 self.assertIn(date(2020, 8, 1), self.holidays)
                 self.assertIn(date(2020, 8, 3), self.holidays)  # observed
+
+    def test_dec_31_on_weekend(self):
+        """Test when Dec 31 of previous year is on a weekend."""
+        self.assertIn(date(2023, JAN, 2), self.holidays)
+        self.assertIn(date(2024, JAN, 1), self.holidays)

--- a/test/countries/test_india.py
+++ b/test/countries/test_india.py
@@ -130,11 +130,11 @@ class TestIND(unittest.TestCase):
 
     def test_diwali_and_holi(self):
         warnings.simplefilter("always")
-        with self.assertWarns(Warning) as w:
+        with self.assertWarns(Warning):
             # Diwali and Holi out of range
             holidays.IN(years=2009)
 
-        with self.assertWarns(Warning) as w:
+        with self.assertWarns(Warning):
             # Diwali and Holi out of range
             holidays.IN(years=2031)
 

--- a/test/countries/test_india.py
+++ b/test/countries/test_india.py
@@ -12,10 +12,12 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
+import warnings
 
 from datetime import date
 
 import holidays
+from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, AUG, OCT, NOV, DEC
 
 
 class TestIND(unittest.TestCase):
@@ -126,5 +128,57 @@ class TestIND(unittest.TestCase):
         self.assertIn(date(2018, 8, 15), py_holidays)
         self.assertIn(date(2018, 10, 15), mh_holidays)
 
-        # TODO: test Diwali and Holi warning -> should check for a warn
-        # self.assertIn(date(2009, 1, 14), self.holidays)
+    def test_diwali_and_holi(self):
+        warnings.simplefilter("always")
+        with self.assertWarns(Warning) as w:
+            # Diwali and Holi out of range
+            holidays.IN(years=2009)
+
+        with self.assertWarns(Warning) as w:
+            # Diwali and Holi out of range
+            holidays.IN(years=2031)
+
+        diwali_name = "Diwali"
+        holi_name = "Holi"
+        self.assertEqual(self.holidays[date(2010, DEC, 5)], diwali_name)
+        self.assertEqual(self.holidays[date(2010, FEB, 28)], holi_name)
+        self.assertEqual(self.holidays[date(2011, MAR, 19)], holi_name)
+        self.assertEqual(self.holidays[date(2011, OCT, 26)], diwali_name)
+        self.assertEqual(self.holidays[date(2012, MAR, 8)], holi_name)
+        self.assertEqual(self.holidays[date(2012, NOV, 13)], diwali_name)
+        self.assertEqual(self.holidays[date(2013, MAR, 26)], holi_name)
+        self.assertEqual(self.holidays[date(2013, NOV, 3)], diwali_name)
+        self.assertEqual(self.holidays[date(2014, MAR, 17)], holi_name)
+        self.assertEqual(self.holidays[date(2014, OCT, 23)], diwali_name)
+        self.assertEqual(self.holidays[date(2015, MAR, 6)], holi_name)
+        self.assertEqual(self.holidays[date(2015, NOV, 11)], diwali_name)
+        self.assertEqual(self.holidays[date(2016, MAR, 24)], holi_name)
+        self.assertEqual(self.holidays[date(2016, OCT, 30)], diwali_name)
+        self.assertEqual(self.holidays[date(2017, MAR, 13)], holi_name)
+        self.assertEqual(self.holidays[date(2017, OCT, 19)], diwali_name)
+        self.assertEqual(self.holidays[date(2018, MAR, 2)], holi_name)
+        self.assertEqual(self.holidays[date(2018, NOV, 7)], diwali_name)
+        self.assertEqual(self.holidays[date(2019, MAR, 21)], holi_name)
+        self.assertEqual(self.holidays[date(2019, OCT, 27)], diwali_name)
+        self.assertEqual(self.holidays[date(2020, MAR, 9)], holi_name)
+        self.assertEqual(self.holidays[date(2020, NOV, 14)], diwali_name)
+        self.assertEqual(self.holidays[date(2021, MAR, 28)], holi_name)
+        self.assertEqual(self.holidays[date(2021, NOV, 4)], diwali_name)
+        self.assertEqual(self.holidays[date(2022, MAR, 18)], holi_name)
+        self.assertEqual(self.holidays[date(2022, OCT, 24)], diwali_name)
+        self.assertEqual(self.holidays[date(2023, MAR, 7)], holi_name)
+        self.assertEqual(self.holidays[date(2023, OCT, 12)], diwali_name)
+        self.assertEqual(self.holidays[date(2024, MAR, 25)], holi_name)
+        self.assertEqual(self.holidays[date(2024, NOV, 1)], diwali_name)
+        self.assertEqual(self.holidays[date(2025, MAR, 14)], holi_name)
+        self.assertEqual(self.holidays[date(2025, OCT, 21)], diwali_name)
+        self.assertEqual(self.holidays[date(2026, MAR, 3)], holi_name)
+        self.assertEqual(self.holidays[date(2026, NOV, 8)], diwali_name)
+        self.assertEqual(self.holidays[date(2027, MAR, 22)], holi_name)
+        self.assertEqual(self.holidays[date(2027, OCT, 29)], diwali_name)
+        self.assertEqual(self.holidays[date(2028, MAR, 11)], holi_name)
+        self.assertEqual(self.holidays[date(2028, OCT, 17)], diwali_name)
+        self.assertEqual(self.holidays[date(2029, FEB, 28)], holi_name)
+        self.assertEqual(self.holidays[date(2029, NOV, 5)], diwali_name)
+        self.assertEqual(self.holidays[date(2030, MAR, 19)], holi_name)
+        self.assertEqual(self.holidays[date(2030, OCT, 26)], diwali_name)

--- a/test/countries/test_saudi_arabia.py
+++ b/test/countries/test_saudi_arabia.py
@@ -40,7 +40,7 @@ class TestSaudiArabia(unittest.TestCase):
 
     def test_national_day(self):
         self.assertIn(date(2020, 9, 23), self.holidays)
-        # National day started as a holiday at 2005
+        # National day started as a holiday on 2005
         self.assertNotIn(date(2004, 9, 23), self.holidays)
         self.assertIn(date(2005, 9, 23), self.holidays)
 
@@ -67,14 +67,26 @@ class TestSaudiArabia(unittest.TestCase):
             import importlib.util
 
             if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.SA(years=[2020])
-                # eid alfitr
+                self.holidays = holidays.SA(years=[2020, 2022])
+                # eid al-fitr
+                self.assertIn(date(2022, 5, 1), self.holidays)
+                self.assertIn(date(2022, 5, 2), self.holidays)
+                self.assertIn(date(2022, 5, 3), self.holidays)
+                self.assertIn(date(2022, 5, 4), self.holidays)
+
+                # eid al-adha
+                self.assertIn(date(2022, 7, 10), self.holidays)
+                self.assertIn(date(2022, 7, 11), self.holidays)
+                self.assertIn(date(2022, 7, 12), self.holidays)
+                self.assertIn(date(2022, 7, 13), self.holidays)
+
+                # eid al-fitr
                 self.assertIn(date(2020, 5, 23), self.holidays)
                 self.assertIn(date(2020, 5, 24), self.holidays)
                 self.assertIn(date(2020, 5, 25), self.holidays)
                 self.assertIn(date(2020, 5, 26), self.holidays)
 
-                # eid aladha
+                # eid al-adha
                 self.assertIn(date(2020, 7, 30), self.holidays)
                 self.assertIn(date(2020, 7, 31), self.holidays)
                 self.assertIn(date(2020, 8, 1), self.holidays)
@@ -85,20 +97,18 @@ class TestSaudiArabia(unittest.TestCase):
             import importlib.util
 
             if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.SA(years=range(2014, 2021))
-                # observed eid alfitr
+                self.holidays = holidays.SA(years=range(2019, 2023))
+                # observed eid al-fitr
                 self.assertIn(date(2020, 5, 27), self.holidays)
 
-                # self.assertIn(date(2016, 7, 10), self.holidays)
-                # self.assertIn(date(2016, 7, 11), self.holidays)
+                self.assertIn(date(2019, 6, 8), self.holidays)
 
-                self.assertIn(date(2018, 6, 18), self.holidays)
-                self.assertIn(date(2018, 6, 19), self.holidays)
+                # osbserved eid al-adha
+                self.assertIn(date(2022, 7, 12), self.holidays)
+                self.assertIn(date(2022, 7, 13), self.holidays)
 
-                self.assertIn(date(2019, 6, 9), self.holidays)
-
-                # osbserved eid aladha
-                self.assertIn(date(2014, 10, 8), self.holidays)
+                self.assertIn(date(2020, 8, 3), self.holidays)
+                self.assertIn(date(2020, 8, 4), self.holidays)
 
                 # self.assertIn(date(2017, 8, 3), self.holidays)
                 # self.assertIn(date(2017, 8, 4), self.holidays)
@@ -117,31 +127,31 @@ class TestSaudiArabia(unittest.TestCase):
                 self.holidays = holidays.SA(
                     observed=False, years=range(2014, 2021)
                 )
-                # observed eid alfitr
+                # observed eid al-fitr
                 self.assertNotIn(date(2020, 5, 27), self.holidays)
 
-                # self.assertNotIn(date(2016, 7, 10), self.holidays)
-                # self.assertNotIn(date(2016, 7, 11), self.holidays)
+                self.assertNotIn(date(2016, 7, 10), self.holidays)
+                self.assertNotIn(date(2016, 7, 11), self.holidays)
 
                 self.assertNotIn(date(2018, 6, 18), self.holidays)
                 self.assertNotIn(date(2018, 6, 19), self.holidays)
 
                 self.assertNotIn(date(2019, 6, 9), self.holidays)
 
-                # osbserved eid aladha
+                # osbserved eid al-adha
                 self.assertNotIn(date(2014, 10, 8), self.holidays)
 
-                # self.assertNotIn(date(2017, 8, 3), self.holidays)
-                # self.assertNotIn(date(2017, 8, 4), self.holidays)
+                self.assertNotIn(date(2017, 8, 3), self.holidays)
+                self.assertNotIn(date(2017, 8, 4), self.holidays)
 
                 # self.assertNotIn(date(2019, 8, 13), self.holidays)
-                # self.assertNotIn(date(2019, 8, 14), self.holidays)
+                self.assertNotIn(date(2019, 8, 14), self.holidays)
 
-                # self.assertNotIn(date(2017, 8, 6), self.holidays)
+                self.assertNotIn(date(2017, 8, 6), self.holidays)
 
     def test_hijri_based_with_two_holidays_in_one_year(self):
         """
-        Note: this might required change if weekend changes
+        Note: this might be required change if weekend changes
         took effect in the holiday.SA class (weekend changed
         on June 28th, 2013), from (Thursdays and Fridays) to
         (Fridays, Saturdays).
@@ -159,11 +169,11 @@ class TestSaudiArabia(unittest.TestCase):
                 self.assertIn(date(2006, 10, 24), self.holidays)
                 self.assertIn(date(2006, 10, 25), self.holidays)
                 self.assertIn(date(2006, 10, 26), self.holidays)
-                # eid_aladha 1 (hijiry year 1426)
+                # eid al-adha 1 (hijri year 1426)
                 self.assertIn(date(2006, 1, 9), self.holidays)
                 self.assertIn(date(2006, 1, 10), self.holidays)
                 self.assertIn(date(2006, 1, 11), self.holidays)
                 self.assertIn(date(2006, 1, 12), self.holidays)
-                # eid_aladha 2 (hijiry year 1427)
+                # eid al-adha 2 (hijri year 1427)
                 # The remaining holidays fall in the next year 2007
                 self.assertIn(date(2006, 12, 31), self.holidays)

--- a/test/countries/test_singapore.py
+++ b/test/countries/test_singapore.py
@@ -127,3 +127,10 @@ class TestSingapore(unittest.TestCase):
                 self.assertIn(
                     date(2023, 6, 28), self.holidays
                 )  # Hari Raya Haji
+
+    def test_aliases(self):
+        """For coverage purposes"""
+        h = holidays.SG()
+        self.assertIsInstance(h, holidays.Singapore)
+        h = holidays.SGP()
+        self.assertIsInstance(h, holidays.Singapore)

--- a/test/test_holiday_base.py
+++ b/test/test_holiday_base.py
@@ -12,6 +12,7 @@
 #  License: MIT (see LICENSE file)
 
 import pickle
+import sys
 import unittest
 import warnings
 
@@ -597,13 +598,18 @@ class TestAllInSameYear(unittest.TestCase):
 
         Here we test all countries for the 12-year period starting ten years
         ago and ending 2 years from now.
+
+        This is logic test and not a code compatibility test, so for expediency
+        we only run it once on the latest Python version.
         """
-        for self.country in self.countries:
-            for self.year in range(
-                date.today().year - 10, date.today().year + 3
-            ):
-                hols = holidays.country_holidays(
-                    self.country, prov=None, state=None, years=[self.year]
-                )
-                for self.hol in hols:
-                    assert self.hol.year == self.year
+        if sys.version_info[0:1] == (3, 10):
+            for self.country in self.countries:
+                for self.year in range(
+                    # date.today().year - 10, date.today().year + 3
+                    1950, 2051
+                ):
+                    hols = holidays.country_holidays(
+                        self.country, prov=None, state=None, years=[self.year]
+                    )
+                    for self.hol in hols:
+                        assert self.hol.year == self.year

--- a/test/test_holiday_base.py
+++ b/test/test_holiday_base.py
@@ -606,7 +606,8 @@ class TestAllInSameYear(unittest.TestCase):
             for self.country in self.countries:
                 for self.year in range(
                     # date.today().year - 10, date.today().year + 3
-                    1950, 2051
+                    1950,
+                    2051,
                 ):
                     hols = holidays.country_holidays(
                         self.country, prov=None, state=None, years=[self.year]


### PR DESCRIPTION
While working on an another PR I discovered that  my PR #586 (Do not expand into other years) was incomplete: I missed that holidays for Saudi Arabia for 2006 would also return holidays for 2007, violating the "do not expand into other years" rule and triggering the "dict expansion while iterating" error in people's code.

The issue, it turns out, is multi-day Islamic holidays; in this specific case it was the Eid al-Adha Holiday running from 30-Dec-2006 to 03-Jan-2007, across Gregorian years.

Here is a fix for this issue, covering Saudi Arabia and all other countries affected. It's not very elegant but I couldn't think of a better solution (open to ideas). The fix has been successfully tested on all years from 1950 to 2050 inclusive.

I also addressed:
* The Saudi Arabia tests had some assertions remarked out, and these were added back in.
* The Saudi Arabia tests were strengthened by adding assertions for 2022 holidays.
* The code for Saudi Arabia had the remark "Weekend used to be THU, FRI before June 28th, 2013", which was not implemented in code; I implemented it
* The `test_all_countries` test I wrote for PR #586 (Do not expand into other years) does not need to be run in all Python versions since it's a logic test, not a code compatibility one; I fixed this so we don't have needlessly long test times (they are already getting a bit too lengthy IMHO).