### PR TITLE
Adding financial holidays - Hurricane Gloria and Sandy

### DIFF
--- a/holidays/financial/ny_stock_exchange.py
+++ b/holidays/financial/ny_stock_exchange.py
@@ -274,6 +274,10 @@ class NewYorkStockExchange(HolidayBase):
             ] = "Funeral for President Lyndon B. Johnson"
         elif year == 1977:
             self[date(year, JUL, 14)] = "Blackout in New Yor City"
+        elif year == 1985:
+            self[
+                date(year, SEP, 27)
+            ] = "Weather related clousre due to the impact of Hurricane Gloria"
         elif year == 1994:
             self[
                 date(year, APR, 27)
@@ -291,6 +295,13 @@ class NewYorkStockExchange(HolidayBase):
             self[
                 date(year, JAN, 2)
             ] = "Day of Mourning for President Gerald R. Ford"
+        elif year == 2012:
+            self[
+                date(year, OCT, 29)
+            ] = "Weather related clousre due to the impact of Hurricane Sandy"
+            self[
+                date(year, OCT, 30)
+            ] = "Weather related clousre due to the impact of Hurricane Sandy"
         elif year == 2018:
             self[
                 date(year, DEC, 5)

--- a/holidays/financial/ny_stock_exchange.py
+++ b/holidays/financial/ny_stock_exchange.py
@@ -275,9 +275,7 @@ class NewYorkStockExchange(HolidayBase):
         elif year == 1977:
             self[date(year, JUL, 14)] = "Blackout in New Yor City"
         elif year == 1985:
-            self[
-                date(year, SEP, 27)
-            ] = "Weather related clousre due to the impact of Hurricane Gloria"
+            self[date(year, SEP, 27)] = "Hurricane Gloria"
         elif year == 1994:
             self[
                 date(year, APR, 27)
@@ -296,12 +294,8 @@ class NewYorkStockExchange(HolidayBase):
                 date(year, JAN, 2)
             ] = "Day of Mourning for President Gerald R. Ford"
         elif year == 2012:
-            self[
-                date(year, OCT, 29)
-            ] = "Weather related clousre due to the impact of Hurricane Sandy"
-            self[
-                date(year, OCT, 30)
-            ] = "Weather related clousre due to the impact of Hurricane Sandy"
+            self[date(year, OCT, 29)] = "Hurricane Sandy"
+            self[date(year, OCT, 30)] = "Hurricane Sandy"
         elif year == 2018:
             self[
                 date(year, DEC, 5)

--- a/test/financial/test_ny_stock_exchange.py
+++ b/test/financial/test_ny_stock_exchange.py
@@ -411,9 +411,7 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1972, DEC, 28),  # Funeral for President Harry S. Truman
             date(1973, JAN, 25),  # Funeral for President Lyndon B. Johnson
             date(1977, JUL, 14),  # Blackout in New Yor City
-            date(
-                1985, SEP, 27
-            ),  # Weather related clousre due to the impact of Hurricane Gloria
+            date(1985, SEP, 27),  # Hurricane Gloria
             date(1994, APR, 27),  # Funeral for President Richard M. Nixon
             date(2001, SEP, 11),  # Closed for Sept 11, 2001 Attacks
             date(2001, SEP, 12),  # Closed for Sept 11, 2001 Attacks
@@ -423,12 +421,8 @@ class TestNewYorkStockExchange(unittest.TestCase):
                 2004, JUN, 11
             ),  # Day of Mourning for President Ronald W. Reagan
             date(2007, JAN, 2),  # Day of Mourning for President Gerald R. Ford
-            date(
-                2012, OCT, 29
-            ),  # Weather related clousre due to the impact of Hurricane Sandy
-            date(
-                2012, OCT, 29
-            ),  # Weather related clousre due to the impact of Hurricane Sandy
+            date(2012, OCT, 29),  # Hurricane Sandy
+            date(2012, OCT, 29),  # Hurricane Sandy
             date(
                 2018, DEC, 5
             ),  # Day of Mourning for President George H.W. Bush

--- a/test/financial/test_ny_stock_exchange.py
+++ b/test/financial/test_ny_stock_exchange.py
@@ -411,6 +411,9 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1972, DEC, 28),  # Funeral for President Harry S. Truman
             date(1973, JAN, 25),  # Funeral for President Lyndon B. Johnson
             date(1977, JUL, 14),  # Blackout in New Yor City
+            date(
+                1985, SEP, 27
+            ),  # Weather related clousre due to the impact of Hurricane Gloria
             date(1994, APR, 27),  # Funeral for President Richard M. Nixon
             date(2001, SEP, 11),  # Closed for Sept 11, 2001 Attacks
             date(2001, SEP, 12),  # Closed for Sept 11, 2001 Attacks
@@ -420,6 +423,12 @@ class TestNewYorkStockExchange(unittest.TestCase):
                 2004, JUN, 11
             ),  # Day of Mourning for President Ronald W. Reagan
             date(2007, JAN, 2),  # Day of Mourning for President Gerald R. Ford
+            date(
+                2012, OCT, 29
+            ),  # Weather related clousre due to the impact of Hurricane Sandy
+            date(
+                2012, OCT, 29
+            ),  # Weather related clousre due to the impact of Hurricane Sandy
             date(
                 2018, DEC, 5
             ),  # Day of Mourning for President George H.W. Bush

--- a/test/financial/test_ny_stock_exchange.py
+++ b/test/financial/test_ny_stock_exchange.py
@@ -422,7 +422,7 @@ class TestNewYorkStockExchange(unittest.TestCase):
             ),  # Day of Mourning for President Ronald W. Reagan
             date(2007, JAN, 2),  # Day of Mourning for President Gerald R. Ford
             date(2012, OCT, 29),  # Hurricane Sandy
-            date(2012, OCT, 29),  # Hurricane Sandy
+            date(2012, OCT, 30),  # Hurricane Sandy
             date(
                 2018, DEC, 5
             ),  # Day of Mourning for President George H.W. Bush


### PR DESCRIPTION
Hurricane sandy - October 29 & 30, 2012

Hurricane Gloria - September 27th, 1985

https://www.sandiegouniontribune.com/sdut-hurricane-sandy-shuts-stock-trading-for-2-days-2012oct29-story.html