### PR TITLE
AU-VIC Set Grand Final Day for 2022 (2022-09-23)

### DIFF
--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -210,6 +210,8 @@ class Australia(HolidayBase):
         if self.subdiv == "VIC":
             # Grand Final Day
             if year == 2022:
+                # Current planned grand final date.
+                # Could change at the dicression of the AFL
                 self[date(2022, 9, 23)] = "Grand Final Day"
             elif year == 2020:
                 # Rescheduled due to COVID-19

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -209,7 +209,9 @@ class Australia(HolidayBase):
 
         if self.subdiv == "VIC":
             # Grand Final Day
-            if year == 2020:
+            if year == 2022:
+                self[date(2022, 9, 23)] = "Grand Final Day"
+            elif year == 2020:
                 # Rescheduled due to COVID-19
                 self[date(year, OCT, 23)] = "Grand Final Day"
             elif year == 2021:

--- a/test/countries/test_australia.py
+++ b/test/countries/test_australia.py
@@ -278,6 +278,7 @@ class TestAU(unittest.TestCase):
         dt_2020 = date(2020, 10, 23)
         dt_2020_old = date(2020, 9, 25)
         dt_2021 = date(2021, 9, 24)
+        dt_2022 = date(2022, 9, 23)
         self.assertIn(dt, self.state_hols["VIC"], dt)
         self.assertEqual(self.state_hols["VIC"][dt], "Grand Final Day")
         self.assertIn(dt_2020, self.state_hols["VIC"], dt_2020)
@@ -285,9 +286,17 @@ class TestAU(unittest.TestCase):
         self.assertNotIn(dt_2020_old, self.state_hols["VIC"], dt_2020_old)
         self.assertIn(dt_2021, self.state_hols["VIC"], dt_2021)
         self.assertEqual(self.state_hols["VIC"][dt_2021], "Grand Final Day")
+        self.assertIn(dt_2022, self.state_hols["VIC"])
+        self.assertEqual(self.state_hols["VIC"][dt_2022], "Grand Final Day")
 
     def test_melbourne_cup(self):
-        for dt in [date(2014, 11, 4), date(2015, 11, 3), date(2016, 11, 1)]:
+        fixtures = [
+            date(2014, 11, 4),
+            date(2015, 11, 3),
+            date(2016, 11, 1),
+            date(2022, 11, 1),
+        ]
+        for dt in fixtures:
             self.assertIn(dt, self.state_hols["VIC"], dt)
             self.assertEqual(self.state_hols["VIC"][dt], "Melbourne Cup")
 


### PR DESCRIPTION
G'day,
Would it be possible to merge this branch into the master / main branch. This branch contains a commit that sets the date of Grand Final Day for the year 2022 in Vic to the 23rd of September. Unlike regular public holidays Grand Final Day changes with the corporate needs of the AFL. Please feel free to provide any critiques or changes that will need to be made. 
Jeremy 🙂 