### PR TITLE
include py.typed in published package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,6 +39,9 @@ install_requires =
     python-dateutil
 python_requires = >=3.7
 
+[options.package_data]
+holidays = py.typed
+
 [bumpversion]
 current_version = 0.14
 


### PR DESCRIPTION
The py.typed that was added at #620 is not being published, so no users of this library can take advantage of the types that it exposes.