### PR TITLE
Rename Eswatini from Swaziland

### DIFF
--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -89,7 +89,7 @@ from .slovakia import Slovakia, SK, SVK
 from .slovenia import Slovenia, SI, SVN
 from .south_africa import SouthAfrica, ZA, ZAF
 from .spain import Spain, ES, ESP
-from .eswatini import Swaziland, SZ, SZW
+from .eswatini import Eswatini, Swaziland, SZ, SZW
 from .sweden import Sweden, SE, SWE
 from .switzerland import Switzerland, CH, CHE
 from .taiwan import Taiwan, TW, TWN

--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -89,7 +89,7 @@ from .slovakia import Slovakia, SK, SVK
 from .slovenia import Slovenia, SI, SVN
 from .south_africa import SouthAfrica, ZA, ZAF
 from .spain import Spain, ES, ESP
-from .swaziland import Swaziland, SZ, SZW
+from .eswatini import Swaziland, SZ, SZW
 from .sweden import Sweden, SE, SWE
 from .switzerland import Switzerland, CH, CHE
 from .taiwan import Taiwan, TW, TWN

--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -36,8 +36,8 @@ from .denmark import Denmark, DK, DNK
 from .djibouti import Djibouti, DJ, DJI
 from .dominican_republic import DominicanRepublic, DO, DOM
 from .egypt import Egypt, EG, EGY
-from .eswatini import Eswatini, Swaziland, SZ, SZW
 from .estonia import Estonia, EE, EST
+from .eswatini import Eswatini, Swaziland, SZ, SZW
 from .ethiopia import Ethiopia, ET, ETH
 from .finland import Finland, FI, FIN
 from .france import France, FR, FRA

--- a/holidays/countries/__init__.py
+++ b/holidays/countries/__init__.py
@@ -36,6 +36,7 @@ from .denmark import Denmark, DK, DNK
 from .djibouti import Djibouti, DJ, DJI
 from .dominican_republic import DominicanRepublic, DO, DOM
 from .egypt import Egypt, EG, EGY
+from .eswatini import Eswatini, Swaziland, SZ, SZW
 from .estonia import Estonia, EE, EST
 from .ethiopia import Ethiopia, ET, ETH
 from .finland import Finland, FI, FIN
@@ -89,7 +90,6 @@ from .slovakia import Slovakia, SK, SVK
 from .slovenia import Slovenia, SI, SVN
 from .south_africa import SouthAfrica, ZA, ZAF
 from .spain import Spain, ES, ESP
-from .eswatini import Eswatini, Swaziland, SZ, SZW
 from .sweden import Sweden, SE, SWE
 from .switzerland import Switzerland, CH, CHE
 from .taiwan import Taiwan, TW, TWN

--- a/holidays/countries/eswatini.py
+++ b/holidays/countries/eswatini.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime
+from datetime import date
 
 from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd
@@ -19,7 +19,7 @@ from holidays.constants import JAN, APR, MAY, JUL, SEP, DEC
 from holidays.holiday_base import HolidayBase
 
 
-class Swaziland(HolidayBase):
+class Eswatini(HolidayBase):
     country = "SZ"
 
     def __init__(self, **kwargs):
@@ -77,9 +77,14 @@ class Swaziland(HolidayBase):
                     self[k + rd(days=add_days)] = v + " (Day Off)"
 
 
-class SZ(Swaziland):
+class Swaziland(Eswatini):
+    # Old country name.
     pass
 
 
-class SZW(Swaziland):
+class SZ(Eswatini):
+    pass
+
+
+class SZW(Eswatini):
     pass

--- a/test/countries/test_eswatini.py
+++ b/test/countries/test_eswatini.py
@@ -16,7 +16,7 @@ from datetime import date
 import holidays
 
 
-class TestSwaziland(unittest.TestCase):
+class TestEswatini(unittest.TestCase):
     def setUp(self):
         self.holidays = holidays.SZ()
 


### PR DESCRIPTION
This country has a different name now (but keep it backwards-compatible).