### PR TITLE
Update Ukraine holidays.

### DIFF
--- a/holidays/countries/ukraine.py
+++ b/holidays/countries/ukraine.py
@@ -30,8 +30,8 @@ class Ukraine(HolidayBase):
 
     def _populate(self, year):
         # The current set of holidays came into force in 1991
-        # But most holiday days was inplemented in 1981
-        if year < 1918:
+        # But most holiday days were implemented in 1918
+        if year <= 1917:
             return
 
         # New Year's Day
@@ -40,36 +40,39 @@ class Ukraine(HolidayBase):
 
         # Christmas Day (Orthodox)
         if year >= 1991:
-            self[date(year, JAN, 7)] = "Різдво Христове" " (православне)"
+            self[date(year, JAN, 7)] = "Різдво Христове (православне)"
 
         # Women's Day
-        if year > 1965:
+        if year >= 1966:
             self[date(year, MAR, 8)] = "Міжнародний жіночий день"
 
         # Easter
         if year >= 1991:
-            self[easter(year, method=EASTER_ORTHODOX)] = "Пасха" " (Великдень)"
+            self[easter(year, method=EASTER_ORTHODOX)] = "Великдень (Пасха)"
 
         # Holy trinity
         if year >= 1991:
             self[easter(year, method=EASTER_ORTHODOX) + rd(days=49)] = "Трійця"
 
         # Labour Day
-        if year > 2017:
+        if year >= 2018:
             name = "День праці"
-        elif 1917 < year <= 2017:
+        elif 1918 <= year <= 2017:
             name = "День міжнародної солідарності трудящих"
         self[date(year, MAY, 1)] = name
 
         # Labour Day in past
-        if 1928 < year < 2018:
+        if 1929 <= year <= 2017:
             self[date(year, MAY, 2)] = "День міжнародної солідарності трудящих"
 
         # Victory Day
         name = "День перемоги"
-        if year >= 1965:
+
+        if year >= 2016:
+            self[date(year, MAY, 9)] = "День перемоги над нацизмом у Другій світовій війні"
+        elif 1965 <= year <= 2015:
             self[date(year, MAY, 9)] = name
-        if 1945 <= year < 1947:
+        elif 1945 <= year <= 1946:
             self[date(year, MAY, 9)] = name
             self[date(year, SEP, 3)] = "День перемоги над Японією"
 
@@ -77,9 +80,13 @@ class Ukraine(HolidayBase):
         if year >= 1997:
             self[date(year, JUN, 28)] = "День Конституції України"
 
+        # Day of Ukrainian Statehood
+        if year >= 2022:
+            self[date(year, JUL, 28)] = "День Української Державності"
+
         # Independence Day
         name = "День незалежності України"
-        if year > 1991:
+        if year >= 1992:
             self[date(year, AUG, 24)] = name
         elif year == 1991:
             self[date(year, JUL, 16)] = name
@@ -90,15 +97,15 @@ class Ukraine(HolidayBase):
 
         # USSR Constitution day
         name = "День Конституції СРСР"
-        if 1981 <= year < 1991:
+        if 1981 <= year <= 1990:
             self[date(year, OCT, 7)] = name
-        elif 1937 <= year < 1981:
+        elif 1937 <= year <= 1980:
             self[date(year, DEC, 5)] = name
 
         # October Revolution
-        if 1917 < year < 2000:
+        if 1918 <= year <= 1999:
             if year <= 1991:
-                name = "Річниця Великої Жовтневої" " соціалістичної революції"
+                name = "Річниця Великої Жовтневої Соціалістичної Революції"
             else:
                 name = "Річниця жовтневого перевороту"
             self[date(year, NOV, 7)] = name
@@ -106,14 +113,15 @@ class Ukraine(HolidayBase):
 
         # Christmas Day (Catholic)
         if year >= 2017:
-            self[date(year, DEC, 25)] = "Різдво Христове" " (католицьке)"
+            self[date(year, DEC, 25)] = "Різдво Христове (католицьке)"
+
         # USSR holidays
         # Bloody_Sunday_(1905)
-        if 1917 <= year < 1951:
+        if 1917 <= year <= 1950:
             self[date(year, JAN, 22)] = "День пам'яті 9 січня 1905 року"
 
         # Paris_Commune
-        if 1917 < year < 1929:
+        if 1918 <= year <= 1928:
             self[date(year, MAR, 18)] = "День паризької комуни"
 
 

--- a/test/countries/test_ukraine.py
+++ b/test/countries/test_ukraine.py
@@ -27,13 +27,27 @@ class TestUkraine(unittest.TestCase):
         # http://www.buhoblik.org.ua/kadry-zarplata/vremya/1676-1676-kalendar.html
         self.assertIn(date(2018, 1, 1), self.holidays)
         self.assertIn(date(2018, 1, 7), self.holidays)
-        self.assertIn(date(2018, 12, 25), self.holidays)
+        self.assertIn(date(2018, 3, 8), self.holidays)
         self.assertIn(date(2018, 4, 8), self.holidays)
         self.assertIn(date(2018, 5, 27), self.holidays)
         self.assertIn(date(2018, 5, 9), self.holidays)
         self.assertIn(date(2018, 6, 28), self.holidays)
         self.assertIn(date(2018, 8, 24), self.holidays)
         self.assertIn(date(2018, 10, 14), self.holidays)
+        self.assertIn(date(2018, 12, 25), self.holidays)
+    
+    def test_2022(self):
+        self.assertIn(date(2022, 1, 1), self.holidays)
+        self.assertIn(date(2022, 1, 7), self.holidays)
+        self.assertIn(date(2022, 3, 8), self.holidays)
+        self.assertIn(date(2022, 4, 24), self.holidays)
+        self.assertIn(date(2022, 5, 9), self.holidays)
+        self.assertIn(date(2022, 6, 12), self.holidays)
+        self.assertIn(date(2022, 6, 28), self.holidays)
+        self.assertIn(date(2022, 7, 28), self.holidays)
+        self.assertIn(date(2022, 8, 24), self.holidays)
+        self.assertIn(date(2022, 10, 14), self.holidays)
+        self.assertIn(date(2022, 12, 25), self.holidays)
 
     def test_old_holidays(self):
         self.assertIn(date(2018, 5, 1), self.holidays)


### PR DESCRIPTION
  - Add Day of Ukrainian Statehood holiday.
  - Edit Victory Day name.
  - Fix formatting.
  - Update tests for Ukraine holidays.
  - Switch to <= and >= for consistency.
  - Rename Orthodox Easter.