### PR TITLE
mypy implementation

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
         args: [--fix=lf]
 
   - repo: https://github.com/python/black
-    rev: 21.12b0
+    rev: 22.1.0
     hooks:
       - id: black
         language_version: python3
@@ -21,6 +21,15 @@ repos:
     hooks:
       - id: flake8
         args: [--max-line-length=79]
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: 'v0.931'
+    hooks:
+      - id: mypy
+        additional_dependencies: [types-all]
+        args:
+          - --ignore-missing-imports
+          - --show-error-codes
 
   - repo: https://github.com/pre-commit/pygrep-hooks
     rev: v1.9.0

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,3 +2,4 @@ include *.py
 include *.rst
 include LICENSE
 include CHANGES
+include py.typed

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,6 +15,7 @@ import os
 import sys
 
 from datetime import date
+from typing import Dict, List, Union
 
 from docutils import nodes
 from docutils.nodes import Element, Node
@@ -60,7 +61,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = []
+exclude_patterns: List[str] = []
 
 # Add any paths that contain templates here, relative to this directory.
 #
@@ -132,7 +133,7 @@ html_copy_source = False
 #
 # See https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html
 #
-html_theme_options = {
+html_theme_options: Dict[str, Union[str, bool, int]] = {
     # 'canonical_url': '',
     # 'analytics_id': 'UA-XXXXXXX-1',  #  Provided by Google in your dashboard
     # 'analytics_anonymize_ip': False

--- a/holidays/countries/korea.py
+++ b/holidays/countries/korea.py
@@ -259,6 +259,9 @@ class Korea(HolidayBase):
         :return:
            A tuple consisting of a flag set to whether the date is different
            and the date itself.
+
+        :raise RuntimeError:
+           When no such date is not found.
         """
         target_weekday = [SUN]
         if include_sat:
@@ -276,6 +279,8 @@ class Korea(HolidayBase):
                 is_alt = True
                 continue
             return is_alt, cur
+
+        raise RuntimeError("Next non-holiday date not found")
 
 
 class KR(Korea):

--- a/holidays/py.typed
+++ b/holidays/py.typed
@@ -1,0 +1,3 @@
+# Required by PEP 561 to show that we have static types
+# See https://www.python.org/dev/peps/pep-0561/#packaging-type-information.
+# Enables mypy to discover type hints.

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -173,8 +173,10 @@ def country_holidays(
         country_classes = inspect.getmembers(
             holidays.countries, inspect.isclass
         )
-        country = next(obj for name, obj in country_classes if name == country)
-        country_holiday = country(
+        country_class = next(
+            obj for name, obj in country_classes if name == country
+        )
+        country_holiday = country_class(
             years=years,
             subdiv=subdiv,
             expand=expand,

--- a/test/countries/__init__.py
+++ b/test/countries/__init__.py
@@ -11,9 +11,19 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 import pkgutil
+from importlib.abc import MetaPathFinder, PathEntryFinder
+from typing import Union
+
+loader: Union[MetaPathFinder, PathEntryFinder]
+module_name: str
+is_pkg: bool
 
 __all__ = []
 for loader, module_name, is_pkg in pkgutil.walk_packages(__path__):
     __all__.append(module_name)
-    _module = loader.find_module(module_name).load_module(module_name)
+    _module = loader.find_module(  # type: ignore[union-attr]
+        module_name
+    ).load_module(  # type: ignore[call-arg]
+        module_name
+    )
     globals()[module_name] = _module

--- a/tox.ini
+++ b/tox.ini
@@ -7,9 +7,11 @@ envlist = py{36,37,38,39,310,py3}, pre-commit, docs
 addopts = --cov=./ --cov-report term --cov-report xml --cov-config=./pyproject.toml
 
 [testenv:pre-commit]
-basepython=python
-deps=pre-commit
-commands=pre-commit run -a
+basepython = python
+deps = pre-commit
+commands =
+    pre-commit autoupdate
+    pre-commit run -a
 
 [testenv]
 deps = -r{toxinidir}/requirements_dev.txt


### PR DESCRIPTION
* Implemented [mypy](http://mypy-lang.org/) static type checker in pre-commit
* Updated pre-commit to current versions ($ [pre-commit autoupdate](https://pre-commit.com/#pre-commit-autoupdate))
* Added `py.typing` file to implement [PEP 561 packaging type information](https://www.python.org/dev/peps/pep-0561/#packaging-type-information)
* Minor cleanup of errors in static typing / incompatibilities with mypy and addition of `# type: ignore`

