### PR TITLE
brazil.py: Update SC holiday according 2017 law

### DIFF
--- a/holidays/countries/brazil.py
+++ b/holidays/countries/brazil.py
@@ -12,21 +12,22 @@
 from datetime import date
 
 from dateutil.easter import easter
+from dateutil.relativedelta import SU, TU
 from dateutil.relativedelta import relativedelta as rd
-from dateutil.relativedelta import TU
 
 from holidays.constants import (
-    JAN,
-    MAR,
     APR,
-    MAY,
-    JUN,
-    JUL,
     AUG,
-    SEP,
-    OCT,
-    NOV,
     DEC,
+    JAN,
+    JUL,
+    JUN,
+    MAR,
+    MAY,
+    NOV,
+    OCT,
+    SEP,
+    WEEKEND,
 )
 from holidays.holiday_base import HolidayBase
 
@@ -198,9 +199,10 @@ class Brazil(HolidayBase):
             self[date(year, OCT, 5)] = "Criação de Roraima"
 
         if self.subdiv == "SC":
-            self[date(year, AUG, 11)] = (
-                "Criação da capitania," " separando-se de SP"
-            )
+            dt = date(year, AUG, 11)
+            if year >= 2018 and dt.weekday() not in WEEKEND:
+                dt += rd(weekday=SU)
+            self[dt] = "Criação da capitania, separando-se de SP"
 
         if self.subdiv == "SP":
             self[date(year, JUL, 9)] = "Revolução Constitucionalista de 1932"

--- a/test/countries/test_brazil.py
+++ b/test/countries/test_brazil.py
@@ -255,11 +255,22 @@ class TestBrazil(unittest.TestCase):
         self.assertEqual(rr_holidays[date(2018, 10, 5)], "Criação de Roraima")
 
     def test_SC_holidays(self):
+        name = "Criação da capitania, separando-se de SP"
         sc_holidays = holidays.BR(subdiv="SC")
         self.assertIn("2018-08-11", sc_holidays)
         self.assertEqual(
             sc_holidays[date(2018, 8, 11)],
-            "Criação da capitania, separando-se de SP",
+            name,
+        )
+        self.assertIn("2017-08-11", sc_holidays)
+        self.assertEqual(
+            sc_holidays[date(2017, 8, 11)],
+            name,
+        )
+        self.assertIn(date(2021, 8, 15), sc_holidays)
+        self.assertEqual(
+            sc_holidays[date(2021, 8, 15)],
+            name,
         )
 
     def test_SP_holidays(self):


### PR DESCRIPTION
From 2017 onwards if the 11th of August falls on a work day the holiday is moved to the next Sunday.

Issue: 592