### PR TITLE
Add founding day holiday to Saudi Arabia holidays

### DIFF
--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -113,7 +113,7 @@ class SaudiArabia(HolidayBase):
 
         # National Day holiday (started at the year 2005).
         # Note: if national day happens within the Eid al-Fitr Holiday or
-        # within Eid al-Fitr Holiday, then it is not holiday.
+        # within Eid al-Fitr Holiday, there is no extra holidays given for it.
         holiday_name = "National Day Holiday"
         if year >= 2005:
             national_day = date(year, SEP, 23)
@@ -130,7 +130,7 @@ class SaudiArabia(HolidayBase):
 
         # Founding Day holiday (started 2022).
         # Note: if founding day happens within the Eid al-Fitr Holiday or
-        # within Eid al-Fitr Holiday, then it is not holiday.
+        # within Eid al-Fitr Holiday, there is no extra holidays given for it.
         holiday_name = "Founding Day Holiday"
         if year >= 2022:
             founding_day = date(year, FEB, 22)

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -14,8 +14,8 @@
 from datetime import date
 
 from dateutil.relativedelta import relativedelta as rd
-from holidays.constants import THU, FRI, SAT, SUN
-from holidays.constants import SEP
+from holidays.constants import THU, FRI, SAT
+from holidays.constants import SEP, FEB
 from holidays.holiday_base import HolidayBase
 from holidays.utils import _islamic_to_gre
 
@@ -23,12 +23,14 @@ from holidays.utils import _islamic_to_gre
 class SaudiArabia(HolidayBase):
 
     """
-    There are only 3 official national holidays in Saudi:
+    There are only 4 official national holidays in Saudi:
     https://laboreducation.hrsd.gov.sa/en/gallery/274
     https://laboreducation.hrsd.gov.sa/en/labor-education/322
-    The national day holiday is based on the Georgian calendar while the
-    other two holidays are based on the Islamic Calendar, and they are
-    estimates as they announced each year and based on moon sightings;
+    https://english.alarabiya.net/News/gulf/2022/01/27/Saudi-Arabia-to-commemorate-Founding-Day-on-Feb-22-annually-Royal-order
+    The national day and the founding day holidays are based on the
+    Georgian calendar while the other two holidays are based on the
+    Islamic Calendar, and they are estimates as they announced each
+    year and based on moon sightings;
     they are:
         - Eid al-Fitr*
         - Eid al-Adha*
@@ -45,15 +47,11 @@ class SaudiArabia(HolidayBase):
     def _populate(self, year):
         if year < 2013:
             # Weekend used to be THU, FRI before June 28th, 2013
-            # On that year both Eids were after that date so what below works:
+            # On that year both Eids were after that date, and foudning
+            # day holiday started at 2022; so what below works,
             WEEKEND = (THU, FRI)
-        elif year < 2022:
-            WEEKEND = (FRI, SAT)
         else:
-            # from 2022 on, UAE aligns his weekend days with Europe,
-            # setting weekend on Sat and Sun.
-            # https://text.npr.org/1062435944
-            WEEKEND = (SAT, SUN)
+            WEEKEND = (FRI, SAT)
 
         observed_str = " (observed)"
 
@@ -121,13 +119,31 @@ class SaudiArabia(HolidayBase):
             national_day = date(year, SEP, 23)
             if national_day not in self:
                 self[national_day] = holiday_name
-
-                if self.observed and national_day.weekday() == FRI:
+                # First weekend day(Thursaday before 2013 and Friday otherwise)
+                if self.observed and national_day.weekday() == WEEKEND[0]:
                     national_day -= rd(days=1)
                     self[national_day] = holiday_name + observed_str
-                elif self.observed and national_day.weekday() == SAT:
+                # Second weekend day(Friday before 2013 and Saturday otherwise)
+                elif self.observed and national_day.weekday() == WEEKEND[1]:
                     national_day += rd(days=1)
                     self[national_day] = holiday_name + observed_str
+
+        # Founding Day holiday (started 2022).
+        # Note: if founding day happens within the Eid al-Fitr Holiday or
+        # within Eid al-Fitr Holiday, then it is not holiday.
+        holiday_name = "Founding Day Holiday"
+        if year >= 2022:
+            founding_day = date(year, FEB, 22)
+            if founding_day not in self:
+                self[founding_day] = holiday_name
+                # First weekend day(Thursaday before 2013 and Friday otherwise)
+                if self.observed and founding_day.weekday() == WEEKEND[0]:
+                    founding_day -= rd(days=1)
+                    self[founding_day] = holiday_name + observed_str
+                # Second weekend day(Friday before 2013 and Saturday otherwise)
+                elif self.observed and founding_day.weekday() == WEEKEND[1]:
+                    founding_day += rd(days=1)
+                    self[founding_day] = holiday_name + observed_str
 
 
 class SA(SaudiArabia):

--- a/test/countries/test_saudi_arabia.py
+++ b/test/countries/test_saudi_arabia.py
@@ -38,6 +38,26 @@ class TestSaudiArabia(unittest.TestCase):
         # National day holiday
         self.assertIn(date(2021, 9, 23), self.holidays)
 
+    def test_weekends(self):
+        # Weekend changed from (Thursday, Friday) to
+        # (Friday, Saturday) at 2013
+        # September 23rd, 2010 was Thursday (Weekend)
+        # so, observed is Wednesday
+        self.assertIn(date(2010, 9, 22), self.holidays)
+        self.assertIn(date(2010, 9, 23), self.holidays)
+        self.assertNotIn(date(2010, 9, 24), self.holidays)
+
+        # September 23rd, 2006 was Friday (Weekend)
+        # so, observed is Saturday
+        self.assertNotIn(date(2005, 9, 22), self.holidays)
+        self.assertIn(date(2005, 9, 23), self.holidays)
+        self.assertIn(date(2005, 9, 24), self.holidays)
+
+        # September 23rd, 2006 was Saturday (Weekday before 2013)
+        self.assertNotIn(date(2006, 9, 22), self.holidays)
+        self.assertIn(date(2006, 9, 23), self.holidays)
+        self.assertNotIn(date(2006, 9, 24), self.holidays)
+
     def test_national_day(self):
         self.assertIn(date(2020, 9, 23), self.holidays)
         # National day started as a holiday on 2005
@@ -61,6 +81,31 @@ class TestSaudiArabia(unittest.TestCase):
         self.holidays.observed = False
         self.assertNotIn(date(2016, 9, 22), self.holidays)
         self.assertNotIn(date(2017, 9, 24), self.holidays)
+
+    def test_founding_day(self):
+        self.assertIn(date(2022, 2, 22), self.holidays)
+        self.assertIn(date(2030, 2, 22), self.holidays)
+        # founding day started as a holiday on 2022
+        self.assertNotIn(date(2021, 2, 22), self.holidays)
+        self.assertNotIn(date(2005, 2, 22), self.holidays)
+
+    def test_founding_day_observed(self):
+        # February 22nd, 2030 is Friday (Weekend)
+        # so, observed is Thursday
+        self.assertIn(date(2030, 2, 21), self.holidays)
+        self.assertIn(date(2030, 2, 22), self.holidays)
+        self.assertNotIn(date(2016, 2, 23), self.holidays)
+
+        # February 22nd, 2031 is Saturday (Weekend)
+        # so, observed is Sunday
+        self.assertNotIn(date(2031, 2, 21), self.holidays)
+        self.assertIn(date(2031, 2, 22), self.holidays)
+        self.assertIn(date(2031, 2, 23), self.holidays)
+
+    def test_founding_day_not_observed(self):
+        self.holidays.observed = False
+        self.assertNotIn(date(2030, 2, 21), self.holidays)
+        self.assertNotIn(date(2031, 2, 23), self.holidays)
 
     def test_hijri_based(self):
         if sys.version_info >= (3, 6):

--- a/test/countries/test_saudi_arabia.py
+++ b/test/countries/test_saudi_arabia.py
@@ -82,6 +82,11 @@ class TestSaudiArabia(unittest.TestCase):
         self.assertNotIn(date(2016, 9, 22), self.holidays)
         self.assertNotIn(date(2017, 9, 24), self.holidays)
 
+    def test_national_day_overlaps_hijri_holiday(self):
+        # Eid al-Fitr Holiday is on the same day as the
+        # national day, so there is no extra holidays given for it.
+        self.assertIn(date(2074, 2, 22), self.holidays)
+
     def test_founding_day(self):
         self.assertIn(date(2022, 2, 22), self.holidays)
         self.assertIn(date(2030, 2, 22), self.holidays)
@@ -106,6 +111,11 @@ class TestSaudiArabia(unittest.TestCase):
         self.holidays.observed = False
         self.assertNotIn(date(2030, 2, 21), self.holidays)
         self.assertNotIn(date(2031, 2, 23), self.holidays)
+
+    def test_founding_day_overlaps_hijri_holiday(self):
+        # Eid al-Fitr Holiday is on the same day as the
+        # founding day, so there is no extra holidays given for it.
+        self.assertIn(date(2061, 2, 22), self.holidays)
 
     def test_hijri_based(self):
         if sys.version_info >= (3, 6):


### PR DESCRIPTION
- Add new [founding day](https://english.alarabiya.net/News/gulf/2022/01/27/Saudi-Arabia-to-commemorate-Founding-Day-on-Feb-22-annually-Royal-order) holiday to Saudi Arabia module
- Add tests for new "founding day" holiday
- Add tests for weekend shifts that happened at 2013 (from Thrusday, Friday weekend to Friday, Saturday weekend)
- Fix weekend check for national holiday to include previous weekends (before 2013)
- Fix weekend code that mistakenly add UAE weekends into Saudi Arabia
- Add tests for edge cases when overlapping holidays between hijri and gregorian calendars