### PR TITLE
Sort holiday names.

### DIFF
--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -349,11 +349,12 @@ class HolidayBase(Dict[date, str]):
 
     def __setitem__(self, key: DateLike, value: str) -> None:
         if key in self:
-            if self.get(key).find(value) < 0 and value.find(self.get(key)) < 0:
-                value = f"{value}, {self.get(key)}"
-            else:
-                value = self.get(key)
-        return dict.__setitem__(self, self.__keytransform__(key), value)
+            delimiter = ", "
+            holiday_names = set(self.get(key).split(delimiter))
+            holiday_names.add(value)
+            value = delimiter.join(sorted(holiday_names))
+
+        dict.__setitem__(self, self.__keytransform__(key), value)
 
     def update(  # type: ignore[override]
         self, *args: Union[Dict[DateLike, str], List[DateLike], DateLike]

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -349,6 +349,8 @@ class HolidayBase(Dict[date, str]):
 
     def __setitem__(self, key: DateLike, value: str) -> None:
         if key in self:
+            # If there are multiple holidays on the same date
+            # order their names alphabetically.
             delimiter = ", "
             holiday_names = set(self.get(key).split(delimiter))
             holiday_names.add(value)

--- a/test/countries/test_brazil.py
+++ b/test/countries/test_brazil.py
@@ -282,7 +282,7 @@ class TestBrazil(unittest.TestCase):
         to_holidays = holidays.BR(subdiv="TO")
         self.assertIn("2018-01-01", to_holidays)
         self.assertEqual(
-            to_holidays[date(2018, 1, 1)], "Instalação de Tocantins, Ano novo"
+            to_holidays[date(2018, 1, 1)], "Ano novo, Instalação de Tocantins"
         )
         self.assertIn("2018-09-08", to_holidays)
         self.assertEqual(

--- a/test/test_holiday_base.py
+++ b/test/test_holiday_base.py
@@ -13,11 +13,10 @@ import pickle
 import sys
 import unittest
 import warnings
-
 from datetime import date, datetime, timedelta
-from dateutil.relativedelta import relativedelta, MO
 
 import holidays
+from dateutil.relativedelta import MO, relativedelta
 
 
 class TestBasics(unittest.TestCase):
@@ -261,7 +260,7 @@ class TestBasics(unittest.TestCase):
         )
         na = holidays.MX() + holidays.CA() + holidays.US()
         self.assertEqual(
-            na.get(date(1969, 12, 25)), "Navidad [Christmas], Christmas Day"
+            na.get(date(1969, 12, 25)), "Christmas Day, Navidad [Christmas]"
         )
 
     def test_get_list(self):
@@ -270,12 +269,12 @@ class TestBasics(unittest.TestCase):
         wild = westland + chathams
         self.assertEqual(
             wild[date(1969, 12, 1)],
-            ("West Coast Anniversary Day, Chatham Islands Anniversary Day"),
+            ("Chatham Islands Anniversary Day, West Coast Anniversary Day"),
         )
 
         self.assertEqual(
             wild.get_list(date(1969, 12, 1)),
-            ["West Coast Anniversary Day", "Chatham Islands Anniversary Day"],
+            ["Chatham Islands Anniversary Day", "West Coast Anniversary Day"],
         )
         self.assertEqual(wild.get_list(date(1969, 1, 1)), ["New Year's Day"])
         self.assertEqual(


### PR DESCRIPTION
Resolves #705 
Order holidays by name when there are multiple holidays on the same date.