### PR TITLE
Financial holiday - Day of Mourning for President George H.W. Bush

### DIFF
--- a/holidays/financial/ny_stock_exchange.py
+++ b/holidays/financial/ny_stock_exchange.py
@@ -291,6 +291,10 @@ class NewYorkStockExchange(HolidayBase):
             self[
                 date(year, JAN, 2)
             ] = "Day of Mourning for President Gerald R. Ford"
+        elif year == 2018:
+            self[
+                date(year, DEC, 5)
+            ] = "Day of Mourning for President George H.W. Bush"
 
 
 class XNYS(NewYorkStockExchange):

--- a/test/financial/test_ny_stock_exchange.py
+++ b/test/financial/test_ny_stock_exchange.py
@@ -420,6 +420,9 @@ class TestNewYorkStockExchange(unittest.TestCase):
                 2004, JUN, 11
             ),  # Day of Mourning for President Ronald W. Reagan
             date(2007, JAN, 2),  # Day of Mourning for President Gerald R. Ford
+            date(
+                2018, DEC, 5
+            ),  # Day of Mourning for President George H.W. Bush
         ]
 
         def _make_special_holiday_list(begin, end, days=None, weekends=False):


### PR DESCRIPTION
Adding a new financial holiday - Day of Mourning for President George H.W. Bush 
https://eu.usatoday.com/story/money/2018/12/03/stock-market-closed-december-5-george-h-w-bush/2192106002/