### PR TITLE
Drop support for EOL Python 3.6

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9, pypy-3.7]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "pypy-3.7"]
 
     steps:
       - uses: actions/checkout@v2
@@ -62,10 +62,10 @@ jobs:
     needs: [test]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install -U pip wheel

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,6 +1,9 @@
 name: "Tests"
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  FORCE_COLOR: 1
+
 jobs:
   pre-commit:
     name: Run Quality Assurance

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,6 +31,8 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: requirements_dev.txt
       - name: Install dependencies
         run: |
           python -m pip install -U pip wheel 'coveralls>=3'

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,7 +35,7 @@ jobs:
           python -m pip install -e .
       - name: Run tests
         run: |
-          py.test
+          pytest
       - name: Upload Coverage
         run: coveralls --service=github
         env:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
       - id: fix-encoding-pragma
+        args: [--remove]
       - id: mixed-line-ending
         args: [--fix=lf]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Configuration file for the Sphinx documentation builder.
 #
 # This file only contains a selection of the most common options. For a full

--- a/holidays/__init__.py
+++ b/holidays/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/constants.py
+++ b/holidays/constants.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/angola.py
+++ b/holidays/countries/angola.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/argentina.py
+++ b/holidays/countries/argentina.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/aruba.py
+++ b/holidays/countries/aruba.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/austria.py
+++ b/holidays/countries/austria.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/azerbaijan.py
+++ b/holidays/countries/azerbaijan.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/bangladesh.py
+++ b/holidays/countries/bangladesh.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/belarus.py
+++ b/holidays/countries/belarus.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/belgium.py
+++ b/holidays/countries/belgium.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/botswana.py
+++ b/holidays/countries/botswana.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/brazil.py
+++ b/holidays/countries/brazil.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/bulgaria.py
+++ b/holidays/countries/bulgaria.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/burundi.py
+++ b/holidays/countries/burundi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/china.py
+++ b/holidays/countries/china.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/croatia.py
+++ b/holidays/countries/croatia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/curacao.py
+++ b/holidays/countries/curacao.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/czechia.py
+++ b/holidays/countries/czechia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/denmark.py
+++ b/holidays/countries/denmark.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/djibouti.py
+++ b/holidays/countries/djibouti.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/dominican_republic.py
+++ b/holidays/countries/dominican_republic.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/egypt.py
+++ b/holidays/countries/egypt.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/estonia.py
+++ b/holidays/countries/estonia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/ethiopia.py
+++ b/holidays/countries/ethiopia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/european_central_bank.py
+++ b/holidays/countries/european_central_bank.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/finland.py
+++ b/holidays/countries/finland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/france.py
+++ b/holidays/countries/france.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/georgia.py
+++ b/holidays/countries/georgia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/germany.py
+++ b/holidays/countries/germany.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/greece.py
+++ b/holidays/countries/greece.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/honduras.py
+++ b/holidays/countries/honduras.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/hongkong.py
+++ b/holidays/countries/hongkong.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/hungary.py
+++ b/holidays/countries/hungary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/iceland.py
+++ b/holidays/countries/iceland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/isle_of_man.py
+++ b/holidays/countries/isle_of_man.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/israel.py
+++ b/holidays/countries/israel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/italy.py
+++ b/holidays/countries/italy.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/jamaica.py
+++ b/holidays/countries/jamaica.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/kazakhstan.py
+++ b/holidays/countries/kazakhstan.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/kenya.py
+++ b/holidays/countries/kenya.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/korea.py
+++ b/holidays/countries/korea.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/latvia.py
+++ b/holidays/countries/latvia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/lesotho.py
+++ b/holidays/countries/lesotho.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/lithuania.py
+++ b/holidays/countries/lithuania.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/luxembourg.py
+++ b/holidays/countries/luxembourg.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/malawi.py
+++ b/holidays/countries/malawi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/malaysia.py
+++ b/holidays/countries/malaysia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/mexico.py
+++ b/holidays/countries/mexico.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/morocco.py
+++ b/holidays/countries/morocco.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/mozambique.py
+++ b/holidays/countries/mozambique.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/namibia.py
+++ b/holidays/countries/namibia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/netherlands.py
+++ b/holidays/countries/netherlands.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/new_zealand.py
+++ b/holidays/countries/new_zealand.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/nicaragua.py
+++ b/holidays/countries/nicaragua.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/nigeria.py
+++ b/holidays/countries/nigeria.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/north_macedonia.py
+++ b/holidays/countries/north_macedonia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/norway.py
+++ b/holidays/countries/norway.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/paraguay.py
+++ b/holidays/countries/paraguay.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/peru.py
+++ b/holidays/countries/peru.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/poland.py
+++ b/holidays/countries/poland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/portugal.py
+++ b/holidays/countries/portugal.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/romania.py
+++ b/holidays/countries/romania.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/russia.py
+++ b/holidays/countries/russia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/serbia.py
+++ b/holidays/countries/serbia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/slovakia.py
+++ b/holidays/countries/slovakia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/slovenia.py
+++ b/holidays/countries/slovenia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/spain.py
+++ b/holidays/countries/spain.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/swaziland.py
+++ b/holidays/countries/swaziland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/sweden.py
+++ b/holidays/countries/sweden.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/switzerland.py
+++ b/holidays/countries/switzerland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/taiwan.py
+++ b/holidays/countries/taiwan.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/tunisia.py
+++ b/holidays/countries/tunisia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/turkey.py
+++ b/holidays/countries/turkey.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/ukraine.py
+++ b/holidays/countries/ukraine.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/united_arab_emirates.py
+++ b/holidays/countries/united_arab_emirates.py
@@ -88,20 +88,20 @@ class UnitedArabEmirates(HolidayBase):
             for date_obs in dates_obs[year]:
                 hol_date = date(year, *date_obs)
                 self[hol_date] = fitr
-                self[hol_date + rd(days=1)] = "{} Holiday".format(fitr)
-                self[hol_date + rd(days=2)] = "{} Holiday".format(fitr)
+                self[hol_date + rd(days=1)] = f"{fitr} Holiday"
+                self[hol_date + rd(days=2)] = f"{fitr} Holiday"
         else:
             for yr in (year - 1, year):
                 for date_obs in _islamic_to_gre(yr, 10, 1):
                     hol_date = date_obs
-                    _add_holiday(hol_date, "{}* (*estimated)".format(fitr))
+                    _add_holiday(hol_date, f"{fitr}* (*estimated)")
                     _add_holiday(
                         hol_date + rd(days=1),
-                        "{} Holiday* (*estimated)".format(fitr),
+                        f"{fitr} Holiday* (*estimated)",
                     )
                     _add_holiday(
                         hol_date + rd(days=2),
-                        "{} Holiday* (*estimated)".format(fitr),
+                        f"{fitr} Holiday* (*estimated)",
                     )
 
         # Arafat Day & Eid al-Adha
@@ -118,23 +118,23 @@ class UnitedArabEmirates(HolidayBase):
                 hol_date = date(year, *date_obs)
                 self[hol_date] = hajj
                 self[hol_date + rd(days=1)] = adha
-                self[hol_date + rd(days=2)] = "{} Holiday".format(adha)
-                self[hol_date + rd(days=3)] = "{} Holiday".format(adha)
+                self[hol_date + rd(days=2)] = f"{adha} Holiday"
+                self[hol_date + rd(days=3)] = f"{adha} Holiday"
         else:
             for yr in (year - 1, year):
                 for date_obs in _islamic_to_gre(yr, 12, 9):
                     hol_date = date_obs
-                    _add_holiday(hol_date, "{}* (*estimated)".format(hajj))
+                    _add_holiday(hol_date, f"{hajj}* (*estimated)")
                     _add_holiday(
-                        hol_date + rd(days=1), "{}* (*estimated)".format(adha)
+                        hol_date + rd(days=1), f"{adha}* (*estimated)"
                     )
                     _add_holiday(
                         hol_date + rd(days=2),
-                        "{}* Holiday* (*estimated)".format(adha),
+                        f"{adha}* Holiday* (*estimated)",
                     )
                     _add_holiday(
                         hol_date + rd(days=3),
-                        "{} Holiday* (*estimated)".format(adha),
+                        f"{adha} Holiday* (*estimated)",
                     )
 
         # Islamic New Year - (hijari_year, 1, 1)
@@ -152,7 +152,7 @@ class UnitedArabEmirates(HolidayBase):
         else:
             for date_obs in _islamic_to_gre(year, 1, 1):
                 hol_date = date_obs
-                self[hol_date] = "{}* (*estimated)".format(new_hijri_year)
+                self[hol_date] = f"{new_hijri_year}* (*estimated)"
 
         # Leilat al-Miraj - The Prophet's ascension (hijari_year, 7, 27)
         if year <= 2018:  # starting from 2019 the UAE government removed this
@@ -165,7 +165,7 @@ class UnitedArabEmirates(HolidayBase):
             else:
                 for date_obs in _islamic_to_gre(year, 7, 27):
                     hol_date = date_obs
-                    self[hol_date] = "{}* (*estimated)".format(ascension)
+                    self[hol_date] = f"{ascension}* (*estimated)"
 
         # Prophet Muhammad's Birthday - (hijari_year, 3, 12)
         if year <= 2019:  # starting from 2020 the UAE government removed this
@@ -182,7 +182,7 @@ class UnitedArabEmirates(HolidayBase):
             else:
                 for date_obs in _islamic_to_gre(year, 3, 12):
                     hol_date = date_obs
-                    self[hol_date] = "{}* (*estimated)".format(mawlud)
+                    self[hol_date] = f"{mawlud}* (*estimated)"
 
 
 class AE(UnitedArabEmirates):

--- a/holidays/countries/united_arab_emirates.py
+++ b/holidays/countries/united_arab_emirates.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/uruguay.py
+++ b/holidays/countries/uruguay.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/uzbekistan.py
+++ b/holidays/countries/uzbekistan.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/venezuela.py
+++ b/holidays/countries/venezuela.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/vietnam.py
+++ b/holidays/countries/vietnam.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/zambia.py
+++ b/holidays/countries/zambia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/countries/zimbabwe.py
+++ b/holidays/countries/zimbabwe.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country and subdivision

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -352,7 +352,7 @@ class HolidayBase(dict):
     ) -> None:
         if key in self:
             if self.get(key).find(value) < 0 and value.find(self.get(key)) < 0:
-                value = "%s, %s" % (value, self.get(key))
+                value = f"{value}, {self.get(key)}"
             else:
                 value = self.get(key)
         return dict.__setitem__(self, self.__keytransform__(key), value)
@@ -555,7 +555,7 @@ class HolidayBase(dict):
         pass
 
     def __reduce__(self) -> Union[str, Tuple[Any, ...]]:
-        return super(HolidayBase, self).__reduce__()
+        return super().__reduce__()
 
     def __repr__(self):
         if len(self) == 0:
@@ -564,12 +564,12 @@ class HolidayBase(dict):
                 _repr += f", subdiv={self.subdiv!r}"
             _repr += ")"
             return _repr
-        return super(HolidayBase, self).__repr__()
+        return super().__repr__()
 
     def __str__(self):
         if len(self) == 0:
             return str(self.__dict__)
-        return super(HolidayBase, self).__str__()
+        return super().__str__()
 
 
 class HolidaySum(HolidayBase):

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country and subdivision

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -38,7 +37,7 @@ install_requires =
     hijri-converter
     korean-lunar-calendar
     python-dateutil
-python_requires = >=3.6
+python_requires = >=3.7
 
 [bumpversion]
 current_version = 0.13

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/__init__.py
+++ b/test/countries/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_angola.py
+++ b/test/countries/test_angola.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_argentina.py
+++ b/test/countries/test_argentina.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_aruba.py
+++ b/test/countries/test_aruba.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_australia.py
+++ b/test/countries/test_australia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_austria.py
+++ b/test/countries/test_austria.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_azerbaijan.py
+++ b/test/countries/test_azerbaijan.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_azerbaijan.py
+++ b/test/countries/test_azerbaijan.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import sys
+import importlib.util
 import unittest
 
 from datetime import date
@@ -48,18 +48,15 @@ class TestAzerbaijan(unittest.TestCase):
         self.assertIn(date(2020, DEC, 31), self.holidays)
 
     def test_hijri_based(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
-
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.AZ(years=[2020])
-                # Ramadan Feast
-                self.assertIn(date(2020, 5, 24), self.holidays)
-                self.assertIn(date(2020, 5, 25), self.holidays)
-                # Sacrifice Feast
-                self.assertIn(date(2020, 7, 31), self.holidays)
-                self.assertIn(date(2020, 8, 1), self.holidays)
-                self.assertIn(date(2020, 8, 3), self.holidays)  # observed
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.AZ(years=[2020])
+            # Ramadan Feast
+            self.assertIn(date(2020, 5, 24), self.holidays)
+            self.assertIn(date(2020, 5, 25), self.holidays)
+            # Sacrifice Feast
+            self.assertIn(date(2020, 7, 31), self.holidays)
+            self.assertIn(date(2020, 8, 1), self.holidays)
+            self.assertIn(date(2020, 8, 3), self.holidays)  # observed
 
     def test_dec_31_on_weekend(self):
         """Test when Dec 31 of previous year is on a weekend."""

--- a/test/countries/test_bangladesh.py
+++ b/test/countries/test_bangladesh.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_belarus.py
+++ b/test/countries/test_belarus.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_belgium.py
+++ b/test/countries/test_belgium.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_botswana.py
+++ b/test/countries/test_botswana.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_brazil.py
+++ b/test/countries/test_brazil.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_bulgaria.py
+++ b/test/countries/test_bulgaria.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_burundi.py
+++ b/test/countries/test_burundi.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import sys
+import importlib.util
 import unittest
 
 from datetime import date
@@ -85,12 +85,9 @@ class TestBurundi(unittest.TestCase):
         self.assertIn("Christmas Day", self.holidays[date(2020, 12, 25)])
 
     def test_eid_al_adha(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.Burundi(years=[2019, 1999])
 
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.Burundi(years=[2019, 1999])
-
-                # eid Al Adha
-                self.assertIn(date(2020, 7, 31), self.holidays)
-                self.assertIn(date(2020, 7, 31), self.holidays)
+            # eid Al Adha
+            self.assertIn(date(2020, 7, 31), self.holidays)
+            self.assertIn(date(2020, 7, 31), self.holidays)

--- a/test/countries/test_burundi.py
+++ b/test/countries/test_burundi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_chile.py
+++ b/test/countries/test_chile.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_china.py
+++ b/test/countries/test_china.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_colombia.py
+++ b/test/countries/test_colombia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_croatia.py
+++ b/test/countries/test_croatia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_curacao.py
+++ b/test/countries/test_curacao.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_czechia.py
+++ b/test/countries/test_czechia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_denmark.py
+++ b/test/countries/test_denmark.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_djibouti.py
+++ b/test/countries/test_djibouti.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_djibouti.py
+++ b/test/countries/test_djibouti.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import sys
+import importlib.util
 import unittest
 
 from datetime import date
@@ -30,24 +30,21 @@ class TestDjibouti(unittest.TestCase):
         self.assertIn(date(2019, 5, 1), self.holidays)
 
     def test_hijri_based(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
-
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.DJ(years=[2010])
-                self.assertIn(date(2019, 6, 5), self.holidays)
-                self.assertIn(date(2019, 8, 10), self.holidays)
-                self.assertIn(date(2019, 8, 11), self.holidays)
-                self.assertIn(date(2019, 8, 12), self.holidays)
-                self.assertIn(date(2019, 8, 31), self.holidays)
-                self.assertIn(date(2019, 11, 9), self.holidays)
-                # eid_alfitr
-                self.assertIn(date(2019, 6, 5), self.holidays)
-                # eid_aladha
-                self.assertIn(date(2019, 8, 11), self.holidays)
-                # islamic_new_year
-                self.assertIn(date(2019, 8, 31), self.holidays)
-                # arafat_2019
-                self.assertIn(date(2019, 8, 10), self.holidays)
-                # muhammad's birthday 2019
-                self.assertIn(date(2019, 11, 9), self.holidays)
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.DJ(years=[2010])
+            self.assertIn(date(2019, 6, 5), self.holidays)
+            self.assertIn(date(2019, 8, 10), self.holidays)
+            self.assertIn(date(2019, 8, 11), self.holidays)
+            self.assertIn(date(2019, 8, 12), self.holidays)
+            self.assertIn(date(2019, 8, 31), self.holidays)
+            self.assertIn(date(2019, 11, 9), self.holidays)
+            # eid_alfitr
+            self.assertIn(date(2019, 6, 5), self.holidays)
+            # eid_aladha
+            self.assertIn(date(2019, 8, 11), self.holidays)
+            # islamic_new_year
+            self.assertIn(date(2019, 8, 31), self.holidays)
+            # arafat_2019
+            self.assertIn(date(2019, 8, 10), self.holidays)
+            # muhammad's birthday 2019
+            self.assertIn(date(2019, 11, 9), self.holidays)

--- a/test/countries/test_dominican_republic.py
+++ b/test/countries/test_dominican_republic.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_egypt.py
+++ b/test/countries/test_egypt.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import sys
+import importlib.util
 import unittest
 
 from datetime import date
@@ -47,26 +47,23 @@ class TestEgypt(unittest.TestCase):
         self.assertIn(date(2010, 1, 25), self.holidays)
 
     def test_hijri_based(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
-
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.EG(years=[2010])
-                self.assertIn(date(2019, 6, 5), self.holidays)
-                self.assertIn(date(2019, 8, 10), self.holidays)
-                self.assertIn(date(2019, 8, 11), self.holidays)
-                self.assertIn(date(2019, 8, 12), self.holidays)
-                self.assertIn(date(2019, 8, 31), self.holidays)
-                self.assertIn(date(2019, 11, 9), self.holidays)
-                # eid_alfitr
-                self.assertIn(date(2019, 6, 4), self.holidays)
-                # eid_aladha
-                self.assertIn(date(2019, 8, 11), self.holidays)
-                # islamic_new_year
-                self.assertIn(date(2019, 8, 31), self.holidays)
-                # eid_elfetr_2010
-                self.assertIn(date(2010, 9, 10), self.holidays)
-                # arafat_2010
-                self.assertIn(date(2010, 11, 15), self.holidays)
-                # muhammad's birthda
-                self.assertIn(date(2010, 2, 26), self.holidays)
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.EG(years=[2010])
+            self.assertIn(date(2019, 6, 5), self.holidays)
+            self.assertIn(date(2019, 8, 10), self.holidays)
+            self.assertIn(date(2019, 8, 11), self.holidays)
+            self.assertIn(date(2019, 8, 12), self.holidays)
+            self.assertIn(date(2019, 8, 31), self.holidays)
+            self.assertIn(date(2019, 11, 9), self.holidays)
+            # eid_alfitr
+            self.assertIn(date(2019, 6, 4), self.holidays)
+            # eid_aladha
+            self.assertIn(date(2019, 8, 11), self.holidays)
+            # islamic_new_year
+            self.assertIn(date(2019, 8, 31), self.holidays)
+            # eid_elfetr_2010
+            self.assertIn(date(2010, 9, 10), self.holidays)
+            # arafat_2010
+            self.assertIn(date(2010, 11, 15), self.holidays)
+            # muhammad's birthda
+            self.assertIn(date(2010, 2, 26), self.holidays)

--- a/test/countries/test_egypt.py
+++ b/test/countries/test_egypt.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_estonia.py
+++ b/test/countries/test_estonia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_ethiopia.py
+++ b/test/countries/test_ethiopia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_ethiopia.py
+++ b/test/countries/test_ethiopia.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import sys
+import importlib.util
 import unittest
 
 from datetime import date
@@ -82,14 +82,11 @@ class TestEthiopia(unittest.TestCase):
         self.assertIn(date(1983, 9, 13), self.holidays)
 
     def test_hijri_based(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
-
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.ET(years=[2019])
-                # eid_alfitr
-                self.assertIn(date(2019, 6, 4), self.holidays)
-                # eid_aladha
-                self.assertIn(date(2019, 8, 11), self.holidays)
-                # muhammad's birthday
-                self.assertIn(date(2019, 11, 10), self.holidays)
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.ET(years=[2019])
+            # eid_alfitr
+            self.assertIn(date(2019, 6, 4), self.holidays)
+            # eid_aladha
+            self.assertIn(date(2019, 8, 11), self.holidays)
+            # muhammad's birthday
+            self.assertIn(date(2019, 11, 10), self.holidays)

--- a/test/countries/test_european_central_bank.py
+++ b/test/countries/test_european_central_bank.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_finland.py
+++ b/test/countries/test_finland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_france.py
+++ b/test/countries/test_france.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_georgia.py
+++ b/test/countries/test_georgia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_germany.py
+++ b/test/countries/test_germany.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_germany.py
+++ b/test/countries/test_germany.py
@@ -58,9 +58,9 @@ class TestDE(unittest.TestCase):
         ]
 
         for holiday in all_de:
-            self.assertIn(holiday, in_2015, "missing: {}".format(holiday))
+            self.assertIn(holiday, in_2015, f"missing: {holiday}")
         for holiday in in_2015:
-            self.assertIn(holiday, all_de, "extra: {}".format(holiday))
+            self.assertIn(holiday, all_de, f"extra: {holiday}")
 
     def test_fixed_holidays(self):
         fixed_days_whole_country = (

--- a/test/countries/test_greece.py
+++ b/test/countries/test_greece.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_honduras.py
+++ b/test/countries/test_honduras.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_hongkong.py
+++ b/test/countries/test_hongkong.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_hungary.py
+++ b/test/countries/test_hungary.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_iceland.py
+++ b/test/countries/test_iceland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_india.py
+++ b/test/countries/test_india.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_ireland.py
+++ b/test/countries/test_ireland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_isle_of_man.py
+++ b/test/countries/test_isle_of_man.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_israel.py
+++ b/test/countries/test_israel.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_italy.py
+++ b/test/countries/test_italy.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_jamaica.py
+++ b/test/countries/test_jamaica.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_japan.py
+++ b/test/countries/test_japan.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_kazakhstan.py
+++ b/test/countries/test_kazakhstan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_kenya.py
+++ b/test/countries/test_kenya.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_korea.py
+++ b/test/countries/test_korea.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_latvia.py
+++ b/test/countries/test_latvia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_lesotho.py
+++ b/test/countries/test_lesotho.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_lithuania.py
+++ b/test/countries/test_lithuania.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_luxembourg.py
+++ b/test/countries/test_luxembourg.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_malawi.py
+++ b/test/countries/test_malawi.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_malaysia.py
+++ b/test/countries/test_malaysia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_mexico.py
+++ b/test/countries/test_mexico.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_morocco.py
+++ b/test/countries/test_morocco.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import sys
+import importlib.util
 import unittest
 
 from datetime import date
@@ -64,21 +64,18 @@ class TestMorocco(unittest.TestCase):
             self.assertIn(holiday, self.holidays)
 
     def test_hijri_based(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.Morocco(years=[2019, 1999])
+            # eid_alfitr
+            self.assertIn(date(2019, 6, 4), self.holidays)
+            self.assertIn(date(2019, 6, 5), self.holidays)
+            # eid_aladha
+            self.assertIn(date(2019, 8, 11), self.holidays)
+            self.assertIn(date(2019, 8, 12), self.holidays)
+            # islamic_new_year
+            self.assertIn(date(2019, 8, 31), self.holidays)
 
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.Morocco(years=[2019, 1999])
-                # eid_alfitr
-                self.assertIn(date(2019, 6, 4), self.holidays)
-                self.assertIn(date(2019, 6, 5), self.holidays)
-                # eid_aladha
-                self.assertIn(date(2019, 8, 11), self.holidays)
-                self.assertIn(date(2019, 8, 12), self.holidays)
-                # islamic_new_year
-                self.assertIn(date(2019, 8, 31), self.holidays)
+            self.assertIn(date(2019, 11, 9), self.holidays)
+            self.assertIn(date(2019, 11, 10), self.holidays)
 
-                self.assertIn(date(2019, 11, 9), self.holidays)
-                self.assertIn(date(2019, 11, 10), self.holidays)
-
-                self.assertIn(date(1999, 4, 17), self.holidays)
+            self.assertIn(date(1999, 4, 17), self.holidays)

--- a/test/countries/test_morocco.py
+++ b/test/countries/test_morocco.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_mozambique.py
+++ b/test/countries/test_mozambique.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_namibia.py
+++ b/test/countries/test_namibia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_netherlands.py
+++ b/test/countries/test_netherlands.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_new_zealand.py
+++ b/test/countries/test_new_zealand.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_nicaragua.py
+++ b/test/countries/test_nicaragua.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_nigeria.py
+++ b/test/countries/test_nigeria.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_north_macedonia.py
+++ b/test/countries/test_north_macedonia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_norway.py
+++ b/test/countries/test_norway.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_paraguay.py
+++ b/test/countries/test_paraguay.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_peru.py
+++ b/test/countries/test_peru.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_poland.py
+++ b/test/countries/test_poland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_portugal.py
+++ b/test/countries/test_portugal.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_romania.py
+++ b/test/countries/test_romania.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_russia.py
+++ b/test/countries/test_russia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_saudi_arabia.py
+++ b/test/countries/test_saudi_arabia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_saudi_arabia.py
+++ b/test/countries/test_saudi_arabia.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import sys
+import importlib.util
 import unittest
 
 from datetime import date
@@ -61,91 +61,81 @@ class TestSaudiArabia(unittest.TestCase):
         self.assertNotIn(date(2017, 9, 24), self.holidays)
 
     def test_hijri_based(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.SA(years=[2020, 2022])
+            # eid al-fitr
+            self.assertIn(date(2022, 5, 1), self.holidays)
+            self.assertIn(date(2022, 5, 2), self.holidays)
+            self.assertIn(date(2022, 5, 3), self.holidays)
+            self.assertIn(date(2022, 5, 4), self.holidays)
 
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.SA(years=[2020, 2022])
-                # eid al-fitr
-                self.assertIn(date(2022, 5, 1), self.holidays)
-                self.assertIn(date(2022, 5, 2), self.holidays)
-                self.assertIn(date(2022, 5, 3), self.holidays)
-                self.assertIn(date(2022, 5, 4), self.holidays)
+            # eid al-adha
+            self.assertIn(date(2022, 7, 10), self.holidays)
+            self.assertIn(date(2022, 7, 11), self.holidays)
+            self.assertIn(date(2022, 7, 12), self.holidays)
+            self.assertIn(date(2022, 7, 13), self.holidays)
 
-                # eid al-adha
-                self.assertIn(date(2022, 7, 10), self.holidays)
-                self.assertIn(date(2022, 7, 11), self.holidays)
-                self.assertIn(date(2022, 7, 12), self.holidays)
-                self.assertIn(date(2022, 7, 13), self.holidays)
+            # eid al-fitr
+            self.assertIn(date(2020, 5, 23), self.holidays)
+            self.assertIn(date(2020, 5, 24), self.holidays)
+            self.assertIn(date(2020, 5, 25), self.holidays)
+            self.assertIn(date(2020, 5, 26), self.holidays)
 
-                # eid al-fitr
-                self.assertIn(date(2020, 5, 23), self.holidays)
-                self.assertIn(date(2020, 5, 24), self.holidays)
-                self.assertIn(date(2020, 5, 25), self.holidays)
-                self.assertIn(date(2020, 5, 26), self.holidays)
-
-                # eid al-adha
-                self.assertIn(date(2020, 7, 30), self.holidays)
-                self.assertIn(date(2020, 7, 31), self.holidays)
-                self.assertIn(date(2020, 8, 1), self.holidays)
-                self.assertIn(date(2020, 8, 2), self.holidays)
+            # eid al-adha
+            self.assertIn(date(2020, 7, 30), self.holidays)
+            self.assertIn(date(2020, 7, 31), self.holidays)
+            self.assertIn(date(2020, 8, 1), self.holidays)
+            self.assertIn(date(2020, 8, 2), self.holidays)
 
     def test_hijri_based_observed(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.SA(years=range(2019, 2023))
+            # observed eid al-fitr
+            self.assertIn(date(2020, 5, 27), self.holidays)
 
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.SA(years=range(2019, 2023))
-                # observed eid al-fitr
-                self.assertIn(date(2020, 5, 27), self.holidays)
+            self.assertIn(date(2019, 6, 8), self.holidays)
 
-                self.assertIn(date(2019, 6, 8), self.holidays)
+            # osbserved eid al-adha
+            self.assertIn(date(2022, 7, 12), self.holidays)
+            self.assertIn(date(2022, 7, 13), self.holidays)
 
-                # osbserved eid al-adha
-                self.assertIn(date(2022, 7, 12), self.holidays)
-                self.assertIn(date(2022, 7, 13), self.holidays)
+            self.assertIn(date(2020, 8, 3), self.holidays)
+            self.assertIn(date(2020, 8, 4), self.holidays)
 
-                self.assertIn(date(2020, 8, 3), self.holidays)
-                self.assertIn(date(2020, 8, 4), self.holidays)
+            # self.assertIn(date(2017, 8, 3), self.holidays)
+            # self.assertIn(date(2017, 8, 4), self.holidays)
 
-                # self.assertIn(date(2017, 8, 3), self.holidays)
-                # self.assertIn(date(2017, 8, 4), self.holidays)
+            # self.assertIn(date(2019, 8, 13), self.holidays)
+            # self.assertIn(date(2019, 8, 14), self.holidays)
 
-                # self.assertIn(date(2019, 8, 13), self.holidays)
-                # self.assertIn(date(2019, 8, 14), self.holidays)
-
-                # self.assertIn(date(2017, 8, 6), self.holidays)
+            # self.assertIn(date(2017, 8, 6), self.holidays)
 
     def test_hijri_based_not_observed(self):
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.SA(
+                observed=False, years=range(2014, 2021)
+            )
+            # observed eid al-fitr
+            self.assertNotIn(date(2020, 5, 27), self.holidays)
 
-        if sys.version_info >= (3, 6):
-            import importlib.util
+            self.assertNotIn(date(2016, 7, 10), self.holidays)
+            self.assertNotIn(date(2016, 7, 11), self.holidays)
 
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.SA(
-                    observed=False, years=range(2014, 2021)
-                )
-                # observed eid al-fitr
-                self.assertNotIn(date(2020, 5, 27), self.holidays)
+            self.assertNotIn(date(2018, 6, 18), self.holidays)
+            self.assertNotIn(date(2018, 6, 19), self.holidays)
 
-                self.assertNotIn(date(2016, 7, 10), self.holidays)
-                self.assertNotIn(date(2016, 7, 11), self.holidays)
+            self.assertNotIn(date(2019, 6, 9), self.holidays)
 
-                self.assertNotIn(date(2018, 6, 18), self.holidays)
-                self.assertNotIn(date(2018, 6, 19), self.holidays)
+            # osbserved eid al-adha
+            self.assertNotIn(date(2014, 10, 8), self.holidays)
 
-                self.assertNotIn(date(2019, 6, 9), self.holidays)
+            self.assertNotIn(date(2017, 8, 3), self.holidays)
+            self.assertNotIn(date(2017, 8, 4), self.holidays)
 
-                # osbserved eid al-adha
-                self.assertNotIn(date(2014, 10, 8), self.holidays)
+            # self.assertNotIn(date(2019, 8, 13), self.holidays)
+            self.assertNotIn(date(2019, 8, 14), self.holidays)
 
-                self.assertNotIn(date(2017, 8, 3), self.holidays)
-                self.assertNotIn(date(2017, 8, 4), self.holidays)
-
-                # self.assertNotIn(date(2019, 8, 13), self.holidays)
-                self.assertNotIn(date(2019, 8, 14), self.holidays)
-
-                self.assertNotIn(date(2017, 8, 6), self.holidays)
+            self.assertNotIn(date(2017, 8, 6), self.holidays)
 
     def test_hijri_based_with_two_holidays_in_one_year(self):
         """
@@ -155,23 +145,20 @@ class TestSaudiArabia(unittest.TestCase):
         (Fridays, Saturdays).
         Currently, using newest weekend days (Fridays, and Saturdays)
         """
-        if sys.version_info >= (3, 6):
-            import importlib.util
-
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.SA(years=[2006])
-                # eid_alfitr
-                # 23rd is a weekend day (Saturday), so there
-                # is a one day shift
-                self.assertIn(date(2006, 10, 23), self.holidays)
-                self.assertIn(date(2006, 10, 24), self.holidays)
-                self.assertIn(date(2006, 10, 25), self.holidays)
-                self.assertIn(date(2006, 10, 26), self.holidays)
-                # eid al-adha 1 (hijri year 1426)
-                self.assertIn(date(2006, 1, 9), self.holidays)
-                self.assertIn(date(2006, 1, 10), self.holidays)
-                self.assertIn(date(2006, 1, 11), self.holidays)
-                self.assertIn(date(2006, 1, 12), self.holidays)
-                # eid al-adha 2 (hijri year 1427)
-                # The remaining holidays fall in the next year 2007
-                self.assertIn(date(2006, 12, 31), self.holidays)
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.SA(years=[2006])
+            # eid_alfitr
+            # 23rd is a weekend day (Saturday), so there
+            # is a one day shift
+            self.assertIn(date(2006, 10, 23), self.holidays)
+            self.assertIn(date(2006, 10, 24), self.holidays)
+            self.assertIn(date(2006, 10, 25), self.holidays)
+            self.assertIn(date(2006, 10, 26), self.holidays)
+            # eid al-adha 1 (hijri year 1426)
+            self.assertIn(date(2006, 1, 9), self.holidays)
+            self.assertIn(date(2006, 1, 10), self.holidays)
+            self.assertIn(date(2006, 1, 11), self.holidays)
+            self.assertIn(date(2006, 1, 12), self.holidays)
+            # eid al-adha 2 (hijri year 1427)
+            # The remaining holidays fall in the next year 2007
+            self.assertIn(date(2006, 12, 31), self.holidays)

--- a/test/countries/test_serbia.py
+++ b/test/countries/test_serbia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_singapore.py
+++ b/test/countries/test_singapore.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import sys
+import importlib.util
 import unittest
 
 from datetime import date
@@ -112,19 +112,12 @@ class TestSingapore(unittest.TestCase):
         self.assertIn(date(2023, 6, 2), self.holidays)  # Vesak Day
         self.assertIn(date(2023, 11, 11), self.holidays)  # Deepavali
         # holidays estimated using library hijri-converter
-        if sys.version_info >= (3, 6):
-            import importlib.util
-
-            if importlib.util.find_spec("hijri_converter"):
-                # <= 1968 holidays
-                self.assertIn(date(1968, 1, 2), self.holidays)
-                # 2021
-                self.assertIn(
-                    date(2023, 4, 21), self.holidays
-                )  # Hari Raya Puasa
-                self.assertIn(
-                    date(2023, 6, 28), self.holidays
-                )  # Hari Raya Haji
+        if importlib.util.find_spec("hijri_converter"):
+            # <= 1968 holidays
+            self.assertIn(date(1968, 1, 2), self.holidays)
+            # 2021
+            self.assertIn(date(2023, 4, 21), self.holidays)  # Hari Raya Puasa
+            self.assertIn(date(2023, 6, 28), self.holidays)  # Hari Raya Haji
 
     def test_aliases(self):
         """For coverage purposes"""

--- a/test/countries/test_singapore.py
+++ b/test/countries/test_singapore.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_slovakia.py
+++ b/test/countries/test_slovakia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_slovenia.py
+++ b/test/countries/test_slovenia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_south_africa.py
+++ b/test/countries/test_south_africa.py
@@ -60,12 +60,12 @@ class TestSouthAfrica(unittest.TestCase):
         self.assertNotIn("1976-09-01", self.holidays)
 
     def test_elections(self):
-        self.assertTrue("1999-06-02" in self.holidays)  # Election Day 1999
-        self.assertTrue("2004-04-14" in self.holidays)  # Election Day 2004
-        self.assertTrue("2006-03-01" in self.holidays)  # Local Election
-        self.assertTrue("2009-04-22" in self.holidays)  # Election Day 2008
-        self.assertTrue("2011-05-18" in self.holidays)  # Election Day 2011
-        self.assertTrue("2014-05-07" in self.holidays)  # Election Day 2014
-        self.assertTrue("2016-08-03" in self.holidays)  # Election Day 2016
-        self.assertTrue("2019-05-08" in self.holidays)  # Election Day 2019
-        self.assertTrue("2021-11-01" in self.holidays)  # Election Day 2019
+        self.assertIn("1999-06-02", self.holidays)  # Election Day 1999
+        self.assertIn("2004-04-14", self.holidays)  # Election Day 2004
+        self.assertIn("2006-03-01", self.holidays)  # Local Election
+        self.assertIn("2009-04-22", self.holidays)  # Election Day 2008
+        self.assertIn("2011-05-18", self.holidays)  # Election Day 2011
+        self.assertIn("2014-05-07", self.holidays)  # Election Day 2014
+        self.assertIn("2016-08-03", self.holidays)  # Election Day 2016
+        self.assertIn("2019-05-08", self.holidays)  # Election Day 2019
+        self.assertIn("2021-11-01", self.holidays)  # Election Day 2019

--- a/test/countries/test_south_africa.py
+++ b/test/countries/test_south_africa.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_spain.py
+++ b/test/countries/test_spain.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_swaziland.py
+++ b/test/countries/test_swaziland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_sweden.py
+++ b/test/countries/test_sweden.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_switzerland.py
+++ b/test/countries/test_switzerland.py
@@ -60,9 +60,9 @@ class TestSwitzerland(unittest.TestCase):
         ]
 
         for holiday in all_ch:
-            self.assertTrue(holiday in all_ch, f"missing: {holiday}")
+            self.assertIn(holiday, all_ch, f"missing: {holiday}")
         for holiday in in_2018:
-            self.assertTrue(holiday in in_2018, f"extra: {holiday}")
+            self.assertIn(holiday, in_2018, f"extra: {holiday}")
 
     def test_fixed_holidays(self):
         fixed_days_whole_country = (
@@ -71,7 +71,7 @@ class TestSwitzerland(unittest.TestCase):
             (12, 25),  # Weihnachten
         )
         for y, (m, d) in product(range(1291, 2050), fixed_days_whole_country):
-            self.assertTrue(date(y, m, d) in self.holidays)
+            self.assertIn(date(y, m, d), self.holidays)
 
     def test_berchtoldstag(self):
         provinces_that_have = {
@@ -96,9 +96,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 1, 2) in self.prov_hols[province])
+            self.assertIn(date(year, 1, 2), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 1, 2) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 1, 2), self.prov_hols[province])
 
     def test_heilige_drei_koenige(self):
         provinces_that_have = {"SZ", "TI", "UR"}
@@ -107,9 +107,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 1, 6) in self.prov_hols[province])
+            self.assertIn(date(year, 1, 6), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 1, 6) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 1, 6), self.prov_hols[province])
 
     def test_jahrestag_der_ausrufung_der_republik(self):
         provinces_that_have = {"NE"}
@@ -118,9 +118,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 3, 1) in self.prov_hols[province])
+            self.assertIn(date(year, 3, 1), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 3, 1) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 3, 1), self.prov_hols[province])
 
     def test_josefstag(self):
         provinces_that_have = {"NW", "SZ", "TI", "UR", "VS"}
@@ -129,9 +129,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 3, 19) in self.prov_hols[province])
+            self.assertIn(date(year, 3, 19), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 3, 19) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 3, 19), self.prov_hols[province])
 
     def test_naefelser_fahrt(self):
         known_good = [
@@ -160,9 +160,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, (y, m, d) in product(provinces_that_have, known_good):
-            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+            self.assertIn(date(y, m, d), self.prov_hols[province])
         for province, (y, m, d) in product(provinces_that_dont, known_good):
-            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
+            self.assertNotIn(date(y, m, d), self.prov_hols[province])
 
     def test_karfreitag(self):
         known_good = [
@@ -190,9 +190,9 @@ class TestSwitzerland(unittest.TestCase):
             set(holidays.CH.subdivisions) - provinces_that_dont
         )
         for province, (y, m, d) in product(provinces_that_have, known_good):
-            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+            self.assertIn(date(y, m, d), self.prov_hols[province])
         for province, (y, m, d) in product(provinces_that_dont, known_good):
-            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
+            self.assertNotIn(date(y, m, d), self.prov_hols[province])
 
     def test_ostern(self):
         known_good = [
@@ -219,7 +219,7 @@ class TestSwitzerland(unittest.TestCase):
         for province, (y, m, d) in product(
             holidays.CH.subdivisions, known_good
         ):
-            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+            self.assertIn(date(y, m, d), self.prov_hols[province])
 
     def test_ostermontag(self):
         known_good = [
@@ -247,9 +247,9 @@ class TestSwitzerland(unittest.TestCase):
             set(holidays.CH.subdivisions) - provinces_that_dont
         )
         for province, (y, m, d) in product(provinces_that_have, known_good):
-            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+            self.assertIn(date(y, m, d), self.prov_hols[province])
         for province, (y, m, d) in product(provinces_that_dont, known_good):
-            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
+            self.assertNotIn(date(y, m, d), self.prov_hols[province])
 
     def test_auffahrt(self):
         known_good = [
@@ -276,7 +276,7 @@ class TestSwitzerland(unittest.TestCase):
         for province, (y, m, d) in product(
             holidays.CH.subdivisions, known_good
         ):
-            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+            self.assertIn(date(y, m, d), self.prov_hols[province])
 
     def test_pfingsten(self):
         known_good = [
@@ -303,7 +303,7 @@ class TestSwitzerland(unittest.TestCase):
         for province, (y, m, d) in product(
             holidays.CH.subdivisions, known_good
         ):
-            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+            self.assertIn(date(y, m, d), self.prov_hols[province])
 
     def test_pfingstmontag(self):
         known_good = [
@@ -330,7 +330,7 @@ class TestSwitzerland(unittest.TestCase):
         for province, (y, m, d) in product(
             holidays.CH.subdivisions, known_good
         ):
-            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+            self.assertIn(date(y, m, d), self.prov_hols[province])
 
     def test_fronleichnam(self):
         known_good = [
@@ -363,9 +363,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, (y, m, d) in product(provinces_that_have, known_good):
-            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+            self.assertIn(date(y, m, d), self.prov_hols[province])
         for province, (y, m, d) in product(provinces_that_dont, known_good):
-            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
+            self.assertNotIn(date(y, m, d), self.prov_hols[province])
 
     def test_fest_der_unabhaengikeit(self):
         provinces_that_have = {"JU"}
@@ -374,12 +374,12 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 6, 23) in self.prov_hols[province])
+            self.assertIn(date(year, 6, 23), self.prov_hols[province])
         # 2011 is "Fronleichnam" on the same date, we don't test this year
         for province, year in product(provinces_that_dont, range(1970, 2010)):
-            self.assertTrue(date(year, 6, 23) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 6, 23), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(2012, 2050)):
-            self.assertTrue(date(year, 6, 23) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 6, 23), self.prov_hols[province])
 
     def test_peter_und_paul(self):
         provinces_that_have = {"TI"}
@@ -388,9 +388,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 6, 29) in self.prov_hols[province])
+            self.assertIn(date(year, 6, 29), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 6, 29) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 6, 29), self.prov_hols[province])
 
     def test_mariae_himmelfahrt(self):
         provinces_that_have = {
@@ -410,9 +410,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 8, 15) in self.prov_hols[province])
+            self.assertIn(date(year, 8, 15), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 8, 15) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 8, 15), self.prov_hols[province])
 
     def test_lundi_du_jeune(self):
         known_good = [
@@ -434,9 +434,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, (y, m, d) in product(provinces_that_have, known_good):
-            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+            self.assertIn(date(y, m, d), self.prov_hols[province])
         for province, (y, m, d) in product(provinces_that_dont, known_good):
-            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
+            self.assertNotIn(date(y, m, d), self.prov_hols[province])
 
     def test_bruder_chlaus(self):
         provinces_that_have = {"OW"}
@@ -445,9 +445,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 9, 25) in self.prov_hols[province])
+            self.assertIn(date(year, 9, 25), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 9, 25) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 9, 25), self.prov_hols[province])
 
     def test_allerheiligen(self):
         provinces_that_have = {
@@ -469,9 +469,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 11, 1) in self.prov_hols[province])
+            self.assertIn(date(year, 11, 1), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 11, 1) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 11, 1), self.prov_hols[province])
 
     def test_jeune_genevois(self):
         known_good = [
@@ -494,9 +494,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, (y, m, d) in product(provinces_that_have, known_good):
-            self.assertTrue(date(y, m, d) in self.prov_hols[province])
+            self.assertIn(date(y, m, d), self.prov_hols[province])
         for province, (y, m, d) in product(provinces_that_dont, known_good):
-            self.assertTrue(date(y, m, d) not in self.prov_hols[province])
+            self.assertNotIn(date(y, m, d), self.prov_hols[province])
 
     def test_stephanstag(self):
         provinces_that_have = {
@@ -528,9 +528,9 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 12, 26) in self.prov_hols[province])
+            self.assertIn(date(year, 12, 26), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 12, 26) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 12, 26), self.prov_hols[province])
 
     def test_wiedererstellung_der_republik(self):
         provinces_that_have = {"GE"}
@@ -539,6 +539,6 @@ class TestSwitzerland(unittest.TestCase):
         )
 
         for province, year in product(provinces_that_have, range(1970, 2050)):
-            self.assertTrue(date(year, 12, 31) in self.prov_hols[province])
+            self.assertIn(date(year, 12, 31), self.prov_hols[province])
         for province, year in product(provinces_that_dont, range(1970, 2050)):
-            self.assertTrue(date(year, 12, 31) not in self.prov_hols[province])
+            self.assertNotIn(date(year, 12, 31), self.prov_hols[province])

--- a/test/countries/test_switzerland.py
+++ b/test/countries/test_switzerland.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_switzerland.py
+++ b/test/countries/test_switzerland.py
@@ -20,10 +20,9 @@ import holidays
 class TestSwitzerland(unittest.TestCase):
     def setUp(self):
         self.holidays = holidays.CH()
-        self.prov_hols = dict(
-            (prov, holidays.CH(subdiv=prov))
-            for prov in holidays.CH.subdivisions
-        )
+        self.prov_hols = {
+            prov: holidays.CH(subdiv=prov) for prov in holidays.CH.subdivisions
+        }
 
     def test_all_holidays_present(self):
         ch_2018 = sum(
@@ -61,9 +60,9 @@ class TestSwitzerland(unittest.TestCase):
         ]
 
         for holiday in all_ch:
-            self.assertTrue(holiday in all_ch, "missing: {}".format(holiday))
+            self.assertTrue(holiday in all_ch, f"missing: {holiday}")
         for holiday in in_2018:
-            self.assertTrue(holiday in in_2018, "extra: {}".format(holiday))
+            self.assertTrue(holiday in in_2018, f"extra: {holiday}")
 
     def test_fixed_holidays(self):
         fixed_days_whole_country = (

--- a/test/countries/test_taiwan.py
+++ b/test/countries/test_taiwan.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_tunisia.py
+++ b/test/countries/test_tunisia.py
@@ -12,7 +12,7 @@
 import unittest
 from datetime import date
 import holidays
-import sys
+import importlib.util
 
 
 class TestTunisia(unittest.TestCase):
@@ -34,20 +34,17 @@ class TestTunisia(unittest.TestCase):
             self.assertIn(TN_hol, self.holidays)
 
     def test_hijri_based(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.TN(years=[2015])
 
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.TN(years=[2015])
+            # eid_alfitr
+            self.assertIn(date(2015, 7, 17), self.holidays)
+            # eid_aladha
+            self.assertIn(date(2015, 9, 24), self.holidays)
+            # islamic_new_year
+            self.assertIn(date(2015, 10, 14), self.holidays)
 
-                # eid_alfitr
-                self.assertIn(date(2015, 7, 17), self.holidays)
-                # eid_aladha
-                self.assertIn(date(2015, 9, 24), self.holidays)
-                # islamic_new_year
-                self.assertIn(date(2015, 10, 14), self.holidays)
-
-                # eid_elfetr_2019
-                self.assertIn(date(2019, 6, 6), self.holidays)
-                # arafat_2019
-                self.assertIn(date(2019, 8, 11), self.holidays)
+            # eid_elfetr_2019
+            self.assertIn(date(2019, 6, 6), self.holidays)
+            # arafat_2019
+            self.assertIn(date(2019, 8, 11), self.holidays)

--- a/test/countries/test_tunisia.py
+++ b/test/countries/test_tunisia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_turkey.py
+++ b/test/countries/test_turkey.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import sys
+import importlib.util
 import unittest
 
 from datetime import date
@@ -31,17 +31,14 @@ class TestTurkey(unittest.TestCase):
         self.assertIn(date(2019, 10, 29), self.holidays)
 
     def test_hijri_based(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
-
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.TR(years=[2020])
-                # Ramadan Feast
-                self.assertIn(date(2020, 5, 24), self.holidays)
-                self.assertIn(date(2020, 5, 25), self.holidays)
-                self.assertIn(date(2020, 5, 26), self.holidays)
-                # Sacrifice Feast
-                self.assertIn(date(2020, 7, 31), self.holidays)
-                self.assertIn(date(2020, 8, 1), self.holidays)
-                self.assertIn(date(2020, 8, 2), self.holidays)
-                self.assertIn(date(2020, 8, 3), self.holidays)
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.TR(years=[2020])
+            # Ramadan Feast
+            self.assertIn(date(2020, 5, 24), self.holidays)
+            self.assertIn(date(2020, 5, 25), self.holidays)
+            self.assertIn(date(2020, 5, 26), self.holidays)
+            # Sacrifice Feast
+            self.assertIn(date(2020, 7, 31), self.holidays)
+            self.assertIn(date(2020, 8, 1), self.holidays)
+            self.assertIn(date(2020, 8, 2), self.holidays)
+            self.assertIn(date(2020, 8, 3), self.holidays)

--- a/test/countries/test_turkey.py
+++ b/test/countries/test_turkey.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_ukraine.py
+++ b/test/countries/test_ukraine.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_united_arab_emirates.py
+++ b/test/countries/test_united_arab_emirates.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import sys
+import importlib.util
 import unittest
 
 from datetime import date
@@ -33,23 +33,20 @@ class UnitedArabEmirates(unittest.TestCase):
         self.assertIn(date(2015, 11, 30), self.holidays)
 
     def test_hijri_based(self):
-        if sys.version_info >= (3, 6):
-            import importlib.util
-
-            if importlib.util.find_spec("hijri_converter"):
-                self.holidays = holidays.AE(years=[2020])
-                # Eid Al-Fitr
-                self.assertIn(date(2020, 5, 24), self.holidays)
-                self.assertIn(date(2020, 5, 25), self.holidays)
-                self.assertIn(date(2020, 5, 26), self.holidays)
-                # Arafat Day & Eid Al-Adha
-                self.assertIn(date(2020, 7, 30), self.holidays)
-                self.assertIn(date(2020, 7, 31), self.holidays)
-                self.assertIn(date(2020, 8, 1), self.holidays)
-                self.assertIn(date(2020, 8, 2), self.holidays)
-                # Islamic New Year
-                self.assertIn(date(2020, 8, 23), self.holidays)
-                # Leilat Al-Miraj 2018
-                self.assertIn(date(2018, 4, 13), self.holidays)
-                # Prophet's Birthday 2018
-                self.assertIn(date(2018, 11, 19), self.holidays)
+        if importlib.util.find_spec("hijri_converter"):
+            self.holidays = holidays.AE(years=[2020])
+            # Eid Al-Fitr
+            self.assertIn(date(2020, 5, 24), self.holidays)
+            self.assertIn(date(2020, 5, 25), self.holidays)
+            self.assertIn(date(2020, 5, 26), self.holidays)
+            # Arafat Day & Eid Al-Adha
+            self.assertIn(date(2020, 7, 30), self.holidays)
+            self.assertIn(date(2020, 7, 31), self.holidays)
+            self.assertIn(date(2020, 8, 1), self.holidays)
+            self.assertIn(date(2020, 8, 2), self.holidays)
+            # Islamic New Year
+            self.assertIn(date(2020, 8, 23), self.holidays)
+            # Leilat Al-Miraj 2018
+            self.assertIn(date(2018, 4, 13), self.holidays)
+            # Prophet's Birthday 2018
+            self.assertIn(date(2018, 11, 19), self.holidays)

--- a/test/countries/test_united_arab_emirates.py
+++ b/test/countries/test_united_arab_emirates.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_united_kingdom.py
+++ b/test/countries/test_united_kingdom.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_united_states.py
+++ b/test/countries/test_united_states.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_uruguay.py
+++ b/test/countries/test_uruguay.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_uzbekistan.py
+++ b/test/countries/test_uzbekistan.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_venezuela.py
+++ b/test/countries/test_venezuela.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_vietnam.py
+++ b/test/countries/test_vietnam.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_zambia.py
+++ b/test/countries/test_zambia.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/countries/test_zimbabwe.py
+++ b/test/countries/test_zimbabwe.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/test/test_holiday_base.py
+++ b/test/test_holiday_base.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 #  python-holidays
 #  ---------------
 #  A fast, efficient Python library for generating country, province and state

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion = 3.24.5
 skip_missing_interpreters = true
-envlist = py{36,37,38,39,310,py3}, pre-commit, docs
+envlist = py{37,38,39,310,py3}, pre-commit, docs
 
 [pytest]
 addopts = --cov=./ --cov-report term --cov-report xml --cov-config=./pyproject.toml


### PR DESCRIPTION

Python 3.6 is EOL and no longer receiving security updates (or any updates) from the core Python team.

| cycle | latest |  release   |    eol     |
|:------|:-------|:----------:|:----------:|
| 3.10  | 3.10.1 | 2021-10-04 | 2026-10-04 |
| 3.9   | 3.9.9  | 2020-10-05 | 2025-10-05 |
| 3.8   | 3.8.12 | 2019-10-14 | 2024-10-14 |
| 3.7   | 3.7.12 | 2018-06-27 | 2023-06-27 |
| 3.6   | 3.6.15 | 2016-12-23 | 2021-12-23 |

https://endoflife.date/python

Also:

* Upgrade Python syntax with https://github.com/asottile/pyupgrade/issues/587 using `--py37-plus`
* Upgrade tests using https://github.com/isidentical/teyit
* Remove encoding pragma, not needed for Python 3
* Test Python 3.10
* Cache pip on the CI: for example reduces PyPy/Windows installation step from 3 to 1.5 mins, PyPy/Mac from 2 to 1 min
* Drop the dot in `py.test` https://twitter.com/pytestdotorg/status/753767547866972160
* Add colour to CI logs
