### PR TITLE
Fix Spain 'observed' date

### DIFF
--- a/holidays/countries/spain.py
+++ b/holidays/countries/spain.py
@@ -149,9 +149,6 @@ class Spain(HolidayBase):
             "MC",
             "AR",
         ]:
-            # self._is_observed(
-            #     date(year, MAY, 2), "Día del Trabajador (Trasladado)"
-            # )
             self._is_observed(date(year, MAY, 1), "Día del Trabajador")
         if self.subdiv in ["CT", "GA", "VC"]:
             self._is_observed(date(year, JUN, 24), "San Juan")

--- a/holidays/countries/spain.py
+++ b/holidays/countries/spain.py
@@ -149,9 +149,10 @@ class Spain(HolidayBase):
             "MC",
             "AR",
         ]:
-            self._is_observed(
-                date(year, MAY, 2), "Día del Trabajador (Trasladado)"
-            )
+            # self._is_observed(
+            #     date(year, MAY, 2), "Día del Trabajador (Trasladado)"
+            # )
+            self._is_observed(date(year, MAY, 1), "Día del Trabajador")
         if self.subdiv in ["CT", "GA", "VC"]:
             self._is_observed(date(year, JUN, 24), "San Juan")
         self._is_observed(date(year, AUG, 15), "Asunción de la Virgen")

--- a/test/countries/test_spain.py
+++ b/test/countries/test_spain.py
@@ -257,8 +257,13 @@ class TestSpain(unittest.TestCase):
             ],
         }
 
+        observed_prov_holidays = {
+            prov: holidays.ES(observed=True, subdiv=prov)
+            for prov in holidays.ES.subdivisions
+        }
+
         for fest_date, fest_provs in province_days.items():
-            for prov, prov_holidays in self.prov_holidays.items():
+            for prov, prov_holidays in observed_prov_holidays.items():
                 self.assertEqual(
                     date(2022, *fest_date) in prov_holidays,
                     prov in fest_provs,


### PR DESCRIPTION
The `_is_observed` funtion takes care about observed dates, so no need to add them as 'observed' dates.
The tests have also been fixed so that they run correctly. In this case, the validations have to be done on the `observed` dates.