### PR TITLE
Adds the Queen of Englands Platinum Jubilee 2022

### DIFF
--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -153,6 +153,11 @@ class UnitedKingdom(HolidayBase):
         elif year >= 1971:
             self[date(year, MAY, 31) + rd(weekday=MO(-1))] = name
 
+        # Platinum Jubilee bank holiday (one off)
+        name = "Platinum Jubilee bank holiday"
+        if year == 2022:
+            self[date(year, JUN, 3)] = name
+
         # Late Summer bank holiday (last Monday in August)
         if self.subdiv != "Scotland" and year >= 1971:
             name = "Late Summer Bank Holiday"


### PR DESCRIPTION
Adds the Queen's Platinum Jubilee 2022.

Information source: https://www.gov.uk/bank-holidays

"In 2022, Her Majesty The Queen will become the first British Monarch to celebrate a Platinum Jubilee after 70 years of service." 
- https://platinumjubilee.gov.uk/