### PR TITLE
SG 2023 final dates

### DIFF
--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -19,6 +19,7 @@ from holidays.constants import (
     JAN,
     FEB,
     MAR,
+    APR,
     MAY,
     JUN,
     JUL,
@@ -53,7 +54,7 @@ class Singapore(HolidayBase):
 
         - Prior to 1969: holidays are estimated.
         - Prior to 2000: holidays may not be accurate.
-        - 2022 and later: the following four moving date holidays (whose exact
+        - 2024 and later: the following four moving date holidays (whose exact
           date is announced yearly) are estimated, and so denoted:
 
           - Hari Raya Puasa
@@ -118,6 +119,7 @@ class Singapore(HolidayBase):
             2020: [(MAY, 24)],
             2021: [(MAY, 13)],
             2022: [(MAY, 2)],
+            2023: [(APR, 22)],
         }
         if year in dates_obs:
             for date_obs in dates_obs[year]:
@@ -166,6 +168,7 @@ class Singapore(HolidayBase):
             2020: [(JUL, 31)],
             2021: [(JUL, 20)],
             2022: [(JUL, 9)],
+            2023: [(JUN, 29)],
         }
         if year in dates_obs:
             for date_obs in dates_obs[year]:
@@ -216,6 +219,7 @@ class Singapore(HolidayBase):
             2020: (MAY, 7),
             2021: (MAY, 26),
             2022: (MAY, 15),
+            2023: (JUN, 3),
         }
         if year in dates_obs:
             hol_date = date(year, *dates_obs[year])
@@ -253,6 +257,7 @@ class Singapore(HolidayBase):
             2020: (NOV, 14),
             2021: (NOV, 4),
             2022: (NOV, 24),
+            2023: (NOV, 12),
         }
         if year in dates_obs:
             hol_date = date(year, *dates_obs[year])

--- a/test/countries/test_singapore.py
+++ b/test/countries/test_singapore.py
@@ -15,6 +15,7 @@ import unittest
 from datetime import date
 
 import holidays
+from holidays.constants import JAN, APR, MAY, JUN, AUG, NOV, DEC
 
 
 class TestSingapore(unittest.TestCase):
@@ -48,48 +49,6 @@ class TestSingapore(unittest.TestCase):
         self.assertIn(date(2018, 12, 25), self.holidays)
         # 2018: total holidays (11 + 0 falling on a Sunday)
         self.assertEqual(len(holidays.Singapore(years=[2018])), 11 + 0)
-        # 2019
-        self.assertIn(date(2019, 1, 1), self.holidays)
-        self.assertIn(date(2019, 2, 5), self.holidays)
-        self.assertIn(date(2019, 2, 6), self.holidays)
-        self.assertIn(date(2019, 4, 19), self.holidays)
-        self.assertIn(date(2019, 5, 1), self.holidays)
-        self.assertIn(date(2019, 5, 19), self.holidays)
-        self.assertIn(date(2019, 6, 5), self.holidays)
-        self.assertIn(date(2019, 8, 9), self.holidays)
-        self.assertIn(date(2019, 8, 11), self.holidays)
-        self.assertIn(date(2019, 10, 27), self.holidays)
-        self.assertIn(date(2019, 12, 25), self.holidays)
-        # 2019: total holidays (11 + 3 falling on a Sunday)
-        self.assertEqual(len(holidays.Singapore(years=[2019])), 11 + 3)
-        # 2020
-        self.assertIn(date(2020, 1, 1), self.holidays)
-        self.assertIn(date(2020, 1, 25), self.holidays)
-        self.assertIn(date(2020, 1, 26), self.holidays)
-        self.assertIn(date(2020, 4, 10), self.holidays)
-        self.assertIn(date(2020, 5, 1), self.holidays)
-        self.assertIn(date(2020, 5, 7), self.holidays)
-        self.assertIn(date(2020, 5, 24), self.holidays)
-        self.assertIn(date(2020, 7, 31), self.holidays)
-        self.assertIn(date(2020, 8, 9), self.holidays)
-        self.assertIn(date(2020, 11, 14), self.holidays)
-        self.assertIn(date(2020, 12, 25), self.holidays)
-        # 2020: total holidays (11 + 3 falling on a Sunday)
-        self.assertEqual(len(holidays.Singapore(years=[2020])), 11 + 4)
-        # 2021
-        self.assertIn(date(2021, 1, 1), self.holidays)
-        self.assertIn(date(2021, 2, 12), self.holidays)
-        self.assertIn(date(2021, 2, 13), self.holidays)
-        self.assertIn(date(2021, 4, 2), self.holidays)
-        self.assertIn(date(2021, 5, 1), self.holidays)
-        self.assertIn(date(2021, 5, 13), self.holidays)
-        self.assertIn(date(2021, 5, 26), self.holidays)
-        self.assertIn(date(2021, 7, 20), self.holidays)
-        self.assertIn(date(2021, 8, 9), self.holidays)
-        self.assertIn(date(2021, 11, 4), self.holidays)
-        self.assertIn(date(2021, 12, 25), self.holidays)
-        # 2021: total holidays (11)
-        self.assertEqual(len(holidays.Singapore(years=[2021])), 11)
         # 2022
         self.assertIn(date(2022, 1, 1), self.holidays)
         self.assertIn(date(2022, 2, 1), self.holidays)
@@ -107,17 +66,34 @@ class TestSingapore(unittest.TestCase):
         self.assertIn(date(2022, 12, 26), self.holidays)
         # 2022: total holidays (11 + 3 falling on a Sunday)
         self.assertEqual(len(holidays.Singapore(years=[2022])), 11 + 3)
+        # 2023
+        self.assertIn(date(2023, JAN, 1), self.holidays)
+        self.assertIn(date(2023, JAN, 2), self.holidays)
+        self.assertIn(date(2023, JAN, 22), self.holidays)
+        self.assertIn(date(2023, JAN, 23), self.holidays)
+        self.assertIn(date(2023, JAN, 24), self.holidays)
+        self.assertIn(date(2023, APR, 7), self.holidays)
+        self.assertIn(date(2023, APR, 22), self.holidays)
+        self.assertIn(date(2023, MAY, 1), self.holidays)
+        self.assertIn(date(2023, JUN, 3), self.holidays)
+        self.assertIn(date(2023, JUN, 29), self.holidays)
+        self.assertIn(date(2023, AUG, 9), self.holidays)
+        self.assertIn(date(2023, NOV, 12), self.holidays)
+        self.assertIn(date(2023, NOV, 13), self.holidays)
+        self.assertIn(date(2023, DEC, 25), self.holidays)
+        # 2023: total holidays (11 + 3 falling on a Sunday)
+        self.assertEqual(len(holidays.Singapore(years=[2023])), 11 + 3)
 
         # holidays estimated using lunar calendar
-        self.assertIn(date(2023, 6, 2), self.holidays)  # Vesak Day
-        self.assertIn(date(2023, 11, 11), self.holidays)  # Deepavali
+        self.assertIn(date(2050, 6, 4), self.holidays)  # Vesak Day
+        self.assertIn(date(2050, 11, 12), self.holidays)  # Deepavali
         # holidays estimated using library hijri-converter
         if importlib.util.find_spec("hijri_converter"):
             # <= 1968 holidays
             self.assertIn(date(1968, 1, 2), self.holidays)
             # 2021
-            self.assertIn(date(2023, 4, 21), self.holidays)  # Hari Raya Puasa
-            self.assertIn(date(2023, 6, 28), self.holidays)  # Hari Raya Haji
+            self.assertIn(date(2050, 6, 20), self.holidays)  # Hari Raya Puasa
+            self.assertIn(date(2050, 8, 28), self.holidays)  # Hari Raya Haji
 
     def test_aliases(self):
         """For coverage purposes"""


### PR DESCRIPTION
Added official movable holiday dates for 2023, which have been announced today, and updated testing: https://www.straitstimes.com/singapore/singapore-to-have-6-long-public-holiday-weekends-in-2023

Official source: https://www.mom.gov.sg/employment-practices/public-holidays