### PR TITLE
Fixed incorrect subdivision code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,7 +162,7 @@ following countries and their subdivisions are available:
      - None
    * - Canada
      - CA
-     - Provinces and territories: AB, BC, MB, NB, NL, NS NT, NU, **ON** (default), PE, QC, SK, YU
+     - Provinces and territories: AB, BC, MB, NB, NL, NS NT, NU, **ON** (default), PE, QC, SK, YT
    * - Chile
      - CL
      - Regions: AI, AN, AP, AR, AT, BI, CO, LI, LL, LR, MA, ML, NB, RM, TA, VS


### PR DESCRIPTION
Looks like the docs have a typo for the Yukon Territory (YU should be YT). In the code this seems to be correct.

https://en.wikipedia.org/wiki/ISO_3166-2:CA