### PR TITLE
Special holidays migration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,8 +17,8 @@ repos:
       - id: black
         language_version: python3
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
       - id: flake8
         args: [--max-line-length=79]
@@ -30,7 +30,7 @@ repos:
         exclude: ^docs/
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.990'
+    rev: 'v0.991'
     hooks:
       - id: mypy
         additional_dependencies: [types-all]

--- a/holidays/countries/botswana.py
+++ b/holidays/countries/botswana.py
@@ -28,6 +28,7 @@ class Botswana(HolidayBase):
     """
 
     country = "BW"
+    special_holidays = {2019: ((JUL, 2, "Public Holiday"),)}
 
     def _populate(self, year: int):
         super()._populate(year)
@@ -96,10 +97,6 @@ class Botswana(HolidayBase):
                 for i in self.get(k).split(","):
                     if " (Observed)" not in i:
                         self[k + rd(days=1)] = i.lstrip() + " (Observed)"
-
-        # Once off ad-hoc holiday.
-        if year == 2019:
-            self[date(year, JUL, 2)] = "Public Holiday"
 
 
 class BW(Botswana):

--- a/holidays/countries/eswatini.py
+++ b/holidays/countries/eswatini.py
@@ -26,6 +26,11 @@ class Eswatini(HolidayBase):
     """
 
     country = "SZ"
+    special_holidays = {
+        # https://mg.co.za/article/1999-12-09-swaziland-declares-bank-holidays/
+        1999: ((DEC, 31, "Y2K changeover"),),
+        2000: ((JAN, 3, "Y2K changeover"),),
+    }
 
     def _populate(self, year):
         super()._populate(year)
@@ -57,15 +62,6 @@ class Eswatini(HolidayBase):
             self[date(year, SEP, 6)] = "Independence Day"
             self[date(year, DEC, 25)] = "Christmas Day"
             self[date(year, DEC, 26)] = "Boxing Day"
-
-            # Once-off public holidays
-            y2k = "Y2K changeover"
-
-            if year == 1999:
-                # https://mg.co.za/article/1999-12-09-swaziland-declares-bank-holidays/
-                self[date(1999, DEC, 31)] = y2k
-            if year == 2000:
-                self[date(2000, JAN, 3)] = y2k
 
             # As of 2021/1/1, whenever a public holiday falls on a
             # Sunday

--- a/holidays/countries/hongkong.py
+++ b/holidays/countries/hongkong.py
@@ -42,6 +42,19 @@ class HongKong(HolidayBase):
     """
 
     country = "HK"
+    special_holidays = {
+        # Special holiday on 2015 - The 70th anniversary day of the victory
+        # of the Chinese people's war of resistance against Japanese
+        # aggression.
+        2015: (
+            (
+                SEP,
+                3,
+                "The 70th anniversary day of the victory of the Chinese "
+                "people's war of resistance against Japanese aggression",
+            ),
+        ),
+    }
 
     def __init__(self, **kwargs):
         self.cnls = _ChineseLuniSolar()
@@ -185,15 +198,6 @@ class HongKong(HolidayBase):
                 self[hksar_date] = name
         else:
             self[hksar_date] = name
-
-        # Special holiday on 2015 - The 70th anniversary day of the victory
-        # of the Chinese people's war of resistance against Japanese aggression
-        name = (
-            "The 70th anniversary day of the victory of the Chinese "
-            + "people's war of resistance against Japanese aggression"
-        )
-        if year == 2015:
-            self[date(year, SEP, 3)] = name
 
         # Chinese Mid-Autumn Festival
         name = "Chinese Mid-Autumn Festival"

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -37,6 +37,9 @@ class Ireland(HolidayBase):
     """
 
     country = "IE"
+    special_holidays = {
+        2022: ((MAR, 18, "Day of Remembrance and Recognition"),)
+    }
 
     def _populate(self, year):
         super()._populate(year)
@@ -50,10 +53,6 @@ class Ireland(HolidayBase):
             self[dt] = name
             if self.observed and dt.weekday() != FRI:
                 self[dt + rd(weekday=MO)] = name + " (Observed)"
-
-        # One-off day of rememberance and recognition
-        if year == 2022:
-            self[date(year, MAR, 18)] = "Day of Rememberance and Recognition"
 
         # St. Patrick's Day
         name = "St. Patrick's Day"

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -37,6 +37,9 @@ class Japan(HolidayBase):
     """
 
     country = "JP"
+    special_holidays = {
+        1989: ((FEB, 24, "大喪の礼"),),  # State Funeral of Emperor Shōwa.
+    }
 
     def _populate(self, year):
         super()._populate(year)
@@ -71,10 +74,6 @@ class Japan(HolidayBase):
             self[date(year, APR, 29)] = "みどりの日"
         else:
             self[date(year, APR, 29)] = "昭和の日"
-
-        # State Funeral of Emperor Shōwa
-        if year == 1989:
-            self[date(year, FEB, 24)] = "大喪の礼"
 
         # Constitution Memorial Day
         self[date(year, MAY, 3)] = "憲法記念日"
@@ -212,11 +211,9 @@ class Japan(HolidayBase):
 
         if year in (2032, 2049, 2060, 2077, 2088, 2094):
             self[date(year, SEP, 21)] = "国民の休日"
-
-        if year in (2009, 2015, 2026, 2037, 2043, 2054, 2065, 2071, 2099):
+        elif year in (2009, 2015, 2026, 2037, 2043, 2054, 2065, 2071, 2099):
             self[date(year, SEP, 22)] = "国民の休日"
-
-        if year == 2019:
+        elif year == 2019:
             self[date(year, APR, 30)] = "国民の休日"
             self[date(year, MAY, 2)] = "国民の休日"
 

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -38,14 +38,21 @@ class Japan(HolidayBase):
 
     country = "JP"
     special_holidays = {
+        1959: ((APR, 10, "結婚の儀"),),  # The Crown Prince marriage ceremony.
         1989: ((FEB, 24, "大喪の礼"),),  # State Funeral of Emperor Shōwa.
+        1990: ((NOV, 12, "即位礼正殿の儀"),),  # Enthronement ceremony.
+        1993: ((JUN, 9, "結婚の儀"),),  # The Crown Prince marriage ceremony.
+        2019: (
+            (MAY, 1, "天皇の即位の日"),  # Enthronement day.
+            (OCT, 22, "即位礼正殿の儀が行われる日"),  # Enthronement ceremony.
+        ),
     }
 
     def _populate(self, year):
-        super()._populate(year)
-
         if year < 1949 or year > 2099:
             raise NotImplementedError
+
+        super()._populate(year)
 
         # New Year's Day
         self[date(year, JAN, 1)] = "元日"
@@ -131,26 +138,9 @@ class Japan(HolidayBase):
         self[date(year, NOV, 23)] = "勤労感謝の日"
 
         # Regarding the Emperor of Heisei
-        if year == 1959:
-            # Marriage ceremony
-            self[date(year, APR, 10)] = "結婚の儀"
         if 1989 <= year <= 2018:
             # Heisei Emperor's Birthday
             self[date(year, DEC, 23)] = "天皇誕生日"
-
-            if year == 1990:
-                # Enthronement ceremony
-                self[date(year, NOV, 12)] = "即位礼正殿の儀"
-
-        # Regarding the Emperor of Reiwa
-        if year == 1993:
-            # Marriage ceremony
-            self[date(year, JUN, 9)] = "結婚の儀"
-        elif year == 2019:
-            # Enthronement Day
-            self[date(year, MAY, 1)] = "天皇の即位の日"
-            # Enthronement ceremony
-            self[date(year, OCT, 22)] = "即位礼正殿の儀が行われる日"
 
         # A weekday between national holidays becomes a holiday too (国民の休日)
         self._add_national_holidays(year)

--- a/holidays/countries/korea.py
+++ b/holidays/countries/korea.py
@@ -50,6 +50,11 @@ class Korea(HolidayBase):
     """
 
     country = "KR"
+    special_holidays = {
+        # Just for year 2020 - since 2020.08.15 is Sat, the government
+        # decided to make 2020.08.17 holiday, yay
+        2020: ((AUG, 17, "Alternative public holiday"),)
+    }
 
     def __init__(self, **kwargs):
         self.korean_cal = KoreanLunarCalendar()
@@ -218,13 +223,6 @@ class Korea(HolidayBase):
         name = "Christmas Day"
         christmas_date = date(year, DEC, 25)
         self[christmas_date] = name
-
-        # Just for year 2020 - since 2020.08.15 is Sat, the government
-        # decided to make 2020.08.17 holiday, yay
-        if year == 2020:
-            name = "Alternative public holiday"
-            alt_date = date(2020, AUG, 17)
-            self[alt_date] = name
 
     # convert lunar calendar date to solar
     def get_solar_date(self, year: int, month: int, day: int) -> date:

--- a/holidays/countries/lesotho.py
+++ b/holidays/countries/lesotho.py
@@ -24,6 +24,10 @@ class Lesotho(HolidayBase):
     """
 
     country = "LS"
+    special_holidays = {
+        # https://tinyurl.com/lesothourl
+        2002: ((APR, 4, "Heroes Day"), (MAY, 25, "Africa Day"))
+    }
 
     def _populate(self, year):
         super()._populate(year)
@@ -32,11 +36,6 @@ class Lesotho(HolidayBase):
             # https://www.ilo.org/dyn/travail/docs/2093/Public%20Holidays%20Act%201995.pdf
             self[date(year, JAN, 1)] = "New Year's Day"
             self[date(year, MAR, 11)] = "Moshoeshoe's Day"
-
-            if year == 2002:
-                # https://tinyurl.com/lesothourl
-                self[date(year, APR, 4)] = "Heroes Day"
-                self[date(year, MAY, 25)] = "Africa Day"
 
             if year < 2002:
                 self[date(year, APR, 4)] = "Heroes Day"

--- a/holidays/countries/malaysia.py
+++ b/holidays/countries/malaysia.py
@@ -38,6 +38,11 @@ from holidays.utils import _ChineseLuniSolar, _islamic_to_gre
 
 class Malaysia(HolidayBase):
     country = "MY"
+    special_holidays = {
+        1999: ((NOV, 29, "Malaysia General Election Holiday"),),
+        2018: ((MAY, 9, "Malaysia General Election Holiday"),),
+    }
+
     subdivisions = [
         "JHR",
         "KDH",
@@ -368,19 +373,6 @@ class Malaysia(HolidayBase):
         # ------------------------------#
         # Other holidays (decrees etc.) #
         # ------------------------------#
-
-        # Malaysia General Election Holiday.
-        dates_obs = {
-            # The years 1955 1959 1995 seems to have the elections
-            # one weekday but I am not sure if they were marked as
-            # holidays.
-            1999: (NOV, 29),
-            2018: (MAY, 9),
-        }
-        if year in dates_obs:
-            self[
-                date(year, *dates_obs[year])
-            ] = "Malaysia General Election Holiday"
 
         # Awal Muharram.
         for hol_date in self.my_islamic_to_gre(year, 1, 1):

--- a/holidays/countries/namibia.py
+++ b/holidays/countries/namibia.py
@@ -26,6 +26,11 @@ class Namibia(HolidayBase):
     """
 
     country = "NA"
+    special_holidays = {
+        # https://gazettes.africa/archive/na/1999/na-government-gazette-dated-1999-11-22-no-2234.pdf
+        1999: ((DEC, 31, "Y2K changeover"),),
+        2000: ((JAN, 3, "Y2K changeover"),),
+    }
 
     def _populate(self, year):
         super()._populate(year)
@@ -49,14 +54,6 @@ class Namibia(HolidayBase):
             self[date(year, MAY, 4)] = "Cassinga Day"
             self[date(year, MAY, 25)] = "Africa Day"
             self[date(year, AUG, 26)] = "Heroes' Day"
-
-            # Once-off public holidays
-            y2k = "Y2K changeover"
-            if year == 1999:
-                # https://gazettes.africa/archive/na/1999/na-government-gazette-dated-1999-11-22-no-2234.pdf
-                self[date(1999, DEC, 31)] = y2k
-            if year == 2000:
-                self[date(2000, JAN, 3)] = y2k
 
             if year > 2004:
                 # http://www.lac.org.na/laws/2004/3348.pdf

--- a/holidays/countries/poland.py
+++ b/holidays/countries/poland.py
@@ -25,6 +25,9 @@ class Poland(HolidayBase):
     """
 
     country = "PL"
+    special_holidays = {
+        2018: ((NOV, 12, "Narodowe Święto Niepodległości - 100-lecie"),)
+    }
 
     def _populate(self, year):
         super()._populate(year)
@@ -50,9 +53,6 @@ class Poland(HolidayBase):
         self[date(year, NOV, 1)] = "Uroczystość Wszystkich Świętych"
         if (1937 <= year <= 1945) or year >= 1989:
             self[date(year, NOV, 11)] = "Narodowe Święto Niepodległości"
-        if year == 2018:
-            name = "Narodowe Święto Niepodległości - 100-lecie"
-            self[date(year, NOV, 12)] = name
 
         self[date(year, DEC, 25)] = "Boże Narodzenie (pierwszy dzień)"
         self[date(year, DEC, 26)] = "Boże Narodzenie (drugi dzień)"

--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -38,10 +38,17 @@ from holidays.utils import _ChineseLuniSolar, _islamic_to_gre
 class Singapore(HolidayBase):
     country = "SG"
     special_holidays = {
-        # SG50 Public holiday
-        # Announced on 14 March 2015
-        # https://www.mom.gov.sg/newsroom/press-releases/2015/sg50-public-holiday-on-7-august-2015
-        2015: ((AUG, 7, "SG50 Public Holiday"),)
+        2001: ((NOV, 3, "Polling Day"),),
+        2006: ((MAY, 6, "Polling Day"),),
+        2011: ((MAY, 7, "Polling Day"),),
+        2015: (
+            # SG50 Public holiday
+            # Announced on 14 March 2015
+            # https://www.mom.gov.sg/newsroom/press-releases/2015/sg50-public-holiday-on-7-august-2015
+            (AUG, 7, "SG50 Public Holiday"),
+            (SEP, 11, "Polling Day"),
+        ),
+        2020: ((JUL, 10, "Polling Day"),),
     }
 
     def __init__(
@@ -284,17 +291,6 @@ class Singapore(HolidayBase):
         # Boxing day (up to and including 1968)
         if year <= 1968:
             self[date(year, DEC, 26)] = "Boxing Day"
-
-        # Polling Day
-        dates_fixed_obs = {
-            2001: (NOV, 3),
-            2006: (MAY, 6),
-            2011: (MAY, 7),
-            2015: (SEP, 11),
-            2020: (JUL, 10),
-        }
-        if year in dates_fixed_obs:
-            self[date(year, *dates_fixed_obs[year])] = "Polling Day"
 
         # Check for holidays that fall on a Sunday and implement Section 4(2)
         # of the Holidays Act: "if any day specified in the Schedule falls on

--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -37,6 +37,12 @@ from holidays.utils import _ChineseLuniSolar, _islamic_to_gre
 
 class Singapore(HolidayBase):
     country = "SG"
+    special_holidays = {
+        # SG50 Public holiday
+        # Announced on 14 March 2015
+        # https://www.mom.gov.sg/newsroom/press-releases/2015/sg50-public-holiday-on-7-august-2015
+        2015: ((AUG, 7, "SG50 Public Holiday"),)
+    }
 
     def __init__(
         self,
@@ -289,12 +295,6 @@ class Singapore(HolidayBase):
         }
         if year in dates_fixed_obs:
             self[date(year, *dates_fixed_obs[year])] = "Polling Day"
-
-        # SG50 Public holiday
-        # Announced on 14 March 2015
-        # https://www.mom.gov.sg/newsroom/press-releases/2015/sg50-public-holiday-on-7-august-2015
-        if year == 2015:
-            self[date(2015, AUG, 7)] = "SG50 Public Holiday"
 
         # Check for holidays that fall on a Sunday and implement Section 4(2)
         # of the Holidays Act: "if any day specified in the Schedule falls on

--- a/holidays/countries/slovakia.py
+++ b/holidays/countries/slovakia.py
@@ -26,6 +26,11 @@ class Slovakia(HolidayBase):
     """
 
     country = "SK"
+    special_holidays = {
+        2018: (
+            (OCT, 30, "100. výročie prijatia Deklarácie slovenského národa"),
+        )
+    }
 
     def _populate(self, year):
         super()._populate(year)
@@ -55,10 +60,7 @@ class Slovakia(HolidayBase):
         self[date(year, SEP, 1)] = "Deň Ústavy Slovenskej republiky"
 
         self[date(year, SEP, 15)] = "Sedembolestná Panna Mária"
-        if year == 2018:
-            self[date(year, OCT, 30)] = (
-                "100. výročie prijatia" " Deklarácie slovenského národa"
-            )
+
         self[date(year, NOV, 1)] = "Sviatok Všetkých svätých"
 
         if year >= 2001:

--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -39,6 +39,28 @@ class SouthAfrica(HolidayBase):
     """
 
     country = "ZA"
+    special_holidays = {
+        1999: (
+            (JUN, 2, "National and provincial government elections"),
+            (DEC, 31, "Y2K changeover"),
+        ),
+        2000: ((JAN, 2, "Y2K changeover"),),
+        2004: ((APR, 14, "National and provincial government elections"),),
+        2006: ((MAR, 1, "Local government elections"),),
+        2008: ((MAY, 2, "By presidential decree"),),
+        2009: ((APR, 22, "National and provincial government elections"),),
+        2011: (
+            (MAY, 18, "Local government elections"),
+            (DEC, 27, "By presidential decree"),
+        ),
+        2014: ((MAY, 7, "National and provincial government elections"),),
+        2016: (
+            (AUG, 3, "Local government elections"),
+            (DEC, 27, "By presidential decree"),
+        ),
+        2019: ((MAY, 8, "National and provincial government elections"),),
+        2021: ((NOV, 1, "Municipal elections"),),
+    }
 
     def _populate(self, year):
         super()._populate(year)
@@ -82,38 +104,6 @@ class SouthAfrica(HolidayBase):
             self[date(year, JUN, 16)] = "Youth Day"
             self[date(year, AUG, 9)] = "National Women's Day"
             self[date(year, SEP, 24)] = "Heritage Day"
-
-        # Once-off public holidays
-        national_election = "National and provincial government elections"
-        y2k = "Y2K changeover"
-        local_election = "Local government elections"
-        presidential = "By presidential decree"
-        municipal_election = "Municipal elections"
-        if year == 1999:
-            self[date(1999, JUN, 2)] = national_election
-            self[date(1999, DEC, 31)] = y2k
-        if year == 2000:
-            self[date(2000, JAN, 2)] = y2k
-        if year == 2004:
-            self[date(2004, APR, 14)] = national_election
-        if year == 2006:
-            self[date(2006, MAR, 1)] = local_election
-        if year == 2008:
-            self[date(2008, MAY, 2)] = presidential
-        if year == 2009:
-            self[date(2009, APR, 22)] = national_election
-        if year == 2011:
-            self[date(2011, MAY, 18)] = local_election
-            self[date(2011, DEC, 27)] = presidential
-        if year == 2014:
-            self[date(2014, MAY, 7)] = national_election
-        if year == 2016:
-            self[date(2016, AUG, 3)] = local_election
-            self[date(2016, DEC, 27)] = presidential
-        if year == 2019:
-            self[date(2019, MAY, 8)] = national_election
-        if year == 2021:
-            self[date(2021, NOV, 1)] = municipal_election
 
         # As of 1995/1/1, whenever a public holiday falls on a Sunday,
         # it rolls over to the following Monday

--- a/holidays/countries/zambia.py
+++ b/holidays/countries/zambia.py
@@ -27,6 +27,12 @@ class Zambia(HolidayBase):
     """
 
     country = "ZM"
+    special_holidays = {
+        2021: (
+            (JUL, 2, "Memorial service for Kenneth Kaunda"),
+            (JUL, 7, "Funeral of Kenneth Kaunda"),
+        )
+    }
 
     def _populate(self, year):
         super()._populate(year)
@@ -85,11 +91,6 @@ class Zambia(HolidayBase):
             if self.observed and year > 1964:
                 if k.weekday() == SUN:
                     self[k + rd(days=1)] = v + " (Observed)"
-
-        # Once-off public holidays
-        if year == 2021:
-            self[date(2021, JUL, 2)] = "Memorial service for Kenneth Kaunda"
-            self[date(2021, JUL, 7)] = "Funeral of Kenneth Kaunda"
 
 
 class ZM(Zambia):

--- a/test/countries/test_botswana.py
+++ b/test/countries/test_botswana.py
@@ -49,7 +49,7 @@ class TestBotswana(unittest.TestCase):
         self.assertNotIn(date(2015, 3, 2), self.holidays)
         self.assertNotIn(date(1964, 4, 16), self.holidays)
 
-    def test_onceoff(self):
+    def test_special_holidays(self):
         self.assertIn(date(2019, 7, 2), self.holidays)
 
     def test_saturday_and_monday(self):

--- a/test/countries/test_eswatini.py
+++ b/test/countries/test_eswatini.py
@@ -34,7 +34,7 @@ class TestEswatini(unittest.TestCase):
         self.assertIn(date(2017, 5, 25), self.holidays)
         self.assertNotIn(date(2017, 5, 26), self.holidays)
 
-    def test_once_off(self):
+    def test_special_holidays(self):
         self.assertIn(date(1999, 12, 31), self.holidays)  # y2k
         self.assertIn(date(2000, 1, 3), self.holidays)  # y2k
 

--- a/test/countries/test_hongkong.py
+++ b/test/countries/test_hongkong.py
@@ -28,10 +28,8 @@ class TestHongKong(unittest.TestCase):
         )
         self.assertEqual(
             self.holidays[date(2015, 9, 3)],
-            "The 70th "
-            + "anniversary day of the victory of the Chinese "
-            + "people's war of resistance against Japanese "
-            + "aggression",
+            "The 70th anniversary day of the victory of the Chinese "
+            "people's war of resistance against Japanese aggression",
         )
 
     def test_first_day_of_january(self):

--- a/test/countries/test_ireland.py
+++ b/test/countries/test_ireland.py
@@ -102,3 +102,6 @@ class TestIreland(unittest.TestCase):
                     "St. Stephen's Day, Christmas Day (Observed)",
                 ],
             )
+
+    def test_special_holidays(self):
+        self.assertIn("2022-03-18", self.holidays)

--- a/test/countries/test_korea.py
+++ b/test/countries/test_korea.py
@@ -404,3 +404,6 @@ class TestKorea(unittest.TestCase):
         self.holidays = holidays.KR(years=range(2006, 2021))
         for year in range(2006, 2021):
             self.assertIn(self.holidays[date(year, 1, 1)], "New Year's Day")
+
+    def test_special_holidays(self):
+        self.assertIn("2020-08-17", self.holidays)

--- a/test/countries/test_lesotho.py
+++ b/test/countries/test_lesotho.py
@@ -33,7 +33,7 @@ class TestLesotho(unittest.TestCase):
         self.assertIn(date(2017, 5, 25), self.holidays)
         self.assertIn(date(2021, 5, 13), self.holidays)
 
-    def test_once_off(self):
+    def test_special_holidays(self):
         self.assertIn(date(2002, 4, 4), self.holidays)
         self.assertIn(date(2002, 5, 25), self.holidays)
 

--- a/test/countries/test_namibia.py
+++ b/test/countries/test_namibia.py
@@ -33,10 +33,9 @@ class TestNamibia(unittest.TestCase):
         self.assertIn(date(2017, 5, 25), self.holidays)
         self.assertIn(date(1994, 4, 1), self.holidays)
 
-    def test_onceoff(self):
+    def test_special_holidays(self):
         self.assertIn(date(1999, 12, 31), self.holidays)  # Y2K
         self.assertIn(date(2000, 1, 3), self.holidays)  # Y2K
-        self.assertNotIn(date(2010, 1, 10), self.holidays)  # notinY2k
 
     def test_namibian_women_int_rights(self):
         self.assertIn(date(2004, 9, 10), self.holidays)

--- a/test/countries/test_poland.py
+++ b/test/countries/test_poland.py
@@ -43,7 +43,7 @@ class TestPL(unittest.TestCase):
 
         self.assertNotIn(date(2017, 11, 12), self.holidays)
 
-    def test_2018(self):
+    def test_special_holidays(self):
         self.assertIn(date(2018, 11, 12), self.holidays)
 
     def test_swieto_trzech_kroli(self):

--- a/test/countries/test_singapore.py
+++ b/test/countries/test_singapore.py
@@ -28,8 +28,6 @@ class TestSingapore(unittest.TestCase):
         self.assertIn(date(1968, 12, 26), self.holidays)
         # latest polling day
         self.assertIn(date(2015, 9, 11), self.holidays)
-        # SG50
-        self.assertIn(date(2015, 8, 7), self.holidays)
         # Year with lunar leap month
         self.assertIn(date(2015, 8, 7), self.holidays)
         # Latest holidays
@@ -100,3 +98,6 @@ class TestSingapore(unittest.TestCase):
         self.assertIsInstance(h, holidays.Singapore)
         h = holidays.SGP()
         self.assertIsInstance(h, holidays.Singapore)
+
+    def test_special_holidays(self):
+        self.assertIn(date(2015, 8, 7), self.holidays)

--- a/test/countries/test_slovakia.py
+++ b/test/countries/test_slovakia.py
@@ -43,9 +43,11 @@ class TestSK(unittest.TestCase):
         self.assertNotIn(date(1996, 5, 8), self.holidays)
         self.assertIn(date(1997, 5, 8), self.holidays)
 
-        self.assertNotIn(date(2017, 10, 30), self.holidays)
-        self.assertIn(date(2018, 10, 30), self.holidays)
-        self.assertNotIn(date(2019, 10, 30), self.holidays)
-
         self.assertNotIn(date(2000, 11, 17), self.holidays)
         self.assertIn(date(2001, 11, 17), self.holidays)
+
+    def test_special_holidays(self):
+        self.assertIn(date(2018, 10, 30), self.holidays)
+
+        self.assertNotIn(date(2017, 10, 30), self.holidays)
+        self.assertNotIn(date(2019, 10, 30), self.holidays)

--- a/test/countries/test_south_africa.py
+++ b/test/countries/test_south_africa.py
@@ -37,11 +37,20 @@ class TestSouthAfrica(unittest.TestCase):
         self.assertNotIn("2016-12-28", self.holidays)
         self.assertNotIn("2015-03-02", self.holidays)
 
-    def test_onceoff(self):
+    def test_special_holidays(self):
+        self.assertIn("1999-06-02", self.holidays)
         self.assertIn("1999-12-31", self.holidays)  # Y2K
-        self.assertIn("2008-05-02", self.holidays)  # Y2K
         self.assertIn("2000-01-02", self.holidays)  # Y2K
-        self.assertNotIn("2017-08-03", self.holidays)
+        self.assertIn("2004-04-14", self.holidays)
+        self.assertIn("2006-03-01", self.holidays)
+        self.assertIn("2008-05-02", self.holidays)
+        self.assertIn("2009-04-22", self.holidays)
+        self.assertIn("2011-05-18", self.holidays)
+        self.assertIn("2011-12-27", self.holidays)
+        self.assertIn("2014-05-07", self.holidays)
+        self.assertIn("2016-08-03", self.holidays)
+        self.assertIn("2019-05-08", self.holidays)
+        self.assertIn("2021-11-01", self.holidays)
 
     def test_presidential(self):
         self.assertIn("2008-05-02", self.holidays)


### PR DESCRIPTION
As #724 has been recently merged the next step is to migrate the rest of the countries to use the new approach.

Move logic from `_populate` to `special_holidays` for:
  - Botswana
  - Eswatini
  - Hongkong
  - Ireland
  - Japan
  - South Korea
  - Lesotho
  - Namibia
  - Poland
  - Singapore
  - Slovakia
  - South Africa
  - Zambia