### PR TITLE
Add queen's funeral holidays for canada

### DIFF
--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -223,8 +223,13 @@ class Canada(HolidayBase):
         # Funeral of Queen Elizabeth II
         # https://www.narcity.com/provinces-territories-will-have-a-day-off-monday-mourn-queen
         # TODO: the territories holiday status (NT, NU, YT) is still preliminary
-        if self.subdiv in ("BC", "NB", "NL", "NS", "PE", "YT") and year == 2022:
-            self[date(year, SEP, 19)] = "Day of Mourning for the Funeral of Her Majesty the Queen Elizabeth II"
+        if (
+            self.subdiv in ("BC", "NB", "NL", "NS", "PE", "YT")
+            and year == 2022
+        ):
+            self[
+                date(year, SEP, 19)
+            ] = "Day of Mourning for the Funeral of Her Majesty the Queen Elizabeth II"
 
         # National Day for Truth and Reconciliation
         if self.subdiv in ("MB", "NS") and year >= 2021:

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -220,6 +220,12 @@ class Canada(HolidayBase):
         if year >= 1894:
             self[date(year, SEP, 1) + rd(weekday=MO)] = "Labour Day"
 
+        # Funeral of Queen Elizabeth II
+        # https://www.narcity.com/provinces-territories-will-have-a-day-off-monday-mourn-queen
+        # TODO: the territories holiday status (NT, NU, YT) is still preliminary
+        if self.subdiv in ("BC", "NB", "NL", "NS", "PE", "YT") and year == 2022:
+            self[date(year, SEP, 19)] = "Day of Mourning for the Funeral of Her Majesty the Queen Elizabeth II"
+
         # National Day for Truth and Reconciliation
         if self.subdiv in ("MB", "NS") and year >= 2021:
             self[

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -222,14 +222,11 @@ class Canada(HolidayBase):
 
         # Funeral of Queen Elizabeth II
         # https://www.narcity.com/provinces-territories-will-have-a-day-off-monday-mourn-queen
-        # TODO: the territories holiday status (NT, NU, YT) is still preliminary
-        if (
-            self.subdiv in ("BC", "NB", "NL", "NS", "PE", "YT")
-            and year == 2022
-        ):
-            self[
-                date(year, SEP, 19)
-            ] = "Day of Mourning for the Funeral of Her Majesty the Queen Elizabeth II"
+        # TODO: the territories holiday status (NT, NU, YT) is still tentative
+        queen_funeral_observers = ("BC", "NB", "NL", "NS", "PE", "YT")
+        if self.subdiv in queen_funeral_observers and year == 2022:
+            holiday_name = "Funeral of Her Majesty the Queen Elizabeth II"
+            self[date(year, SEP, 19)] = holiday_name
 
         # National Day for Truth and Reconciliation
         if self.subdiv in ("MB", "NS") and year >= 2021:

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -371,22 +371,12 @@ class TestCA(unittest.TestCase):
     def test_queens_funeral(self):
         queen_funeral_year = 2022
         queen_funeral = date(queen_funeral_year, 9, 19)
-        subdivisions_following_queen_funeral = (
-            "BC",
-            "NB",
-            "NL",
-            "NS",
-            "PE",
-            "YT",
-        )
+        observers = ("BC", "NB", "NL", "NS", "PE", "YT")
 
-        for subdivision in holidays.Canada.subdivisions:
-            holidays_canada = holidays.CA(subdiv=subdivision)
+        for subdiv in holidays.Canada.subdivisions:
+            holidays_canada = holidays.CA(subdiv=subdiv)
             for year in range(1900, 2100):
-                if (
-                    year == queen_funeral_year
-                    and subdivision in subdivisions_following_queen_funeral
-                ):
-                    self.assertIn(queen_funeral, holidays_canada)
+                if year == queen_funeral_year and subdiv in observers:
+                    self.assertIn(queen_funeral, holidays_canada, subdiv)
                 else:
-                    self.assertNotIn(queen_funeral, holidays_canada)
+                    self.assertNotIn(queen_funeral, holidays_canada, subdiv)

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -371,12 +371,22 @@ class TestCA(unittest.TestCase):
     def test_queens_funeral(self):
         queen_funeral_year = 2022
         queen_funeral = date(queen_funeral_year, 9, 19)
-        subdivisions_following_queen_funeral = ("BC", "NB", "NL", "NS", "PE", "YT")
+        subdivisions_following_queen_funeral = (
+            "BC",
+            "NB",
+            "NL",
+            "NS",
+            "PE",
+            "YT",
+        )
 
         for subdivision in holidays.Canada.subdivisions:
             holidays_canada = holidays.CA(subdiv=subdivision)
             for year in range(1900, 2100):
-                if year == queen_funeral_year and subdivision in subdivisions_following_queen_funeral:
+                if (
+                    year == queen_funeral_year
+                    and subdivision in subdivisions_following_queen_funeral
+                ):
                     self.assertIn(queen_funeral, holidays_canada)
                 else:
                     self.assertNotIn(queen_funeral, holidays_canada)

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -369,14 +369,15 @@ class TestCA(unittest.TestCase):
         self.assertIn(date(2010, 12, 27), self.holidays)
 
     def test_queens_funeral(self):
-        queen_funeral_year = 2022
-        queen_funeral = date(queen_funeral_year, 9, 19)
-        observers = ("BC", "NB", "NL", "NS", "PE", "YT")
+        queen_funeral = date(2022, 9, 19)
 
-        for subdiv in holidays.Canada.subdivisions:
-            holidays_canada = holidays.CA(subdiv=subdiv)
-            for year in range(1900, 2100):
-                if year == queen_funeral_year and subdiv in observers:
-                    self.assertIn(queen_funeral, holidays_canada, subdiv)
+        for year in range(1900, 2100):
+            for subdiv in ("BC", "NB", "NL", "NS", "PE", "YT"):
+                subdiv_holidays = holidays.CA(subdiv=subdiv)
+                if year == 2022:
+                    self.assertIn(queen_funeral, subdiv_holidays, subdiv)
                 else:
-                    self.assertNotIn(queen_funeral, holidays_canada, subdiv)
+                    self.assertNotIn(queen_funeral, subdiv_holidays, subdiv)
+            for subdiv in ("AB", "MB", "NT", "NU", "ON", "QC", "SK"):
+                subdiv_holidays = holidays.CA(subdiv=subdiv)
+                self.assertNotIn(queen_funeral, subdiv_holidays, subdiv)

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -369,16 +369,11 @@ class TestCA(unittest.TestCase):
         self.assertIn(date(2010, 12, 27), self.holidays)
 
     def test_queens_funeral(self):
-        queen_funeral_year = 2022
-        queen_funeral = date(queen_funeral_year, 9, 19)
         observers = ("BC", "NB", "NL", "NS", "PE", "YT")
-
         for subdiv in holidays.CA.subdivisions:
             holidays_canada = holidays.CA(subdiv=subdiv)
             for year in range(1900, 2100):
-                err_msg = f"{subdiv} {year} {year == queen_funeral_year}"
-                err_msg += f" {subdiv in observers}"
-                if year == queen_funeral_year and subdiv in observers:
-                    self.assertIn(queen_funeral, holidays_canada, err_msg)
+                if year == 2022 and subdiv in observers:
+                    self.assertIn(date(year, 9, 19), holidays_canada)
                 else:
-                    self.assertNotIn(queen_funeral, holidays_canada, err_msg)
+                    self.assertNotIn(date(year, 9, 19), holidays_canada)

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -367,3 +367,16 @@ class TestCA(unittest.TestCase):
         self.holidays.observed = True
         self.assertIn(date(2009, 12, 28), self.holidays)
         self.assertIn(date(2010, 12, 27), self.holidays)
+
+    def test_queens_funeral(self):
+        queen_funeral_year = 2022
+        queen_funeral = date(queen_funeral_year, 9, 19)
+        subdivisions_following_queen_funeral = ("BC", "NB", "NL", "NS", "PE", "YT")
+
+        for subdivision in holidays.Canada.subdivisions:
+            holidays_canada = holidays.CA(subdiv=subdivision)
+            for year in range(1900, 2100):
+                if year == queen_funeral_year and subdivision in subdivisions_following_queen_funeral:
+                    self.assertIn(queen_funeral, holidays_canada)
+                else:
+                    self.assertNotIn(queen_funeral, holidays_canada)

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -369,15 +369,16 @@ class TestCA(unittest.TestCase):
         self.assertIn(date(2010, 12, 27), self.holidays)
 
     def test_queens_funeral(self):
-        queen_funeral = date(2022, 9, 19)
+        queen_funeral_year = 2022
+        queen_funeral = date(queen_funeral_year, 9, 19)
+        observers = ("BC", "NB", "NL", "NS", "PE", "YT")
 
-        for year in range(1900, 2100):
-            for subdiv in ("BC", "NB", "NL", "NS", "PE", "YT"):
-                subdiv_holidays = holidays.CA(subdiv=subdiv)
-                if year == 2022:
-                    self.assertIn(queen_funeral, subdiv_holidays, subdiv)
+        for subdiv in holidays.CA.subdivisions:
+            holidays_canada = holidays.CA(subdiv=subdiv)
+            for year in range(1900, 2100):
+                err_msg = f"{subdiv} {year} {year == queen_funeral_year}"
+                err_msg += f" {subdiv in observers}"
+                if year == queen_funeral_year and subdiv in observers:
+                    self.assertIn(queen_funeral, holidays_canada, err_msg)
                 else:
-                    self.assertNotIn(queen_funeral, subdiv_holidays, subdiv)
-            for subdiv in ("AB", "MB", "NT", "NU", "ON", "QC", "SK"):
-                subdiv_holidays = holidays.CA(subdiv=subdiv)
-                self.assertNotIn(queen_funeral, subdiv_holidays, subdiv)
+                    self.assertNotIn(queen_funeral, holidays_canada, err_msg)


### PR DESCRIPTION
The queen's funeral will be a holiday federally and in some provinces and territories. However, the default is ON and not federal so the federal holiday logic isn't here.