### PR TITLE
Fix New Year observance for Saturdays.

### DIFF
--- a/holidays/financial/ny_stock_exchange.py
+++ b/holidays/financial/ny_stock_exchange.py
@@ -51,18 +51,16 @@ class NewYorkStockExchange(HolidayBase):
     def __init__(self, **kwargs):
         HolidayBase.__init__(self, **kwargs)
 
-    def _get_observed(self, d, always_post=False):
+    def _get_observed(self, d):
         wdnum = d.isoweekday()
-        if always_post and wdnum == 6:  # treat sat as sun
-            wdnum = 7
         if wdnum == 6:
             return d + rd(weekday=FR(-1))
         if wdnum == 7:
             return d + rd(weekday=MO(+1))
         return d
 
-    def _set_observed_date(self, date, name, always_post=False):
-        date_obs = self._get_observed(date, always_post=always_post)
+    def _set_observed_date(self, date, name):
+        date_obs = self._get_observed(date)
         if date_obs == date:
             self[date] = name
         else:
@@ -73,8 +71,13 @@ class NewYorkStockExchange(HolidayBase):
         # REGULAR HOLIDAYS
         ##############################################################
         # NYD
-        nyd = date(year, JAN, 1)
-        self._set_observed_date(nyd, "New Year's Day", always_post=True)
+        this_year_nye = date(year, DEC, 31)
+        if this_year_nye.isoweekday() == 5:  # check if NYE should be observed
+            self._set_observed_date(  # from Jan 1 next year.
+                this_year_nye + rd(days=+1), "New Year's Day"
+            )
+
+        self._set_observed_date(date(year, JAN, 1), "New Year's Day")
 
         # MLK - observed 1998 - 3rd Monday of Jan
         if year >= 1998:

--- a/holidays/financial/ny_stock_exchange.py
+++ b/holidays/financial/ny_stock_exchange.py
@@ -68,8 +68,8 @@ class NewYorkStockExchange(HolidayBase):
         self._set_observed_date(date(year, JAN, 1), "New Year's Day")
 
         # https://www.nyse.com/publicdocs/nyse/regulation/nyse/NYSE_Rules.pdf
-        # As per Rule 7.2.: check if next year's NYD falls on Saturday and needs
-        # to be observed on Friday (Dec 31 of previous year).
+        # As per Rule 7.2.: check if next year's NYD falls on Saturday and
+        # needs to be observed on Friday (Dec 31 of previous year).
         dec_31 = date(year, DEC, 31)
         if dec_31.isoweekday() == 5:
             self._set_observed_date(dec_31 + rd(days=+1), "New Year's Day")

--- a/holidays/financial/ny_stock_exchange.py
+++ b/holidays/financial/ny_stock_exchange.py
@@ -40,11 +40,9 @@ from holidays.holiday_base import HolidayBase
 
 class NewYorkStockExchange(HolidayBase):
     # https://www.nyse.com/markets/hours-calendars
-    # historical data:
+    # Historical data:
     # s3.amazonaws.com/armstrongeconomics-wp/2013/07/NYSE-Closings.pdf
-    # also available for 1901- at:
-    # nyseholidays.blogspot.com/2012/11/nyse-holidays-from-<year1>-<year2>.html
-    # where year1 ends in 01, year2 ends in 00 (e.g. 1901-1910)
+    # https://www.nyse.com/publicdocs/nyse/regulation/nyse/NYSE_Rules.pdf
 
     country = "NYSE"
 
@@ -70,14 +68,17 @@ class NewYorkStockExchange(HolidayBase):
         ##############################################################
         # REGULAR HOLIDAYS
         ##############################################################
-        # NYD
-        this_year_nye = date(year, DEC, 31)
-        if this_year_nye.isoweekday() == 5:  # check if NYE should be observed
-            self._set_observed_date(  # from Jan 1 next year.
-                this_year_nye + rd(days=+1), "New Year's Day"
-            )
 
+        # NYD
+        # This year's New Year Day.
         self._set_observed_date(date(year, JAN, 1), "New Year's Day")
+
+        # https://www.nyse.com/publicdocs/nyse/regulation/nyse/NYSE_Rules.pdf
+        # As per Rule 7.2.: check if next year's NYD falls on Saturday and needs
+        # to be observed on Friday (Dec 31 of previous year).
+        dec_31 = date(year, DEC, 31)
+        if dec_31.isoweekday() == 5:
+            self._set_observed_date(dec_31 + rd(days=+1), "New Year's Day")
 
         # MLK - observed 1998 - 3rd Monday of Jan
         if year >= 1998:

--- a/holidays/financial/ny_stock_exchange.py
+++ b/holidays/financial/ny_stock_exchange.py
@@ -12,37 +12,31 @@
 from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import (
-    relativedelta as rd,
-    MO,
-    TU,
-    TH,
-    FR,
-)
-
+from dateutil.relativedelta import FR, MO, TH, TU
+from dateutil.relativedelta import relativedelta as rd
 from holidays.constants import (
-    JAN,
-    FEB,
-    MAR,
     APR,
-    MAY,
-    JUN,
-    JUL,
     AUG,
-    SEP,
-    OCT,
-    NOV,
     DEC,
+    FEB,
+    JAN,
+    JUL,
+    JUN,
+    MAR,
+    MAY,
+    NOV,
+    OCT,
+    SEP,
 )
-
 from holidays.holiday_base import HolidayBase
 
 
 class NewYorkStockExchange(HolidayBase):
+    # Official regulations:
+    # https://www.nyse.com/publicdocs/nyse/regulation/nyse/NYSE_Rules.pdf
     # https://www.nyse.com/markets/hours-calendars
     # Historical data:
     # s3.amazonaws.com/armstrongeconomics-wp/2013/07/NYSE-Closings.pdf
-    # https://www.nyse.com/publicdocs/nyse/regulation/nyse/NYSE_Rules.pdf
 
     country = "NYSE"
 

--- a/test/financial/test_ny_stock_exchange.py
+++ b/test/financial/test_ny_stock_exchange.py
@@ -41,13 +41,14 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1930, JAN, 1),
             date(1950, JAN, 2),
             date(1999, JAN, 1),
-            date(2000, JAN, 3),
+            date(1999, DEC, 31),
+            date(2001, JAN, 1),
             date(2010, JAN, 1),
             date(2018, JAN, 1),
             date(2019, JAN, 1),
             date(2020, JAN, 1),
             date(2021, JAN, 1),
-            date(2022, JAN, 3),
+            date(2021, DEC, 31),
         ]:
             self.assertIn(dt, self.holidays)
             self.assertNotIn(dt + relativedelta(days=-1), self.holidays)

--- a/test/financial/test_ny_stock_exchange.py
+++ b/test/financial/test_ny_stock_exchange.py
@@ -42,13 +42,13 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1950, JAN, 2),
             date(1999, JAN, 1),
             date(1999, DEC, 31),
-            date(2001, JAN, 1),
             date(2010, JAN, 1),
             date(2018, JAN, 1),
             date(2019, JAN, 1),
             date(2020, JAN, 1),
             date(2021, JAN, 1),
             date(2021, DEC, 31),
+            date(2027, DEC, 31),
         ]:
             self.assertIn(dt, self.holidays)
             self.assertNotIn(dt + relativedelta(days=-1), self.holidays)


### PR DESCRIPTION
Resolves #693 

Fix New Year observance for Saturdays:
  - Make NYD observance complied with NYSE official regulations (Rule 7.2.).
  - Remove out of date comment URLs.
  - Simplify `_get_observed` method code.
  - Fix corner case for next year's Saturday NYD.
  - Add tests.