### PR TITLE
Add special cases for observing Labour Day in Greece

### DIFF
--- a/holidays/countries/greece.py
+++ b/holidays/countries/greece.py
@@ -12,9 +12,9 @@
 from datetime import date
 
 from dateutil.easter import easter, EASTER_ORTHODOX
-from dateutil.relativedelta import relativedelta as rd, WE
+from dateutil.relativedelta import relativedelta as rd, MO, TU
 
-from holidays.constants import JAN, MAR, MAY, AUG, OCT, DEC
+from holidays.constants import JAN, MAR, MAY, AUG, OCT, DEC, WEEKEND
 from holidays.holiday_base import HolidayBase
 
 
@@ -44,13 +44,24 @@ class Greece(HolidayBase):
         # Easter Monday
         self[eday + rd(days=1)] = "Δευτέρα του Πάσχα [Easter Monday]"
 
-        # Labour Day
-        self[date(year, MAY, 1)] = "Εργατική Πρωτομαγιά [Labour day]"
-
         # Monday of the Holy Spirit
         self[
             eday + rd(days=50)
         ] = "Δευτέρα του Αγίου Πνεύματος [Monday of the Holy Spirit]"
+
+        # Labour Day
+        name = "Εργατική Πρωτομαγιά [Labour day]"
+        name_observed = name + " (Observed)"
+
+        self[date(year, MAY, 1)] = name
+        if self.observed and date(year, MAY, 1).weekday() in WEEKEND:
+            # https://en.wikipedia.org/wiki/Public_holidays_in_Greece
+            labour_day_observed_date = date(year, MAY, 1) + rd(weekday=MO)
+            # In 2016 and 2021, Labour Day coincided with other holidays
+            # https://www.timeanddate.com/holidays/greece/labor-day
+            if self.get(labour_day_observed_date):
+                labour_day_observed_date += rd(weekday=TU)
+            self[labour_day_observed_date] = name_observed
 
         # Assumption of Mary
         self[date(year, AUG, 15)] = "Κοίμηση της Θεοτόκου [Assumption of Mary]"

--- a/test/countries/test_greece.py
+++ b/test/countries/test_greece.py
@@ -97,3 +97,32 @@ class TestGreece(unittest.TestCase):
                 "Δευτέρα του Αγίου Πνεύματος " + "[Monday of the Holy Spirit]",
                 self.gr_holidays[d],
             )
+
+    def test_gr_labour_day_observed(self):
+        # Dates when labour day was observed on a different date
+        checkdates = (
+            date(2016, 5, 3),
+            date(2021, 5, 4),
+            date(2022, 5, 2),
+            date(2033, 5, 2),
+        )
+        # Years when labour date was observed on May 1st
+        checkyears = (2017, 2018, 2019, 2020, 2023)
+
+        for d in checkdates:
+            self.assertIn(d, self.gr_holidays)
+            self.assertIn(
+                "Εργατική Πρωτομαγιά [Labour day] (Observed)",
+                self.gr_holidays[d],
+            )
+
+        # Check that there is no observed day created for years
+        # when Labour Day was on May 1st
+        for year in checkyears:
+            for day in (2, 3, 4):
+                d = date(year, 5, day)
+                if d in self.gr_holidays:
+                    self.assertNotIn(
+                        "Εργατική Πρωτομαγιά [Labour day] (Observed)",
+                        self.gr_holidays[d],
+                    )


### PR DESCRIPTION
https://www.timeanddate.com/holidays/greece/labor-day
https://en.wikipedia.org/wiki/Public_holidays_in_Greece
From the wikipedia article:
> A public holiday that occurs on a Sunday is not transferred to another date, with the exception of 1 May, which is regarded by the locals more as a general strike than a public holiday. 