### PR TITLE
README.rst: Remove Alpha-3 code for Bosnia and Herzegovina

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -150,7 +150,6 @@ following countries and their subdivisions are available:
      - Departments: B, C, H, L, N, O, P, S, T
    * - Bosnia and Herzegovina
      - BA
-     - BIH
      - Departments: FBiH, RS, BD
    * - Botswana
      - BW


### PR DESCRIPTION
Adding an extra entry like the Alpha-3 code in the countries table causes render failure
By removing this line, the table is displayed correctly.