### PR TITLE
Make Colombian holidays preserve historical observation

### DIFF
--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -26,7 +26,15 @@ class Colombia(HolidayBase):
         HolidayBase.__init__(self, **kwargs)
 
     def _add_with_bridge(self, _date, name):
-        if self.observed and _date.weekday() != MON and _date.year >= 1983:
+        """
+        On the 6th of December 1983, the government of Colombia declared which
+        holidays are to take effect, and also clarified that a subset of them
+        are to take place the next Monday if they do not fall on a Monday.
+        This law is "Ley 51 de 1983" which translates to law 51 of 1983.
+        Link: https://www.funcionpublica.gov.co/eva/gestornormativo/norma.php?i=4954#:~:text=Determina%20los%20d%C3%ADas%20festivos%20en,remuneraci%C3%B3n%20del%20d%C3%ADa%20festivo%20art.
+        """
+
+        if self.observed and _date.weekday() != MON and _date.year > 1983:
             self[_date + rd(weekday=MO)] = name + " (Observed)"
         else:
             self[_date] = name
@@ -65,6 +73,11 @@ class Colombia(HolidayBase):
         self[date(year, DEC, 25)] = "Navidad [Christmas]"
 
     def _add_flexible_date_holidays(self, year):
+        """
+        These holidays fall on the next Monday if they are not already on
+        Monday.
+        """
+
         # Epiphany
         self._add_with_bridge(
             date(year, JAN, 6),
@@ -108,6 +121,10 @@ class Colombia(HolidayBase):
         )
 
     def _add_easter_based_holidays(self, year):
+        """
+        These holidays change each year based on when easter is.
+        """
+
         _easter = easter(year)
         self._add_fixed_easter_based_holidays(_easter)
         self._add_flexible_easter_based_holidays(_easter)

--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -20,6 +20,14 @@ from holidays.holiday_base import HolidayBase
 
 
 class Colombia(HolidayBase):
+    """
+    Colombia has 18 holidays. The establishing of these are by:
+    Ley 35 de 1939 (DEC 4): https://www.funcionpublica.gov.co/eva/gestornormativo/norma_pdf.php?i=86145#:~:text=LEY%2035%20DE%201939%20(Diciembre,los%20siguientes%20d%C3%ADas%20de%20fiesta.
+    Decreto 2663 de 1950 (AUG 5): https://www.suin-juriscol.gov.co/viewDocument.asp?id=1874133
+    Decreto 3743 de 1950 (DEC 20): https://www.suin-juriscol.gov.co/viewDocument.asp?id=1535683
+    Ley 51 de 1983 (DEC 6): https://www.funcionpublica.gov.co/eva/gestornormativo/norma.php?i=4954#:~:text=Determina%20los%20d%C3%ADas%20festivos%20en,remuneraci%C3%B3n%20del%20d%C3%ADa%20festivo%20art.
+    """
+
     country = "CO"
 
     def __init__(self, **kwargs):
@@ -32,6 +40,13 @@ class Colombia(HolidayBase):
         are to take place the next Monday if they do not fall on a Monday.
         This law is "Ley 51 de 1983" which translates to law 51 of 1983.
         Link: https://www.funcionpublica.gov.co/eva/gestornormativo/norma.php?i=4954#:~:text=Determina%20los%20d%C3%ADas%20festivos%20en,remuneraci%C3%B3n%20del%20d%C3%ADa%20festivo%20art.
+        A few links below to calendars from the 1980s to demonstrate this law
+        change. In 1984 some calendars still use the old rules, presumably
+        because they were printed prior to the declaration of law change.
+        1981: https://cloud10.todocoleccion.online/calendarios-antiguos/tc/2018/07/02/19/126899607_96874586.jpg
+        1982: https://cloud10.todocoleccion.online/calendarios-antiguos/tc/2016/08/19/12/58620712_34642074.jpg
+        1984: https://cloud10.todocoleccion.online/calendarios-antiguos/tc/2017/07/12/15/92811790_62818054.jpg
+        1984: https://cloud10.todocoleccion.online/calendarios-antiguos/tc/2019/09/23/01/177081467_160179253_tcimg_A547F69E.jpg
         """
 
         if self.observed and _date.weekday() != MON and _date.year > 1983:
@@ -64,10 +79,11 @@ class Colombia(HolidayBase):
         # Battle of Boyaca
         self[date(year, AUG, 7)] = "Batalla de Boyacá [Battle of Boyacá]"
 
-        # Immaculate Conception
-        self[date(year, DEC, 8)] = (
-            "La Inmaculada Concepción [Immaculate Conception]"
-        )
+        if year > 1950:
+            # Immaculate Conception
+            self[date(year, DEC, 8)] = (
+                "La Inmaculada Concepción [Immaculate Conception]"
+            )
 
         # Christmas
         self[date(year, DEC, 25)] = "Navidad [Christmas]"
@@ -78,29 +94,30 @@ class Colombia(HolidayBase):
         Monday.
         """
 
-        # Epiphany
-        self._add_with_bridge(
-            date(year, JAN, 6),
-            "Día de los Reyes Magos [Epiphany]",
-        )
+        if year > 1950:
+            # Epiphany
+            self._add_with_bridge(
+                date(year, JAN, 6),
+                "Día de los Reyes Magos [Epiphany]",
+            )
 
-        # Saint Joseph's Day
-        self._add_with_bridge(
-            date(year, MAR, 19),
-            "Día de San José [Saint Joseph's Day]",
-        )
+            # Saint Joseph's Day
+            self._add_with_bridge(
+                date(year, MAR, 19),
+                "Día de San José [Saint Joseph's Day]",
+            )
 
-        # Saint Peter and Saint Paul's Day
-        self._add_with_bridge(
-            date(year, JUN, 29),
-            "San Pedro y San Pablo [Saint Peter and Saint Paul]",
-        )
+            # Saint Peter and Saint Paul's Day
+            self._add_with_bridge(
+                date(year, JUN, 29),
+                "San Pedro y San Pablo [Saint Peter and Saint Paul]",
+            )
 
-        # Assumption of Mary
-        self._add_with_bridge(
-            date(year, AUG, 15),
-            "La Asunción [Assumption of Mary]",
-        )
+            # Assumption of Mary
+            self._add_with_bridge(
+                date(year, AUG, 15),
+                "La Asunción [Assumption of Mary]",
+            )
 
         # Columbus Day
         self._add_with_bridge(
@@ -108,11 +125,12 @@ class Colombia(HolidayBase):
             "Día de la Raza [Columbus Day]",
         )
 
-        # All Saints’ Day
-        self._add_with_bridge(
-            date(year, NOV, 1),
-            "Día de Todos los Santos [All Saint's Day]",
-        )
+        if year > 1950:
+            # All Saints’ Day
+            self._add_with_bridge(
+                date(year, NOV, 1),
+                "Día de Todos los Santos [All Saint's Day]",
+            )
 
         # Independence of Cartagena
         self._add_with_bridge(
@@ -130,30 +148,35 @@ class Colombia(HolidayBase):
         self._add_flexible_easter_based_holidays(_easter)
 
     def _add_fixed_easter_based_holidays(self, _easter):
-        # Maundy Thursday
-        self[_easter + rd(weekday=TH(-1))] = "Jueves Santo [Maundy Thursday]"
+        if _easter.year > 1950:
+            # Maundy Thursday
+            self[_easter + rd(weekday=TH(-1))] = (
+                "Jueves Santo [Maundy Thursday]"
+            )
 
-        # Good Friday
-        self[_easter + rd(weekday=FR(-1))] = "Viernes Santo [Good Friday]"
+            # Good Friday
+            self[_easter + rd(weekday=FR(-1))] = "Viernes Santo [Good Friday]"
 
     def _add_flexible_easter_based_holidays(self, _easter):
-        # Ascension of Jesus
-        self._add_with_bridge(
-            _easter + rd(days=+39),
-            "Ascensión del señor [Ascension of Jesus]",
-        )
+        if _easter.year > 1950:
+            # Ascension of Jesus
+            self._add_with_bridge(
+                _easter + rd(days=+39),
+                "Ascensión del señor [Ascension of Jesus]",
+            )
 
-        # Corpus Christi
-        self._add_with_bridge(
-            _easter + rd(days=+60),
-            "Corpus Christi [Corpus Christi]",
-        )
+            # Corpus Christi
+            self._add_with_bridge(
+                _easter + rd(days=+60),
+                "Corpus Christi [Corpus Christi]",
+            )
 
-        # Sacred Heart
-        self._add_with_bridge(
-            _easter + rd(days=+68),
-            "Sagrado Corazón [Sacred Heart]",
-        )
+        if _easter.year > 1983:
+            # Sacred Heart
+            self._add_with_bridge(
+                _easter + rd(days=+68),
+                "Sagrado Corazón [Sacred Heart]",
+            )
 
 
 class CO(Colombia):

--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -15,142 +15,128 @@ from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd, MO, TH, FR
 
 from holidays.constants import JAN, MAR, MAY, JUN, JUL, AUG, OCT, NOV, DEC
-from holidays.constants import MON, WEEKEND
+from holidays.constants import MON
 from holidays.holiday_base import HolidayBase
 
 
 class Colombia(HolidayBase):
-    # https://es.wikipedia.org/wiki/Anexo:D%C3%ADas_festivos_en_Colombia
-
     country = "CO"
 
     def __init__(self, **kwargs):
         HolidayBase.__init__(self, **kwargs)
 
-    def _populate(self, year):
+    def _add_with_bridge(self, _date, name):
+        if self.observed and _date.weekday() != MON and _date.year >= 1983:
+            self[_date + rd(weekday=MO)] = name + " (Observed)"
+        else:
+            self[_date] = name
 
-        # Fixed date holidays!
-        # If observed=True and they fall on a weekend they are not observed.
-        # If observed=False there are 18 holidays
+    def _populate(self, year):
+        self._add_fixed_date_holidays(year)
+        self._add_flexible_date_holidays(year)
+        self._add_easter_based_holidays(year)
+
+    def _add_fixed_date_holidays(self, year):
+        """
+        These holidays are always on the same date no matter what day of the
+        week they fall on.
+        """
 
         # New Year's Day
-        if self.observed and date(year, JAN, 1).weekday() in WEEKEND:
-            pass
-        else:
-            self[date(year, JAN, 1)] = "Año Nuevo [New Year's Day]"
+        self[date(year, JAN, 1)] = "Año Nuevo [New Year's Day]"
 
         # Labor Day
         self[date(year, MAY, 1)] = "Día del Trabajo [Labour Day]"
 
         # Independence Day
-        name = "Día de la Independencia [Independence Day]"
-        if self.observed and date(year, JUL, 20).weekday() in WEEKEND:
-            pass
-        else:
-            self[date(year, JUL, 20)] = name
+        self[date(year, JUL, 20)] = (
+            "Día de la Independencia [Independence Day]"
+        )
 
         # Battle of Boyaca
         self[date(year, AUG, 7)] = "Batalla de Boyacá [Battle of Boyacá]"
 
         # Immaculate Conception
-        if self.observed and date(year, DEC, 8).weekday() in WEEKEND:
-            pass
-        else:
-            self[date(year, DEC, 8)] = (
-                "La Inmaculada Concepción" " [Immaculate Conception]"
-            )
+        self[date(year, DEC, 8)] = (
+            "La Inmaculada Concepción [Immaculate Conception]"
+        )
 
         # Christmas
         self[date(year, DEC, 25)] = "Navidad [Christmas]"
 
-        # Emiliani Law holidays!
-        # Unless they fall on a Monday they are observed the following monday
-
-        #  Epiphany
-        name = "Día de los Reyes Magos [Epiphany]"
-        if date(year, JAN, 6).weekday() == MON or not self.observed:
-            self[date(year, JAN, 6)] = name
-        else:
-            self[date(year, JAN, 6) + rd(weekday=MO)] = name + "(Observed)"
+    def _add_flexible_date_holidays(self, year):
+        # Epiphany
+        self._add_with_bridge(
+            date(year, JAN, 6),
+            "Día de los Reyes Magos [Epiphany]",
+        )
 
         # Saint Joseph's Day
-        name = "Día de San José [Saint Joseph's Day]"
-        if date(year, MAR, 19).weekday() == MON or not self.observed:
-            self[date(year, MAR, 19)] = name
-        else:
-            self[date(year, MAR, 19) + rd(weekday=MO)] = name + "(Observed)"
+        self._add_with_bridge(
+            date(year, MAR, 19),
+            "Día de San José [Saint Joseph's Day]",
+        )
 
         # Saint Peter and Saint Paul's Day
-        name = "San Pedro y San Pablo [Saint Peter and Saint Paul]"
-        if date(year, JUN, 29).weekday() == MON or not self.observed:
-            self[date(year, JUN, 29)] = name
-        else:
-            self[date(year, JUN, 29) + rd(weekday=MO)] = name + "(Observed)"
+        self._add_with_bridge(
+            date(year, JUN, 29),
+            "San Pedro y San Pablo [Saint Peter and Saint Paul]",
+        )
 
         # Assumption of Mary
-        name = "La Asunción [Assumption of Mary]"
-        if date(year, AUG, 15).weekday() == MON or not self.observed:
-            self[date(year, AUG, 15)] = name
-        else:
-            self[date(year, AUG, 15) + rd(weekday=MO)] = name + "(Observed)"
+        self._add_with_bridge(
+            date(year, AUG, 15),
+            "La Asunción [Assumption of Mary]",
+        )
 
         # Columbus Day
-        name = "Día de la Raza [Columbus Day]"
-        if date(year, OCT, 12).weekday() == MON or not self.observed:
-            self[date(year, OCT, 12)] = name
-        else:
-            self[date(year, OCT, 12) + rd(weekday=MO)] = name + "(Observed)"
+        self._add_with_bridge(
+            date(year, OCT, 12),
+            "Día de la Raza [Columbus Day]",
+        )
 
         # All Saints’ Day
-        name = "Día de Todos los Santos [All Saint's Day]"
-        if date(year, NOV, 1).weekday() == MON or not self.observed:
-            self[date(year, NOV, 1)] = name
-        else:
-            self[date(year, NOV, 1) + rd(weekday=MO)] = name + "(Observed)"
+        self._add_with_bridge(
+            date(year, NOV, 1),
+            "Día de Todos los Santos [All Saint's Day]",
+        )
 
         # Independence of Cartagena
-        name = "Independencia de Cartagena [Independence of Cartagena]"
-        if date(year, NOV, 11).weekday() == MON or not self.observed:
-            self[date(year, NOV, 11)] = name
-        else:
-            self[date(year, NOV, 11) + rd(weekday=MO)] = name + "(Observed)"
+        self._add_with_bridge(
+            date(year, NOV, 11),
+            "Independencia de Cartagena [Independence of Cartagena]",
+        )
 
-        # Holidays based on Easter
+    def _add_easter_based_holidays(self, year):
+        _easter = easter(year)
+        self._add_fixed_easter_based_holidays(_easter)
+        self._add_flexible_easter_based_holidays(_easter)
 
+    def _add_fixed_easter_based_holidays(self, _easter):
         # Maundy Thursday
-        self[
-            easter(year) + rd(weekday=TH(-1))
-        ] = "Jueves Santo [Maundy Thursday]"
+        self[_easter + rd(weekday=TH(-1))] = "Jueves Santo [Maundy Thursday]"
 
         # Good Friday
-        self[easter(year) + rd(weekday=FR(-1))] = "Viernes Santo [Good Friday]"
+        self[_easter + rd(weekday=FR(-1))] = "Viernes Santo [Good Friday]"
 
-        # Holidays based on Easter but are observed the following monday
-        # (unless they occur on a monday)
-
+    def _add_flexible_easter_based_holidays(self, _easter):
         # Ascension of Jesus
-        name = "Ascensión del señor [Ascension of Jesus]"
-        hdate = easter(year) + rd(days=+39)
-        if hdate.weekday() == MON or not self.observed:
-            self[hdate] = name
-        else:
-            self[hdate + rd(weekday=MO)] = name + "(Observed)"
+        self._add_with_bridge(
+            _easter + rd(days=+39),
+            "Ascensión del señor [Ascension of Jesus]",
+        )
 
         # Corpus Christi
-        name = "Corpus Christi [Corpus Christi]"
-        hdate = easter(year) + rd(days=+60)
-        if hdate.weekday() == MON or not self.observed:
-            self[hdate] = name
-        else:
-            self[hdate + rd(weekday=MO)] = name + "(Observed)"
+        self._add_with_bridge(
+            _easter + rd(days=+60),
+            "Corpus Christi [Corpus Christi]",
+        )
 
         # Sacred Heart
-        name = "Sagrado Corazón [Sacred Heart]"
-        hdate = easter(year) + rd(days=+68)
-        if hdate.weekday() == MON or not self.observed:
-            self[hdate] = name
-        else:
-            self[hdate + rd(weekday=MO)] = name + "(Observed)"
+        self._add_with_bridge(
+            _easter + rd(days=+68),
+            "Sagrado Corazón [Sacred Heart]",
+        )
 
 
 class CO(Colombia):

--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -72,18 +72,18 @@ class Colombia(HolidayBase):
         self[date(year, MAY, 1)] = "Día del Trabajo [Labour Day]"
 
         # Independence Day
-        self[date(year, JUL, 20)] = (
-            "Día de la Independencia [Independence Day]"
-        )
+        self[
+            date(year, JUL, 20)
+        ] = "Día de la Independencia [Independence Day]"
 
         # Battle of Boyaca
         self[date(year, AUG, 7)] = "Batalla de Boyacá [Battle of Boyacá]"
 
         if year > 1950:
             # Immaculate Conception
-            self[date(year, DEC, 8)] = (
-                "La Inmaculada Concepción [Immaculate Conception]"
-            )
+            self[
+                date(year, DEC, 8)
+            ] = "La Inmaculada Concepción [Immaculate Conception]"
 
         # Christmas
         self[date(year, DEC, 25)] = "Navidad [Christmas]"
@@ -150,9 +150,9 @@ class Colombia(HolidayBase):
     def _add_fixed_easter_based_holidays(self, _easter):
         if _easter.year > 1950:
             # Maundy Thursday
-            self[_easter + rd(weekday=TH(-1))] = (
-                "Jueves Santo [Maundy Thursday]"
-            )
+            self[
+                _easter + rd(weekday=TH(-1))
+            ] = "Jueves Santo [Maundy Thursday]"
 
             # Good Friday
             self[_easter + rd(weekday=FR(-1))] = "Viernes Santo [Good Friday]"

--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -22,10 +22,10 @@ from holidays.holiday_base import HolidayBase
 class Colombia(HolidayBase):
     """
     Colombia has 18 holidays. The establishing of these are by:
-    Ley 35 de 1939 (DEC 4): https://www.funcionpublica.gov.co/eva/gestornormativo/norma_pdf.php?i=86145#:~:text=LEY%2035%20DE%201939%20(Diciembre,los%20siguientes%20d%C3%ADas%20de%20fiesta.
-    Decreto 2663 de 1950 (AUG 5): https://www.suin-juriscol.gov.co/viewDocument.asp?id=1874133
-    Decreto 3743 de 1950 (DEC 20): https://www.suin-juriscol.gov.co/viewDocument.asp?id=1535683
-    Ley 51 de 1983 (DEC 6): https://www.funcionpublica.gov.co/eva/gestornormativo/norma.php?i=4954#:~:text=Determina%20los%20d%C3%ADas%20festivos%20en,remuneraci%C3%B3n%20del%20d%C3%ADa%20festivo%20art.
+    Ley 35 de 1939 (DEC 4): https://bit.ly/3PJwk7B
+    Decreto 2663 de 1950 (AUG 5): https://bit.ly/3PJcut8
+    Decreto 3743 de 1950 (DEC 20): https://bit.ly/3B9Otr3
+    Ley 51 de 1983 (DEC 6): https://bit.ly/3aSobiB
     """
 
     country = "CO"
@@ -39,14 +39,14 @@ class Colombia(HolidayBase):
         holidays are to take effect, and also clarified that a subset of them
         are to take place the next Monday if they do not fall on a Monday.
         This law is "Ley 51 de 1983" which translates to law 51 of 1983.
-        Link: https://www.funcionpublica.gov.co/eva/gestornormativo/norma.php?i=4954#:~:text=Determina%20los%20d%C3%ADas%20festivos%20en,remuneraci%C3%B3n%20del%20d%C3%ADa%20festivo%20art.
+        Link: https://bit.ly/3PtPi2e
         A few links below to calendars from the 1980s to demonstrate this law
         change. In 1984 some calendars still use the old rules, presumably
         because they were printed prior to the declaration of law change.
-        1981: https://cloud10.todocoleccion.online/calendarios-antiguos/tc/2018/07/02/19/126899607_96874586.jpg
-        1982: https://cloud10.todocoleccion.online/calendarios-antiguos/tc/2016/08/19/12/58620712_34642074.jpg
-        1984: https://cloud10.todocoleccion.online/calendarios-antiguos/tc/2017/07/12/15/92811790_62818054.jpg
-        1984: https://cloud10.todocoleccion.online/calendarios-antiguos/tc/2019/09/23/01/177081467_160179253_tcimg_A547F69E.jpg
+        1981: https://bit.ly/3BbgKOc
+        1982: https://bit.ly/3BdbhWW
+        1984: https://bit.ly/3PqGxWU
+        1984: https://bit.ly/3B7ogt8
         """
 
         if self.observed and _date.weekday() != MON and _date.year > 1983:

--- a/test/countries/test_colombia.py
+++ b/test/countries/test_colombia.py
@@ -233,3 +233,86 @@ class TestCO(unittest.TestCase):
             date(year, DEC, 25),
         ]
         self._check_all_dates(year, expected_holidays)
+
+    def test_1984(self):
+        year = 1984
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, JAN, 9),
+            date(year, MAR, 19),
+            date(year, APR, 19),
+            date(year, APR, 20),
+            date(year, MAY, 1),
+            date(year, JUN, 4),
+            date(year, JUN, 25),
+            date(year, JUL, 2),
+            date(year, JUL, 2),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 20),
+            date(year, OCT, 15),
+            date(year, NOV, 5),
+            date(year, NOV, 12),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_1983(self):
+        year = 1983
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, JAN, 6),
+            date(year, MAR, 19),
+            date(year, MAR, 31),
+            date(year, APR, 1),
+            date(year, MAY, 1),
+            date(year, MAY, 12),
+            date(year, JUN, 2),
+            date(year, JUN, 29),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 15),
+            date(year, OCT, 12),
+            date(year, NOV, 1),
+            date(year, NOV, 11),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_1951(self):
+        year = 1951
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, JAN, 6),
+            date(year, MAR, 19),
+            date(year, MAR, 22),
+            date(year, MAR, 23),
+            date(year, MAY, 1),
+            date(year, MAY, 3),
+            date(year, MAY, 24),
+            date(year, JUN, 29),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 15),
+            date(year, OCT, 12),
+            date(year, NOV, 1),
+            date(year, NOV, 11),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_1950(self):
+        year = 1950
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, MAY, 1),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, OCT, 12),
+            date(year, NOV, 11),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)

--- a/test/countries/test_colombia.py
+++ b/test/countries/test_colombia.py
@@ -15,6 +15,7 @@ from datetime import date
 from datetime import timedelta
 
 import holidays
+from holidays.constants import JAN, MAR, APR, MAY, JUN, JUL, AUG, OCT, NOV, DEC
 
 
 class TestCO(unittest.TestCase):
@@ -37,23 +38,198 @@ class TestCO(unittest.TestCase):
         # https://www.officeholidays.com/countries/colombia/2016
         year = 2016
         expected_holidays = [
-            date(year, 1, 1),
-            date(year, 1, 11),
-            date(year, 3, 21),
-            date(year, 3, 24),
-            date(year, 3, 25),
-            date(year, 5, 1),
-            date(year, 5, 9),
-            date(year, 5, 30),
-            date(year, 6, 6),
-            date(year, 7, 4),
-            date(year, 7, 20),
-            date(year, 8, 7),
-            date(year, 8, 15),
-            date(year, 10, 17),
-            date(year, 11, 7),
-            date(year, 11, 14),
-            date(year, 12, 8),
-            date(year, 12, 25),
+            date(year, JAN, 1),
+            date(year, JAN, 11),
+            date(year, MAR, 21),
+            date(year, MAR, 24),
+            date(year, MAR, 25),
+            date(year, MAY, 1),
+            date(year, MAY, 9),
+            date(year, MAY, 30),
+            date(year, JUN, 6),
+            date(year, JUL, 4),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 15),
+            date(year, OCT, 17),
+            date(year, NOV, 7),
+            date(year, NOV, 14),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2017(self):
+        # https://www.officeholidays.com/countries/colombia/2017
+        year = 2017
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, JAN, 9),
+            date(year, MAR, 20),
+            date(year, APR, 13),
+            date(year, APR, 14),
+            date(year, MAY, 1),
+            date(year, MAY, 29),
+            date(year, JUN, 19),
+            date(year, JUN, 26),
+            date(year, JUL, 3),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 21),
+            date(year, OCT, 16),
+            date(year, NOV, 6),
+            date(year, NOV, 13),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2018(self):
+        # https://publicholidays.co/2018-dates/
+        year = 2018
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, JAN, 8),
+            date(year, MAR, 19),
+            date(year, MAR, 29),
+            date(year, MAR, 30),
+            date(year, MAY, 1),
+            date(year, MAY, 14),
+            date(year, JUN, 4),
+            date(year, JUN, 11),
+            date(year, JUL, 2),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 20),
+            date(year, OCT, 15),
+            date(year, NOV, 5),
+            date(year, NOV, 12),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2019(self):
+        # https://www.officeholidays.com/countries/colombia/2019
+        year = 2019
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, JAN, 7),
+            date(year, MAR, 25),
+            date(year, APR, 18),
+            date(year, APR, 19),
+            date(year, MAY, 1),
+            date(year, JUN, 3),
+            date(year, JUN, 24),
+            date(year, JUL, 1),
+            date(year, JUL, 1),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 19),
+            date(year, OCT, 14),
+            date(year, NOV, 4),
+            date(year, NOV, 11),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2020(self):
+        # https://www.officeholidays.com/countries/colombia/2020
+        year = 2020
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, JAN, 6),
+            date(year, MAR, 23),
+            date(year, APR, 9),
+            date(year, APR, 10),
+            date(year, MAY, 1),
+            date(year, MAY, 25),
+            date(year, JUN, 15),
+            date(year, JUN, 22),
+            date(year, JUN, 29),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 17),
+            date(year, OCT, 12),
+            date(year, NOV, 2),
+            date(year, NOV, 16),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2021(self):
+        # https://www.officeholidays.com/countries/colombia/2021
+        year = 2021
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, JAN, 11),
+            date(year, MAR, 22),
+            date(year, APR, 1),
+            date(year, APR, 2),
+            date(year, MAY, 1),
+            date(year, MAY, 17),
+            date(year, JUN, 7),
+            date(year, JUN, 14),
+            date(year, JUL, 5),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 16),
+            date(year, OCT, 18),
+            date(year, NOV, 1),
+            date(year, NOV, 15),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2022(self):
+        # https://www.officeholidays.com/countries/colombia/2022
+        year = 2022
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, JAN, 10),
+            date(year, MAR, 21),
+            date(year, APR, 14),
+            date(year, APR, 15),
+            date(year, MAY, 1),
+            date(year, MAY, 30),
+            date(year, JUN, 20),
+            date(year, JUN, 27),
+            date(year, JUL, 4),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 15),
+            date(year, OCT, 17),
+            date(year, NOV, 7),
+            date(year, NOV, 14),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2023(self):
+        # https://publicholidays.co/2023-dates/
+        year = 2023
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, JAN, 9),
+            date(year, MAR, 20),
+            date(year, APR, 6),
+            date(year, APR, 7),
+            date(year, MAY, 1),
+            date(year, MAY, 22),
+            date(year, JUN, 12),
+            date(year, JUN, 19),
+            date(year, JUL, 3),
+            date(year, JUL, 20),
+            date(year, AUG, 7),
+            date(year, AUG, 21),
+            date(year, OCT, 16),
+            date(year, NOV, 6),
+            date(year, NOV, 13),
+            date(year, DEC, 8),
+            date(year, DEC, 25),
         ]
         self._check_all_dates(year, expected_holidays)

--- a/test/countries/test_colombia.py
+++ b/test/countries/test_colombia.py
@@ -12,6 +12,7 @@
 import unittest
 
 from datetime import date
+from datetime import timedelta
 
 import holidays
 
@@ -20,40 +21,39 @@ class TestCO(unittest.TestCase):
     def setUp(self):
         self.holidays = holidays.CO(observed=True)
 
+    def _check_all_dates(self, year, expected_holidays):
+        start_date = date(year, 1, 1)
+        end_date = date(year, 12, 31)
+        delta = timedelta(days=1)
+
+        while start_date <= end_date:
+            if start_date in expected_holidays:
+                self.assertIn(start_date, self.holidays)
+            else:
+                self.assertNotIn(start_date, self.holidays)
+            start_date += delta
+
     def test_2016(self):
-        # http://www.officeholidays.com/countries/colombia/
-        self.assertIn(date(2016, 1, 1), self.holidays)
-        self.assertIn(date(2016, 1, 11), self.holidays)
-        self.assertIn(date(2016, 3, 21), self.holidays)
-        self.assertIn(date(2016, 3, 24), self.holidays)
-        self.assertIn(date(2016, 3, 25), self.holidays)
-        self.assertIn(date(2016, 5, 1), self.holidays)
-        self.assertIn(date(2016, 5, 9), self.holidays)
-        self.assertIn(date(2016, 5, 30), self.holidays)
-        self.assertIn(date(2016, 6, 6), self.holidays)
-        self.assertIn(date(2016, 7, 4), self.holidays)
-        self.assertIn(date(2016, 7, 20), self.holidays)
-        self.assertIn(date(2016, 8, 7), self.holidays)
-        self.assertIn(date(2016, 8, 15), self.holidays)
-        self.assertIn(date(2016, 10, 17), self.holidays)
-        self.assertIn(date(2016, 11, 7), self.holidays)
-        self.assertIn(date(2016, 11, 14), self.holidays)
-        self.assertIn(date(2016, 12, 8), self.holidays)
-        self.assertIn(date(2016, 12, 25), self.holidays)
-
-    def test_others(self):
-        # holidays falling on weekend
-        self.assertNotIn(date(2017, 1, 1), self.holidays)
-        self.assertNotIn(date(2014, 7, 20), self.holidays)
-        self.assertNotIn(date(2018, 8, 12), self.holidays)
-
-        self.assertIn(date(2014, 1, 6), self.holidays)
-        self.assertIn(date(2012, 3, 19), self.holidays)
-        self.assertIn(date(2015, 6, 29), self.holidays)
-        self.assertIn(date(2010, 8, 16), self.holidays)
-        self.assertIn(date(2015, 10, 12), self.holidays)
-        self.assertIn(date(2010, 11, 1), self.holidays)
-        self.assertIn(date(2013, 11, 11), self.holidays)
-        self.holidays.observed = False
-        self.assertIn(date(2016, 5, 5), self.holidays)
-        self.assertIn(date(2016, 5, 26), self.holidays)
+        # https://www.officeholidays.com/countries/colombia/2016
+        year = 2016
+        expected_holidays = [
+            date(year, 1, 1),
+            date(year, 1, 11),
+            date(year, 3, 21),
+            date(year, 3, 24),
+            date(year, 3, 25),
+            date(year, 5, 1),
+            date(year, 5, 9),
+            date(year, 5, 30),
+            date(year, 6, 6),
+            date(year, 7, 4),
+            date(year, 7, 20),
+            date(year, 8, 7),
+            date(year, 8, 15),
+            date(year, 10, 17),
+            date(year, 11, 7),
+            date(year, 11, 14),
+            date(year, 12, 8),
+            date(year, 12, 25),
+        ]
+        self._check_all_dates(year, expected_holidays)


### PR DESCRIPTION
Colombia essentially has four types of holidays:
1. fixed non-easter based
2. flexible non-easter based
3. fixed easter based
4. flexible easter based

The easter based holidays depend on when easter occurs. The flexible holidays occur on the next Monday after the date the holiday falls on, unless it already falls on a Monday.

This change does the following:
1. fixes non-easter based holidays not being set (ie: new year's wasn't being set for 2022: https://github.com/dr-prodigy/python-holidays/issues/674).
2. I rigorously went through the Colombian laws and decrees about holidays and labour since 1905 (wasn't precisely codified until 1939) and went through examples of physical calendars to verify this. Proof is in the code as comments.
3. I improved the test cases to increase confidence in the code correctness.

This branch was rebased off master as instructed