### PR TITLE
lithuania: add the 2nd on November as holiday

### DIFF
--- a/holidays/countries/lithuania.py
+++ b/holidays/countries/lithuania.py
@@ -80,6 +80,10 @@ class Lithuania(HolidayBase):
         # All Saints' Day
         self[date(year, 11, 1)] = "Visų šventųjų diena (Vėlinės)"
 
+        # All Souls' Day
+        if year >= 2020:
+            self[date(year, 11, 2)] = "Mirusiųjų atminimo diena (Vėlinės)"
+
         # Christmas Eve
         self[date(year, 12, 24)] = "Šv. Kūčios"
 

--- a/test/countries/test_lithuania.py
+++ b/test/countries/test_lithuania.py
@@ -82,3 +82,7 @@ class TestLithuania(unittest.TestCase):
 
         self.assertNotIn(date(1990, 7, 6), self.holidays)
         self.assertIn(date(1991, 7, 6), self.holidays)
+
+    def test_all_souls_day(self):
+        self.assertNotIn(date(2018, 11, 2), self.holidays)
+        self.assertIn(date(2021, 11, 2), self.holidays)


### PR DESCRIPTION
2nd of November is a holiday in Lithuania (https://publicholidays.lt/2022-dates/)
issue-774