### PR TITLE
Make Venezuela holidays preserve historical observation

### DIFF
--- a/holidays/countries/venezuela.py
+++ b/holidays/countries/venezuela.py
@@ -32,12 +32,12 @@ class Venezuela(HolidayBase):
         """
         Overview: https://dias-festivos.eu/dias-festivos/venezuela/#
         Various decrees about holidays:
-          1909 (AUG 5): https://www.guao.org/sites/default/files/efemerides/69.Ley%20fiestas%20nacionales%201909.pdf
-          1918 (MAY 19): https://www.guao.org/sites/default/files/efemerides/70.%20Ley%20de%20fiestas%20nacionales%201918.pdf
-          1921 (JUN 11): https://guao.org/sites/default/files/efemerides/37.LEYES_Y_DECRETOS_1921_Di%CC%81a_de_la_raza.PDF
-          1971 (JUN 22): https://www.ilo.org/dyn/travail/docs/2030/Law%20No.29.541.pdf
-          2002 (OCT 10): https://www.acnur.org/fileadmin/Documentos/BDL/2008/6635.pdf
-          2012 (MAY 7): https://oig.cepal.org/sites/default/files/2012_leyorgtrabajo_ven.pdf
+          1909 (AUG 5): https://bit.ly/3J0mWKQ
+          1918 (MAY 19): https://bit.ly/3B8O1Jz
+          1921 (JUN 11): https://bit.ly/3aUE2gz
+          1971 (JUN 22): https://bit.ly/3yZaUN9
+          2002 (OCT 10): https://bit.ly/3B7nRqC
+          2012 (MAY 7): https://bit.ly/2MT5x97
         """
 
         self[date(year, JAN, 1)] = "Año Nuevo [New Year's]"
@@ -60,7 +60,7 @@ class Venezuela(HolidayBase):
                 date(year, APR, 19)
             ] = "Declaración de la Independencia [Declaration of Independence]"
 
-        # http://www.ine.gov.ve/index.php?option=com_content&view=article&id=888%3Adia-del-trabajador-01-de-mayo&Itemid=3#:~:text=A%C3%B1os%20m%C3%A1s%20tarde%2C%20R%C3%B3mulo%20Betancourt,la%20agricultura%20y%20en%20la
+        # https://bit.ly/3B4Xd1L
         if year >= 1946:
             self[
                 date(year, MAY, 1)

--- a/holidays/countries/venezuela.py
+++ b/holidays/countries/venezuela.py
@@ -14,7 +14,7 @@ from datetime import date
 from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd
 
-from holidays.constants import (JAN, APR, MAY, JUN, JUL, OCT, DEC)
+from holidays.constants import JAN, APR, MAY, JUN, JUL, OCT, DEC
 from holidays.holiday_base import HolidayBase
 
 
@@ -42,13 +42,13 @@ class Venezuela(HolidayBase):
 
         self[date(year, JAN, 1)] = "Año Nuevo [New Year's]"
 
-        self[easter(year) - rd(days=48)] = (
-            "Lunes de Carnaval [Monday of Carnival]"
-        )
+        self[
+            easter(year) - rd(days=48)
+        ] = "Lunes de Carnaval [Monday of Carnival]"
 
-        self[easter(year) - rd(days=47)] = (
-            "Martes de Carnaval [Tuesday of Carnival]"
-        )
+        self[
+            easter(year) - rd(days=47)
+        ] = "Martes de Carnaval [Tuesday of Carnival]"
 
         self[easter(year) - rd(days=3)] = "Jueves Santo [Maundy Thursday]"
 
@@ -56,46 +56,46 @@ class Venezuela(HolidayBase):
 
         # Note: not sure about the start year, but this event happened in 1811
         if year >= 1811:
-            self[date(year, APR, 19)] = (
-                "Declaración de la Independencia [Declaration of Independence]"
-            )
+            self[
+                date(year, APR, 19)
+            ] = "Declaración de la Independencia [Declaration of Independence]"
 
         # http://www.ine.gov.ve/index.php?option=com_content&view=article&id=888%3Adia-del-trabajador-01-de-mayo&Itemid=3#:~:text=A%C3%B1os%20m%C3%A1s%20tarde%2C%20R%C3%B3mulo%20Betancourt,la%20agricultura%20y%20en%20la
         if year >= 1946:
-            self[date(year, MAY, 1)] = (
-                "Dia Mundial del Trabajador [International Worker's Day]"
-            )
+            self[
+                date(year, MAY, 1)
+            ] = "Dia Mundial del Trabajador [International Worker's Day]"
 
         # Note: not sure about the start year, but this event happened in 1824
         if year >= 1971 or (1918 > year >= 1824):
-            self[date(year, JUN, 24)] = (
-                "Batalla de Carabobo [Battle of Carabobo]"
-            )
+            self[
+                date(year, JUN, 24)
+            ] = "Batalla de Carabobo [Battle of Carabobo]"
 
         # Note: not sure about the start year, but this event happened in 1811
         if year >= 1811:
-            self[date(year, JUL, 5)] = (
-                "Día de la Independencia [Independence Day]"
-            )
+            self[
+                date(year, JUL, 5)
+            ] = "Día de la Independencia [Independence Day]"
 
         if year >= 1918:
-            self[date(year, JUL, 24)] = (
-                "Natalicio de Simón Bolívar [Birth of Simon Bolivar]"
-            )
+            self[
+                date(year, JUL, 24)
+            ] = "Natalicio de Simón Bolívar [Birth of Simon Bolivar]"
 
         if year >= 2002:
-            self[date(year, OCT, 12)] = (
-                "Día de la Resistencia Indígena [Day of Indigenous Resistance]"
-            )
+            self[
+                date(year, OCT, 12)
+            ] = "Día de la Resistencia Indígena [Day of Indigenous Resistance]"
         elif year >= 1921:
             self[date(year, OCT, 12)] = "Día de la Raza [Columbus Day]"
 
         # Note: not sure about the start year nor the reason this was
         # Note: celebrated; the historical records are unclear
         if 1909 <= year < 1918:
-            self[date(year, OCT, 28)] = (
-                "Día Festivo Desconocido [Unknown Holiday]"
-            )
+            self[
+                date(year, OCT, 28)
+            ] = "Día Festivo Desconocido [Unknown Holiday]"
 
         self[date(year, DEC, 24)] = "Nochebuena [Christmas Eve]"
 

--- a/holidays/countries/venezuela.py
+++ b/holidays/countries/venezuela.py
@@ -12,21 +12,9 @@
 from datetime import date
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd, TH, FR
+from dateutil.relativedelta import relativedelta as rd
 
-from holidays.constants import (
-    JAN,
-    MAR,
-    APR,
-    MAY,
-    JUN,
-    JUL,
-    AUG,
-    SEP,
-    OCT,
-    NOV,
-    DEC,
-)
+from holidays.constants import (JAN, APR, MAY, JUN, JUL, OCT, DEC)
 from holidays.holiday_base import HolidayBase
 
 
@@ -41,47 +29,79 @@ class Venezuela(HolidayBase):
         HolidayBase.__init__(self, **kwargs)
 
     def _populate(self, year):
-        # New Year's Day
-        self[date(year, JAN, 1)] = "Año Nuevo [New Year's Day]"
+        """
+        Overview: https://dias-festivos.eu/dias-festivos/venezuela/#
+        Various decrees about holidays:
+          1909 (AUG 5): https://www.guao.org/sites/default/files/efemerides/69.Ley%20fiestas%20nacionales%201909.pdf
+          1918 (MAY 19): https://www.guao.org/sites/default/files/efemerides/70.%20Ley%20de%20fiestas%20nacionales%201918.pdf
+          1921 (JUN 11): https://guao.org/sites/default/files/efemerides/37.LEYES_Y_DECRETOS_1921_Di%CC%81a_de_la_raza.PDF
+          1971 (JUN 22): https://www.ilo.org/dyn/travail/docs/2030/Law%20No.29.541.pdf
+          2002 (OCT 10): https://www.acnur.org/fileadmin/Documentos/BDL/2008/6635.pdf
+          2012 (MAY 7): https://oig.cepal.org/sites/default/files/2012_leyorgtrabajo_ven.pdf
+        """
 
-        self[date(year, MAY, 1)] = "Dia Mundial del Trabajador"
+        self[date(year, JAN, 1)] = "Año Nuevo [New Year's]"
 
-        self[date(year, JUN, 24)] = "Batalla de Carabobo"
+        self[easter(year) - rd(days=48)] = (
+            "Lunes de Carnaval [Monday of Carnival]"
+        )
 
-        self[date(year, JUL, 5)] = "Dia de la Independencia"
+        self[easter(year) - rd(days=47)] = (
+            "Martes de Carnaval [Tuesday of Carnival]"
+        )
 
-        self[date(year, JUL, 24)] = "Natalicio de Simón Bolívar"
+        self[easter(year) - rd(days=3)] = "Jueves Santo [Maundy Thursday]"
 
-        self[date(year, OCT, 12)] = "Día de la Resistencia Indígena"
+        self[easter(year) - rd(days=2)] = "Viernes Santo [Good Friday]"
 
-        self[date(year, DEC, 17)] = "Muerte del Libertador Simón Bolívar"
+        # Note: not sure about the start year, but this event happened in 1811
+        if year >= 1811:
+            self[date(year, APR, 19)] = (
+                "Declaración de la Independencia [Declaration of Independence]"
+            )
 
-        # Christmas Day
-        self[date(year, DEC, 24)] = "Nochebuena"
+        # http://www.ine.gov.ve/index.php?option=com_content&view=article&id=888%3Adia-del-trabajador-01-de-mayo&Itemid=3#:~:text=A%C3%B1os%20m%C3%A1s%20tarde%2C%20R%C3%B3mulo%20Betancourt,la%20agricultura%20y%20en%20la
+        if year >= 1946:
+            self[date(year, MAY, 1)] = (
+                "Dia Mundial del Trabajador [International Worker's Day]"
+            )
 
-        self[date(year, DEC, 25)] = "Día de Navidad"
+        # Note: not sure about the start year, but this event happened in 1824
+        if year >= 1971 or (1918 > year >= 1824):
+            self[date(year, JUN, 24)] = (
+                "Batalla de Carabobo [Battle of Carabobo]"
+            )
 
-        self[date(year, DEC, 31)] = "Fiesta de Fin de Año"
+        # Note: not sure about the start year, but this event happened in 1811
+        if year >= 1811:
+            self[date(year, JUL, 5)] = (
+                "Día de la Independencia [Independence Day]"
+            )
 
-        # Semana Santa y Carnaval
-        if date(year, APR, 19) == (easter(year) - rd(days=2)):
-            self[
-                date(year, APR, 19)
-            ] = "Viernes Santo y Declaración de la Independencia"
-            self[easter(year) - rd(days=3)] = "Jueves Santo"
-        elif date(year, APR, 19) == (easter(year) - rd(days=3)):
-            self[
-                date(year, APR, 19)
-            ] = "Jueves Santo y Declaración de la Independencia"
-            self[easter(year) - rd(days=2)] = "Viernes Santo"
-        else:
-            self[date(year, APR, 19)] = "Declaración de la Independencia"
-            self[easter(year) - rd(days=2)] = "Viernes Santo"
-            self[easter(year) - rd(days=3)] = "Jueves Santo"
+        if year >= 1918:
+            self[date(year, JUL, 24)] = (
+                "Natalicio de Simón Bolívar [Birth of Simon Bolivar]"
+            )
 
-        self[easter(year) - rd(days=47)] = "Martes de Carnaval"
+        if year >= 2002:
+            self[date(year, OCT, 12)] = (
+                "Día de la Resistencia Indígena [Day of Indigenous Resistance]"
+            )
+        elif year >= 1921:
+            self[date(year, OCT, 12)] = "Día de la Raza [Columbus Day]"
 
-        self[easter(year) - rd(days=48)] = "Lunes de Carnaval"
+        # Note: not sure about the start year nor the reason this was
+        # Note: celebrated; the historical records are unclear
+        if 1909 <= year < 1918:
+            self[date(year, OCT, 28)] = (
+                "Día Festivo Desconocido [Unknown Holiday]"
+            )
+
+        self[date(year, DEC, 24)] = "Nochebuena [Christmas Eve]"
+
+        self[date(year, DEC, 25)] = "Día de Navidad [Christmas Day]"
+
+        self[date(year, DEC, 31)] = "Fiesta de Fin de Año [New Year's Eve]"
 
 
 class VE(Venezuela):

--- a/test/countries/test_venezuela.py
+++ b/test/countries/test_venezuela.py
@@ -12,73 +12,227 @@
 import unittest
 
 from datetime import date
+from datetime import timedelta
 
+from holidays.constants import (JAN, FEB, MAR, APR, MAY, JUN, JUL, OCT, DEC)
 import holidays
 
 
 class TestVenezuela(unittest.TestCase):
-    def test_VE_holidays(self):
-        self.holidays = holidays.VE(years=2019)
-        self.assertIn("2019-01-01", self.holidays)
-        self.assertEqual(
-            self.holidays[date(2019, 1, 1)], "Año Nuevo [New Year's Day]"
-        )
-        self.assertIn("2019-03-04", self.holidays)
-        self.assertEqual(
-            self.holidays[date(2019, 3, 4)],
-            "Lunes de Carnaval",
-        )
-        self.assertIn("2019-03-05", self.holidays)
-        self.assertEqual(self.holidays[date(2019, 3, 5)], "Martes de Carnaval")
-        self.assertIn("2019-04-18", self.holidays)
-        self.assertEqual(self.holidays[date(2019, 4, 18)], "Jueves Santo")
-        self.assertIn("2019-04-19", self.holidays)
-        self.assertEqual(
-            self.holidays[date(2019, 4, 19)],
-            "Viernes Santo y Declaración de la Independencia",
-        )
-        self.assertIn("2019-05-01", self.holidays)
-        self.assertEqual(
-            self.holidays[date(2019, 5, 1)], "Dia Mundial del Trabajador"
-        )
-        self.assertIn("2019-06-24", self.holidays)
-        self.assertEqual(
-            self.holidays[date(2019, 6, 24)], "Batalla de Carabobo"
-        )
-        self.assertIn("2019-05-01", self.holidays)
-        self.assertEqual(
-            self.holidays[date(2019, 7, 5)], "Dia de la Independencia"
-        )
-        self.assertIn("2019-07-24", self.holidays)
-        self.assertEqual(
-            self.holidays[date(2019, 7, 24)], "Natalicio de Simón Bolívar"
-        )
-        self.assertIn("2019-10-12", self.holidays)
-        self.assertEqual(
-            self.holidays[date(2019, 10, 12)], "Día de la Resistencia Indígena"
-        )
-        self.assertIn("2019-12-17", self.holidays)
-        self.assertEqual(
-            self.holidays[date(2019, 12, 17)],
-            "Muerte del Libertador Simón Bolívar",
-        )
-        self.assertIn("2019-12-24", self.holidays)
-        self.assertEqual(self.holidays[date(2019, 12, 24)], "Nochebuena")
-        self.assertIn("2019-12-25", self.holidays)
-        self.assertEqual(self.holidays[date(2019, 12, 25)], "Día de Navidad")
-        self.assertIn("2019-12-31", self.holidays)
-        self.assertEqual(
-            self.holidays[date(2019, 12, 31)], "Fiesta de Fin de Año"
-        )
+    def setUp(self):
+        self.holidays = holidays.VE(observed=True)
 
-        self.assertEqual(self.holidays[date(2020, 4, 9)], "Jueves Santo")
-        self.assertEqual(self.holidays[date(2020, 4, 10)], "Viernes Santo")
-        self.assertEqual(
-            self.holidays[date(2020, 4, 19)],
-            "Declaración de la Independencia",
-        )
+    def _check_all_dates(self, year, expected_holidays):
+        start_date = date(year, 1, 1)
+        end_date = date(year, 12, 31)
+        delta = timedelta(days=1)
 
-        self.assertEqual(
-            self.holidays[date(1984, 4, 19)],
-            "Jueves Santo y Declaración de la Independencia",
-        )
+        while start_date <= end_date:
+            if start_date in expected_holidays:
+                self.assertIn(start_date, self.holidays)
+            else:
+                self.assertNotIn(start_date, self.holidays)
+            start_date += delta
+
+    def test_2016(self):
+        # https://www.officeholidays.com/countries/venezuela/2016
+        year = 2016
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, FEB, 8),
+            date(year, FEB, 9),
+            date(year, MAR, 24),
+            date(year, MAR, 25),
+            date(year, APR, 19),
+            date(year, MAY, 1),
+            date(year, JUN, 24),
+            date(year, JUL, 5),
+            date(year, JUL, 24),
+            date(year, OCT, 12),
+            date(year, DEC, 24),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2017(self):
+        # https://www.officeholidays.com/countries/venezuela/2017
+        year = 2017
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, FEB, 27),
+            date(year, FEB, 28),
+            date(year, APR, 13),
+            date(year, APR, 14),
+            date(year, APR, 19),
+            date(year, MAY, 1),
+            date(year, JUN, 24),
+            date(year, JUL, 5),
+            date(year, JUL, 24),
+            date(year, OCT, 12),
+            date(year, DEC, 24),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2018(self):
+        # https://www.officeholidays.com/countries/venezuela/2018
+        year = 2018
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, FEB, 12),
+            date(year, FEB, 13),
+            date(year, MAR, 29),
+            date(year, MAR, 30),
+            date(year, APR, 19),
+            date(year, MAY, 1),
+            date(year, JUN, 24),
+            date(year, JUL, 5),
+            date(year, JUL, 24),
+            date(year, OCT, 12),
+            date(year, DEC, 24),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2019(self):
+        # https://www.officeholidays.com/countries/venezuela/2019
+        year = 2019
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, MAR, 4),
+            date(year, MAR, 5),
+            date(year, APR, 18),
+            date(year, APR, 19),
+            date(year, APR, 19),
+            date(year, MAY, 1),
+            date(year, JUN, 24),
+            date(year, JUL, 5),
+            date(year, JUL, 24),
+            date(year, OCT, 12),
+            date(year, DEC, 24),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2020(self):
+        # https://www.officeholidays.com/countries/venezuela/2020
+        year = 2020
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, FEB, 24),
+            date(year, FEB, 25),
+            date(year, APR, 9),
+            date(year, APR, 10),
+            date(year, APR, 19),
+            date(year, MAY, 1),
+            date(year, JUN, 24),
+            date(year, JUL, 5),
+            date(year, JUL, 24),
+            date(year, OCT, 12),
+            date(year, DEC, 24),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2021(self):
+        # https://www.officeholidays.com/countries/venezuela/2021
+        year = 2021
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, FEB, 15),
+            date(year, FEB, 16),
+            date(year, APR, 1),
+            date(year, APR, 2),
+            date(year, APR, 19),
+            date(year, MAY, 1),
+            date(year, JUN, 24),
+            date(year, JUL, 5),
+            date(year, JUL, 24),
+            date(year, OCT, 12),
+            date(year, DEC, 24),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2022(self):
+        # https://www.officeholidays.com/countries/venezuela/2022
+        year = 2022
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, FEB, 28),
+            date(year, MAR, 1),
+            date(year, APR, 14),
+            date(year, APR, 15),
+            date(year, APR, 19),
+            date(year, MAY, 1),
+            date(year, JUN, 24),
+            date(year, JUL, 5),
+            date(year, JUL, 24),
+            date(year, OCT, 12),
+            date(year, DEC, 24),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_2023(self):
+        # https://www.officeholidays.com/countries/venezuela/2023
+        year = 2023
+        expected_holidays = [
+            date(year, JAN, 1),
+            date(year, FEB, 20),
+            date(year, FEB, 21),
+            date(year, APR, 6),
+            date(year, APR, 7),
+            date(year, APR, 19),
+            date(year, MAY, 1),
+            date(year, JUN, 24),
+            date(year, JUL, 5),
+            date(year, JUL, 24),
+            date(year, OCT, 12),
+            date(year, DEC, 24),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected_holidays)
+
+    def test_independence(self):
+        self.assertNotIn(date(1800, APR, 19), self.holidays)
+        self.assertNotIn(date(1810, JUL, 5), self.holidays)
+
+    def test_workers_day(self):
+        self.assertIn(date(1946, MAY, 1), self.holidays)
+        self.assertNotIn(date(1945, MAY, 1), self.holidays)
+        self.assertNotIn(date(1944, MAY, 1), self.holidays)
+        self.assertNotIn(date(1900, MAY, 1), self.holidays)
+
+    def test_birth_simon_bolivar(self):
+        self.assertIn(date(1918, JUL, 24), self.holidays)
+        self.assertNotIn(date(1917, JUL, 24), self.holidays)
+        self.assertNotIn(date(1916, JUL, 24), self.holidays)
+        self.assertNotIn(date(1900, JUL, 24), self.holidays)
+
+    def test_unknown_holiday(self):
+        self.assertNotIn(date(1918, OCT, 28), self.holidays)
+        self.assertIn(date(1917, OCT, 28), self.holidays)
+        self.assertIn(date(1909, OCT, 28), self.holidays)
+        self.assertNotIn(date(1908, OCT, 28), self.holidays)
+
+    def test_battle_of_carabobo(self):
+        self.assertIn(date(1971, JUN, 24), self.holidays)
+        self.assertNotIn(date(1970, JUN, 24), self.holidays)
+        self.assertNotIn(date(1969, JUN, 24), self.holidays)
+
+    def test_indigenous_resistance(self):
+        self.assertNotIn(date(1920, OCT, 12), self.holidays)
+        self.assertIn(date(1921, OCT, 12), self.holidays)
+        old_name = self.holidays.get(date(2001, OCT, 12)).lower()
+        self.assertIn('raza', old_name)
+        new_name = self.holidays.get(date(2002, OCT, 12)).lower()
+        self.assertIn('resistencia', new_name)

--- a/test/countries/test_venezuela.py
+++ b/test/countries/test_venezuela.py
@@ -14,7 +14,7 @@ import unittest
 from datetime import date
 from datetime import timedelta
 
-from holidays.constants import (JAN, FEB, MAR, APR, MAY, JUN, JUL, OCT, DEC)
+from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, OCT, DEC
 import holidays
 
 
@@ -233,6 +233,6 @@ class TestVenezuela(unittest.TestCase):
         self.assertNotIn(date(1920, OCT, 12), self.holidays)
         self.assertIn(date(1921, OCT, 12), self.holidays)
         old_name = self.holidays.get(date(2001, OCT, 12)).lower()
-        self.assertIn('raza', old_name)
+        self.assertIn("raza", old_name)
         new_name = self.holidays.get(date(2002, OCT, 12)).lower()
-        self.assertIn('resistencia', new_name)
+        self.assertIn("resistencia", new_name)


### PR DESCRIPTION
I rigorously went back through the historical records by analyzing laws and decrees until 1909 to get an accurate representation of what holidays there were over the years. I added many more test cases to increase confidence in the code. I put the proof for each year I picked in the code.

For some holidays, such as declaration of independence, I put conservative dates such as when they declared independence because I could not find any laws or decrees in the historical record before 1909.

There is one holiday that was in a decree in 1909 and was overturned in 1918. I tried my best to find out what it was called, but could not unfortunately.