### PR TITLE
Fixed Easter Dates for Bulgaria

### DIFF
--- a/holidays/countries/bulgaria.py
+++ b/holidays/countries/bulgaria.py
@@ -64,9 +64,6 @@ class Bulgaria(HolidayBase):
             date(year, MAY, 1)
         ] = "Ден на труда и на международната работническа солидарност"
 
-        # Resurrection Monday
-        self[date(year, MAY, 3)] = "Возкресенни понеделник"
-
         # Saint George's Day
         self[
             date(year, MAY, 6)
@@ -99,7 +96,9 @@ class Bulgaria(HolidayBase):
             easter(year, method=EASTER_ORTHODOX) - rd(days=1)
         ] = "Велика събота"
         self[easter(year, method=EASTER_ORTHODOX)] = "Великден"
-
+        self[
+            easter(year, method=EASTER_ORTHODOX) + rd(days=1)
+        ] = "Великден"
 
 class BG(Bulgaria):
     pass


### PR DESCRIPTION
Fixed the Easter dates.
In Bulgaria the days off are the Friday, Saturday, Sunday (Easter) and Monday.

Source: https://www.officeholidays.com/countries/bulgaria/2022

The removed line looks like a hardcoded post-Easter Monday in Russian, so it's not applicable.