### PR TITLE
Add Cuba

### DIFF
--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -27,6 +27,7 @@ from .chile import Chile, CL, CHL
 from .china import China, CN, CHN
 from .colombia import Colombia, CO, COL
 from .croatia import Croatia, HR, HRV
+from .cuba import Cuba, CU, CUB
 from .curacao import Curacao, CW, CUW
 from .cyprus import Cyprus, CY, CYP
 from .czechia import Czechia, CZ, CZE

--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -41,11 +41,10 @@ class Cuba(HolidayBase):
         """
 
         name = "Aniversario de la Revolución [Anniversary of the Revolution]"
+        self[date(year, JAN, 1)] = name
         if year <= 2013 and self.observed \
                 and date(year, JAN, 1).weekday() == SUN:
             self[date(year, JAN, 1) + rd(weekday=MO)] = name + " (Observed)"
-        else:
-            self[date(year, JAN, 1)] = name
 
         # Granted in 2007 decree.
         if year > 2007:
@@ -59,10 +58,9 @@ class Cuba(HolidayBase):
             self[easter(year) - rd(days=2)] = "Viernes Santo [Good Friday]"
 
         name = "Día Internacional de los Trabajadores [Labour Day]"
+        self[date(year, MAY, 1)] = name
         if self.observed and date(year, MAY, 1).weekday() == SUN:
             self[date(year, MAY, 1) + rd(weekday=MO)] = name + " (Observed)"
-        else:
-            self[date(year, MAY, 1)] = name
 
         self[date(year, JUL, 25)] = (
             "Conmemoración del asalto a Moncada "
@@ -79,10 +77,9 @@ class Cuba(HolidayBase):
         )
 
         name = "Inicio de las Guerras de Independencia [Independence Day]"
+        self[date(year, OCT, 10)] = name
         if self.observed and date(year, OCT, 10).weekday() == SUN:
             self[date(year, OCT, 10) + rd(weekday=MO)] = name + " (Observed)"
-        else:
-            self[date(year, OCT, 10)] = name
 
         # In 1969, Christmas was cancelled for the sugar harvest but then was
         # cancelled for good:

--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -14,7 +14,7 @@ from datetime import date
 from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd, MO
 
-from holidays.constants import (JAN, MAY, JUL, OCT, DEC)
+from holidays.constants import JAN, MAY, JUL, OCT, DEC
 from holidays.constants import SUN
 from holidays.holiday_base import HolidayBase
 
@@ -42,8 +42,11 @@ class Cuba(HolidayBase):
 
         name = "Aniversario de la Revolución [Anniversary of the Revolution]"
         self[date(year, JAN, 1)] = name
-        if year <= 2013 and self.observed \
-                and date(year, JAN, 1).weekday() == SUN:
+        if (
+            year <= 2013
+            and self.observed
+            and date(year, JAN, 1).weekday() == SUN
+        ):
             self[date(year, JAN, 1) + rd(weekday=MO)] = name + " (Observed)"
 
         # Granted in 2007 decree.
@@ -67,9 +70,9 @@ class Cuba(HolidayBase):
             "[Commemoration of the Assault of the Moncada garrison]"
         )
 
-        self[date(year, JUL, 26)] = (
-            "Día de la Rebeldía Nacional [Day of the National Rebellion]"
-        )
+        self[
+            date(year, JUL, 26)
+        ] = "Día de la Rebeldía Nacional [Day of the National Rebellion]"
 
         self[date(year, JUL, 27)] = (
             "Conmemoración del asalto a Moncada "

--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -28,9 +28,9 @@ class Cuba(HolidayBase):
     def _populate(self, year):
         """
         Overview: https://en.wikipedia.org/wiki/Public_holidays_in_Cuba
-        1984 (DEC 28): https://files.sld.cu/prevemi/files/2013/03/ley_49_codigo_trabajo_1984.pdf
-        2007 (NOV 19): https://www.gacetaoficial.gob.cu/sites/default/files/go_x_053_2007.pdf
-        2013 (DEC 20): https://www.gacetaoficial.gob.cu/es/ley-no-116-codigo-de-trabajo
+        1984 (DEC 28): https://bit.ly/3okNBbt
+        2007 (NOV 19): https://bit.ly/3oFbhaZ
+        2013 (DEC 20): https://bit.ly/3zoO3vC
         Note: for holidays that can be moved to a Monday if they fall on a
               Monday, between 1984 and 2013, the State Committee of Work and
               Social Security would determine if they would be moved to the
@@ -54,8 +54,8 @@ class Cuba(HolidayBase):
             self[date(year, JAN, 2)] = "Día de la Victoria [Victory Day]"
 
         # Granted temporarily in 2012 and 2013:
-        #   https://www.cnn.com/2012/03/31/world/americas/cuba-good-friday/index.html#:~:text=During%20his%20visit%20to%20Cuba,since%20the%201959%20Cuban%20revolution.
-        #   https://www.catholicnewsagency.com/news/29455/cuban-government-makes-good-friday-official-holiday
+        #   https://cnn.it/3v5V6GY
+        #   https://bit.ly/3v6bM18
         # Permanently granted in 2013 decree for 2014 and onwards.
         if year >= 2012:
             self[easter(year) - rd(days=2)] = "Viernes Santo [Good Friday]"
@@ -86,12 +86,12 @@ class Cuba(HolidayBase):
 
         # In 1969, Christmas was cancelled for the sugar harvest but then was
         # cancelled for good:
-        #   https://time.com/vault/issue/1969-11-07/page/44/
+        #   https://bit.ly/3OpwX5i
         # In 1997, Christmas was temporarily back for the pope's visit:
-        #   http://www.cnn.com/WORLD/9712/15/castro.christmas/
+        #   https://cnn.it/3Omn349
         # In 1998, Christmas returns for good:
-        #   https://www.independent.co.uk/news/cuba-ends-its-30year-ban-on-christmas-1193525.html
-        #   https://www.ilo.org/dyn/travail/docs/1320/DECRETO-LEY%20No.%20189-1998.pdf
+        #   https://bit.ly/3cyXhwz
+        #   https://bit.ly/3cyXj7F
         if year >= 1997 or year < 1969:
             self[date(year, DEC, 25)] = "Día de Navidad [Christmas Day]"
 

--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -1,0 +1,108 @@
+#  python-holidays
+#  ---------------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: dr-prodigy <maurizio.montel@gmail.com> (c) 2017-2022
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/dr-prodigy/python-holidays
+#  License: MIT (see LICENSE file)
+
+from datetime import date
+
+from dateutil.easter import easter
+from dateutil.relativedelta import relativedelta as rd, MO
+
+from holidays.constants import (JAN, MAY, JUL, OCT, DEC)
+from holidays.constants import SUN
+from holidays.holiday_base import HolidayBase
+
+
+class Cuba(HolidayBase):
+    country = "CU"
+
+    def __init__(self, **kwargs):
+        HolidayBase.__init__(self, **kwargs)
+
+    def _populate(self, year):
+        """
+        Overview: https://en.wikipedia.org/wiki/Public_holidays_in_Cuba
+        1984 (DEC 28): https://files.sld.cu/prevemi/files/2013/03/ley_49_codigo_trabajo_1984.pdf
+        2007 (NOV 19): https://www.gacetaoficial.gob.cu/sites/default/files/go_x_053_2007.pdf
+        2013 (DEC 20): https://www.gacetaoficial.gob.cu/es/ley-no-116-codigo-de-trabajo
+        Note: for holidays that can be moved to a Monday if they fall on a
+              Monday, between 1984 and 2013, the State Committee of Work and
+              Social Security would determine if they would be moved to the
+              Monday, or if they would stay on the Sunday, presumably depending
+              on quotas. After 2013, they always move to Monday. I could not
+              find any records of this, so I implemented this making it always
+              go to the next Monday.
+        """
+
+        name = "Aniversario de la Revolución [Anniversary of the Revolution]"
+        if year <= 2013 and self.observed \
+                and date(year, JAN, 1).weekday() == SUN:
+            self[date(year, JAN, 1) + rd(weekday=MO)] = name + " (Observed)"
+        else:
+            self[date(year, JAN, 1)] = name
+
+        # Granted in 2007 decree.
+        if year > 2007:
+            self[date(year, JAN, 2)] = "Día de la Victoria [Victory Day]"
+
+        # Granted temporarily in 2012 and 2013:
+        #   https://www.cnn.com/2012/03/31/world/americas/cuba-good-friday/index.html#:~:text=During%20his%20visit%20to%20Cuba,since%20the%201959%20Cuban%20revolution.
+        #   https://www.catholicnewsagency.com/news/29455/cuban-government-makes-good-friday-official-holiday
+        # Permanently granted in 2013 decree for 2014 and onwards.
+        if year >= 2012:
+            self[easter(year) - rd(days=2)] = "Viernes Santo [Good Friday]"
+
+        name = "Día Internacional de los Trabajadores [Labour Day]"
+        if self.observed and date(year, MAY, 1).weekday() == SUN:
+            self[date(year, MAY, 1) + rd(weekday=MO)] = name + " (Observed)"
+        else:
+            self[date(year, MAY, 1)] = name
+
+        self[date(year, JUL, 25)] = (
+            "Conmemoración del asalto a Moncada "
+            "[Commemoration of the Assault of the Moncada garrison]"
+        )
+
+        self[date(year, JUL, 26)] = (
+            "Día de la Rebeldía Nacional [Day of the National Rebellion]"
+        )
+
+        self[date(year, JUL, 27)] = (
+            "Conmemoración del asalto a Moncada "
+            "[Commemoration of the Assault of the Moncada garrison]"
+        )
+
+        name = "Inicio de las Guerras de Independencia [Independence Day]"
+        if self.observed and date(year, OCT, 10).weekday() == SUN:
+            self[date(year, OCT, 10) + rd(weekday=MO)] = name + " (Observed)"
+        else:
+            self[date(year, OCT, 10)] = name
+
+        # In 1969, Christmas was cancelled for the sugar harvest but then was
+        # cancelled for good:
+        #   https://time.com/vault/issue/1969-11-07/page/44/
+        # In 1997, Christmas was temporarily back for the pope's visit:
+        #   http://www.cnn.com/WORLD/9712/15/castro.christmas/
+        # In 1998, Christmas returns for good:
+        #   https://www.independent.co.uk/news/cuba-ends-its-30year-ban-on-christmas-1193525.html
+        #   https://www.ilo.org/dyn/travail/docs/1320/DECRETO-LEY%20No.%20189-1998.pdf
+        if year >= 1997 or year < 1969:
+            self[date(year, DEC, 25)] = "Día de Navidad [Christmas Day]"
+
+        # Granted in 2007 decree.
+        if year >= 2007:
+            self[date(year, DEC, 31)] = "Fiesta de Fin de Año [New Year's Eve]"
+
+
+class CU(Cuba):
+    pass
+
+
+class CUB(Cuba):
+    pass

--- a/test/countries/test_cuba.py
+++ b/test/countries/test_cuba.py
@@ -15,7 +15,7 @@ from datetime import date
 from datetime import timedelta
 
 import holidays
-from holidays.constants import (JAN, MAR, APR, MAY, JUL, OCT, DEC)
+from holidays.constants import JAN, MAR, APR, MAY, JUL, OCT, DEC
 
 
 class TestCuba(unittest.TestCase):

--- a/test/countries/test_cuba.py
+++ b/test/countries/test_cuba.py
@@ -1,0 +1,301 @@
+#  python-holidays
+#  ---------------
+#  A fast, efficient Python library for generating country, province and state
+#  specific sets of holidays on the fly. It aims to make determining whether a
+#  specific date is a holiday as fast and flexible as possible.
+#
+#  Authors: dr-prodigy <maurizio.montel@gmail.com> (c) 2017-2022
+#           ryanss <ryanssdev@icloud.com> (c) 2014-2017
+#  Website: https://github.com/dr-prodigy/python-holidays
+#  License: MIT (see LICENSE file)
+
+import unittest
+
+from datetime import date
+from datetime import timedelta
+
+import holidays
+from holidays.constants import (JAN, MAR, APR, MAY, JUL, OCT, DEC)
+
+
+class TestCuba(unittest.TestCase):
+    def setUp(self):
+        self.holidays = holidays.CU(observed=True)
+
+    def _check_all_dates(self, year, expected_holidays):
+        start_date = date(year, 1, 1)
+        end_date = date(year, 12, 31)
+        delta = timedelta(days=1)
+
+        while start_date <= end_date:
+            if start_date in expected_holidays:
+                self.assertIn(start_date, self.holidays)
+            else:
+                self.assertNotIn(start_date, self.holidays)
+            start_date += delta
+
+    def test_1968(self):
+        year = 1968
+        expected = [
+            date(year, JAN, 1),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_1969(self):
+        year = 1969
+        expected = [
+            date(year, JAN, 1),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_1970(self):
+        year = 1970
+        expected = [
+            date(year, JAN, 1),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_1996(self):
+        year = 1996
+        expected = [
+            date(year, JAN, 1),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_1997(self):
+        year = 1997
+        expected = [
+            date(year, JAN, 1),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_1998(self):
+        year = 1998
+        expected = [
+            date(year, JAN, 1),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2006(self):
+        year = 2006
+        expected = [
+            date(year, JAN, 2),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2007(self):
+        year = 2007
+        expected = [
+            date(year, JAN, 1),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2008(self):
+        year = 2008
+        expected = [
+            date(year, JAN, 1),
+            date(year, JAN, 2),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2011(self):
+        year = 2011
+        expected = [
+            date(year, JAN, 1),
+            date(year, JAN, 2),
+            date(year, MAY, 2),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2012(self):
+        year = 2012
+        expected = [
+            date(year, JAN, 2),
+            date(year, JAN, 2),
+            date(year, APR, 6),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2013(self):
+        year = 2013
+        expected = [
+            date(year, JAN, 1),
+            date(year, JAN, 2),
+            date(year, MAR, 29),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2018(self):
+        # https://www.officeholidays.com/countries/cuba/2018
+        year = 2018
+        expected = [
+            date(year, JAN, 1),
+            date(year, JAN, 2),
+            date(year, MAR, 30),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2019(self):
+        # https://www.officeholidays.com/countries/cuba/2019
+        year = 2019
+        expected = [
+            date(year, JAN, 1),
+            date(year, JAN, 2),
+            date(year, APR, 19),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2020(self):
+        # https://www.officeholidays.com/countries/cuba/2020
+        year = 2020
+        expected = [
+            date(year, JAN, 1),
+            date(year, JAN, 2),
+            date(year, APR, 10),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2021(self):
+        # https://www.officeholidays.com/countries/cuba/2021
+        year = 2021
+        expected = [
+            date(year, JAN, 1),
+            date(year, JAN, 2),
+            date(year, APR, 2),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 11),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2022(self):
+        # https://www.officeholidays.com/countries/cuba/2022
+        year = 2022
+        expected = [
+            date(year, JAN, 1),
+            date(year, JAN, 2),
+            date(year, APR, 15),
+            date(year, MAY, 2),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)
+
+    def test_2023(self):
+        # https://www.officeholidays.com/countries/cuba/2023
+        year = 2023
+        expected = [
+            date(year, JAN, 1),
+            date(year, JAN, 2),
+            date(year, APR, 7),
+            date(year, MAY, 1),
+            date(year, JUL, 25),
+            date(year, JUL, 26),
+            date(year, JUL, 27),
+            date(year, OCT, 10),
+            date(year, DEC, 25),
+            date(year, DEC, 31),
+        ]
+        self._check_all_dates(year, expected)

--- a/test/countries/test_cuba.py
+++ b/test/countries/test_cuba.py
@@ -112,6 +112,7 @@ class TestCuba(unittest.TestCase):
     def test_2006(self):
         year = 2006
         expected = [
+            date(year, JAN, 1),
             date(year, JAN, 2),
             date(year, MAY, 1),
             date(year, JUL, 25),
@@ -156,6 +157,7 @@ class TestCuba(unittest.TestCase):
         expected = [
             date(year, JAN, 1),
             date(year, JAN, 2),
+            date(year, MAY, 1),
             date(year, MAY, 2),
             date(year, JUL, 25),
             date(year, JUL, 26),
@@ -169,6 +171,7 @@ class TestCuba(unittest.TestCase):
     def test_2012(self):
         year = 2012
         expected = [
+            date(year, JAN, 1),
             date(year, JAN, 2),
             date(year, JAN, 2),
             date(year, APR, 6),
@@ -260,6 +263,7 @@ class TestCuba(unittest.TestCase):
             date(year, JUL, 25),
             date(year, JUL, 26),
             date(year, JUL, 27),
+            date(year, OCT, 10),
             date(year, OCT, 11),
             date(year, DEC, 25),
             date(year, DEC, 31),
@@ -273,6 +277,7 @@ class TestCuba(unittest.TestCase):
             date(year, JAN, 1),
             date(year, JAN, 2),
             date(year, APR, 15),
+            date(year, MAY, 1),
             date(year, MAY, 2),
             date(year, JUL, 25),
             date(year, JUL, 26),


### PR DESCRIPTION
All primary and secondary sources in comments in the code. Could only find information for 1969 and onwards, so these holidays only apply to Socialist/Modern Cuba and not Batista's Cuba nor pre-Batista Cuba.