### PR TITLE
Add Australia National Day of Mourning and confirmed Grand Final Day date

### DIFF
--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -205,12 +205,17 @@ class Australia(HolidayBase):
             if year >= 2018:
                 self[date(year, 5, 27) + rd(weekday=MO)] = name
 
+        # National Day of Mourning for Queen Elizabeth II
+        name = "National Day of Mourning for Queen Elizabeth II"
+        if year == 2022:
+            self[date(year, SEP, 23)] = name
+
         if self.subdiv == "VIC":
             # Grand Final Day
             if year == 2022:
                 # Current planned grand final date.
                 # Could change at the dicression of the AFL
-                self[date(2022, 9, 23)] = "Grand Final Day"
+                self[date(2022, SEP, 24)] = "Grand Final Day"
             elif year == 2020:
                 # Rescheduled due to COVID-19
                 self[date(year, OCT, 23)] = "Grand Final Day"

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -213,8 +213,6 @@ class Australia(HolidayBase):
         if self.subdiv == "VIC":
             # Grand Final Day
             if year == 2022:
-                # Current planned grand final date.
-                # Could change at the dicression of the AFL
                 self[date(2022, SEP, 24)] = "Grand Final Day"
             elif year == 2020:
                 # Rescheduled due to COVID-19

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -208,12 +208,12 @@ class Australia(HolidayBase):
         # National Day of Mourning for Queen Elizabeth II
         name = "National Day of Mourning for Queen Elizabeth II"
         if year == 2022:
-            self[date(year, SEP, 23)] = name
+            self[date(year, SEP, 22)] = name
 
         if self.subdiv == "VIC":
             # Grand Final Day
             if year == 2022:
-                self[date(2022, SEP, 24)] = "Grand Final Day"
+                self[date(2022, SEP, 23)] = "Grand Final Day"
             elif year == 2020:
                 # Rescheduled due to COVID-19
                 self[date(year, OCT, 23)] = "Grand Final Day"

--- a/test/countries/test_australia.py
+++ b/test/countries/test_australia.py
@@ -272,7 +272,7 @@ class TestAU(unittest.TestCase):
             self.assertEqual(self.state_hols["ACT"][dt], "Reconciliation Day")
 
     def test_national_day_of_mourning_for_queen_elizabeth_II(self):
-        dt = date(2022, 9, 23)
+        dt = date(2022, 9, 22)
         for state in ["ACT", "NSW", "NT", "QLD", "SA", "TAS", "VIC", "WA"]:
             self.assertIn(dt, self.state_hols[state], (state, dt))
             self.assertEqual(
@@ -290,7 +290,7 @@ class TestAU(unittest.TestCase):
         dt_2020 = date(2020, 10, 23)
         dt_2020_old = date(2020, 9, 25)
         dt_2021 = date(2021, 9, 24)
-        dt_2022 = date(2022, 9, 24)
+        dt_2022 = date(2022, 9, 23)
         self.assertIn(dt, self.state_hols["VIC"], dt)
         self.assertEqual(self.state_hols["VIC"][dt], "Grand Final Day")
         self.assertIn(dt_2020, self.state_hols["VIC"], dt_2020)

--- a/test/countries/test_australia.py
+++ b/test/countries/test_australia.py
@@ -275,9 +275,15 @@ class TestAU(unittest.TestCase):
         dt = date(2022, 9, 23)
         for state in ["ACT", "NSW", "NT", "QLD", "SA", "TAS", "VIC", "WA"]:
             self.assertIn(dt, self.state_hols[state], (state, dt))
-            self.assertEqual(self.state_hols[state][dt], "National Day of Mourning for Queen Elizabeth II")
+            self.assertEqual(
+                self.state_hols[state][dt],
+                "National Day of Mourning for Queen Elizabeth II",
+            )
         self.assertIn(dt, self.holidays, dt)
-        self.assertEqual(self.holidays[dt], "National Day of Mourning for Queen Elizabeth II")
+        self.assertEqual(
+            self.holidays[dt],
+            "National Day of Mourning for Queen Elizabeth II",
+        )
 
     def test_grand_final_day(self):
         dt = date(2019, 9, 27)

--- a/test/countries/test_australia.py
+++ b/test/countries/test_australia.py
@@ -271,12 +271,20 @@ class TestAU(unittest.TestCase):
             self.assertIn(dt, self.state_hols["ACT"], dt)
             self.assertEqual(self.state_hols["ACT"][dt], "Reconciliation Day")
 
+    def test_national_day_of_mourning_for_queen_elizabeth_II(self):
+        dt = date(2022, 9, 23)
+        for state in ["ACT", "NSW", "NT", "QLD", "SA", "TAS", "VIC", "WA"]:
+            self.assertIn(dt, self.state_hols[state], (state, dt))
+            self.assertEqual(self.state_hols[state][dt], "National Day of Mourning for Queen Elizabeth II")
+        self.assertIn(dt, self.holidays, dt)
+        self.assertEqual(self.holidays[dt], "National Day of Mourning for Queen Elizabeth II")
+
     def test_grand_final_day(self):
         dt = date(2019, 9, 27)
         dt_2020 = date(2020, 10, 23)
         dt_2020_old = date(2020, 9, 25)
         dt_2021 = date(2021, 9, 24)
-        dt_2022 = date(2022, 9, 23)
+        dt_2022 = date(2022, 9, 24)
         self.assertIn(dt, self.state_hols["VIC"], dt)
         self.assertEqual(self.state_hols["VIC"][dt], "Grand Final Day")
         self.assertIn(dt_2020, self.state_hols["VIC"], dt_2020)


### PR DESCRIPTION
The Australian government has announced the 22rd of September 2022 will be a once-off public holiday to mourn the death of Queen Elizabeth II.
https://www.abc.net.au/news/2022-09-11/national-day-of-mourning-queen-death-to-be-public-holiday/101427050

The grand final day holiday is confirmed for the Friday 23rd so I've removed the comments stating it is still in question
https://www.afl.com.au/news/763512/afl-confirms-2022-toyota-grand-final-start-time

First time contributor so please let me know if I've made any missteps and I'll be more than happy to correct them.

