### PR TITLE
Remove not available --update option when installing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ The latest stable version can always be installed or updated via pip:
 
 .. code-block:: bash
 
-    $ pip install --update holidays
+    $ pip install holidays
 
 
 Documentation


### PR DESCRIPTION
$pip install --update holidays

Usage:   
  pip install [options] <requirement specifier> [package-index-options] ...
  pip install [options] -r <requirements file> [package-index-options] ...
  pip install [options] [-e] <vcs project url> ...
  pip install [options] [-e] <local project path> ...
  pip install [options] <archive url/path> ...

no such option: --update