### PR TITLE
Canada: make observed New Year's Day fall on or after the holiday

### DIFF
--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -77,10 +77,8 @@ class Canada(HolidayBase):
         self[date(year, JAN, 1)] = name
         if self.observed and date(year, JAN, 1).weekday() == SUN:
             self[date(year, JAN, 1) + rd(days=+1)] = name + " (Observed)"
-        # The following year's observed New Year's Day can be in this year
-        # when it falls on a Friday (Jan 1st is a Saturday).
-        if self.observed and date(year, DEC, 31).weekday() == FRI:
-            self[date(year, DEC, 31)] = name + " (Observed)"
+        elif self.observed and date(year, JAN, 1).weekday() == SAT:
+            self[date(year, JAN, 1) + rd(days=+2)] = name + " (Observed)"
 
         # Family Day / Louis Riel Day (MB) / Islander Day (PE)
         # / Heritage Day (NS, YT)

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -17,7 +17,6 @@ from dateutil.relativedelta import MO, FR, SU
 
 from holidays.constants import (
     FRI,
-    SAT,
     SUN,
     WEEKEND,
     JAN,
@@ -76,10 +75,8 @@ class Canada(HolidayBase):
         # New Year's Day
         name = "New Year's Day"
         self[date(year, JAN, 1)] = name
-        if self.observed and date(year, JAN, 1).weekday() == SUN:
-            self[date(year, JAN, 1) + rd(days=+1)] = name + " (Observed)"
-        elif self.observed and date(year, JAN, 1).weekday() == SAT:
-            self[date(year, JAN, 1) + rd(days=+2)] = name + " (Observed)"
+        if self.observed and date(year, JAN, 1).weekday() in WEEKEND:
+            self[date(year, JAN, 1) + rd(weekday=MO)] = name + " (Observed)"
 
         # Family Day / Louis Riel Day (MB) / Islander Day (PE)
         # / Heritage Day (NS, YT)

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -17,6 +17,7 @@ from dateutil.relativedelta import MO, FR, SU
 
 from holidays.constants import (
     FRI,
+    SAT,
     SUN,
     WEEKEND,
     JAN,

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -24,9 +24,11 @@ class TestCA(unittest.TestCase):
     def test_new_years(self):
         self.assertNotIn(date(1866, 12, 31), self.holidays)
         self.assertNotIn(date(2010, 12, 31), self.holidays)
+        self.assertNotIn(date(2011, 1, 3), self.holidays)
         self.assertNotIn(date(2017, 1, 2), self.holidays)
         self.holidays.observed = True
-        self.assertIn(date(2010, 12, 31), self.holidays)
+        self.assertNotIn(date(2010, 12, 31), self.holidays)
+        self.assertIn(date(2011, 1, 3), self.holidays)
         self.assertIn(date(2017, 1, 2), self.holidays)
         self.holidays.observed = False
         for year in range(1900, 2100):


### PR DESCRIPTION
The Canadian rules are ambiguous w.r.t. where to place the observed day when a statutory holiday falls on a weekend. According to Wikipedia the observed day can come before or after the holiday:
https://en.wikipedia.org/wiki/Public_holidays_in_Canada#Holidays_occurring_on_non-work_days

However, in the case of NYD, this has historically been falling after new year's. Since 1980 NYD has fallen on a Saturday six times (1983, 1994, 2000, 2005, 2011, and 2022). In all cases, the TSX (Toronto Stock Exchange) has had data on December 31st (the Friday) and no data on January 3rd (the following Monday).

Similarly, NYD has fallen on a Sunday seven times (1978, 1984, 1989, 1995, 2006, 2012, 2017). A similar pattern is observed there; data on Dec 30th and no data on Jan 2nd. For national markets at least, there is consistency in the placement of NYD.