### PR TITLE
CI: If one job fails, let the others continue

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     needs: [pre-commit]
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: ["3.7", "3.8", "3.9", "3.10", "pypy-3.7"]


### PR DESCRIPTION
For example, if one jobs fails to upload to Coveralls, it won't cancel all the others. 

Should help situations like this:

<img width="1497" alt="image" src="https://user-images.githubusercontent.com/1324225/161373776-991370c0-1f1e-49e3-b9bd-571f42202e53.png">

https://github.com/dr-prodigy/python-holidays/actions/runs/2081388552