### PR TITLE
South Africa - 27 December 2022 declared public holiday

### DIFF
--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -114,6 +114,8 @@ class SouthAfrica(HolidayBase):
             self[date(2019, MAY, 8)] = national_election
         if year == 2021:
             self[date(2021, NOV, 1)] = municipal_election
+        if year == 2022:
+            self[date(2022, DEC, 27)] = "Special Day of Goodwill addition"
 
         # As of 1995/1/1, whenever a public holiday falls on a Sunday,
         # it rolls over to the following Monday


### PR DESCRIPTION
https://www.gov.za/speeches/president-cyril-ramaphosa-declares-27-december-public-holiday-8-dec-2022-0000