### PR TITLE
Fix spelling of Seward's Day in US/AK

### DIFF
--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -255,8 +255,8 @@ class UnitedStates(HolidayBase):
             elif self.observed and date(year, MAR, 26).weekday() == SUN:
                 self[date(year, MAR, 27)] = name + " (Observed)"
 
-        # Steward's Day
-        name = "Steward's Day"
+        # Seward's Day
+        name = "Seward's Day"
         if self.subdiv == "AK" and year >= 1955:
             self[date(year, APR, 1) + rd(days=-1, weekday=MO(-1))] = name
         elif self.subdiv == "AK" and year >= 1918:


### PR DESCRIPTION
Just a spelling correction.

https://en.wikipedia.org/wiki/Seward's_Day
https://doa.alaska.gov/dof/payroll/resource/calendar2022-holiday.pdf