### PR TITLE
fix capitalization typo (Poland - Uroczystość Wszystkich Świętych)

### DIFF
--- a/holidays/countries/poland.py
+++ b/holidays/countries/poland.py
@@ -46,7 +46,7 @@ class Poland(HolidayBase):
 
         self[date(year, AUG, 15)] = "Wniebowzięcie Najświętszej Marii Panny"
 
-        self[date(year, NOV, 1)] = "Uroczystość Wszystkich świętych"
+        self[date(year, NOV, 1)] = "Uroczystość Wszystkich Świętych"
         if (1937 <= year <= 1945) or year >= 1989:
             self[date(year, NOV, 11)] = "Narodowe Święto Niepodległości"
         if year == 2018:

--- a/test/countries/test_poland.py
+++ b/test/countries/test_poland.py
@@ -21,6 +21,11 @@ class TestPL(unittest.TestCase):
     def setUp(self):
         self.holidays = holidays.PL()
 
+    def test_1910(self):
+        self.assertNotIn(date(1910, 5, 1), self.holidays)
+        self.assertNotIn(date(1910, 5, 3), self.holidays)
+        self.assertNotIn(date(1910, 11, 11), self.holidays)
+
     def test_2017(self):
         # http://www.officeholidays.com/countries/poland/2017.php
         self.assertIn(date(2017, 1, 1), self.holidays)


### PR DESCRIPTION
`Uroczystość Wszystkich świętych` -> `Uroczystość Wszystkich Świętych`  
  
references:
* https://pl.wikipedia.org/wiki/Dni_wolne_od_pracy_w_Polsce
* https://pl.wikipedia.org/wiki/Uroczystość_Wszystkich_Świętych
* https://pl.wiktionary.org/wiki/Wszystkich_Świętych

(also, added a new test case to bump `poland.py` test coverage to 100%)