### PR TITLE
South Africa: added 27 Dec 2022 public holiday

### DIFF
--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -35,19 +35,20 @@ class SouthAfrica(HolidayBase):
         2000: ((JAN, 2, "Y2K changeover"),),
         2004: ((APR, 14, "National and provincial government elections"),),
         2006: ((MAR, 1, "Local government elections"),),
-        2008: ((MAY, 2, "By presidential decree"),),
+        2008: ((MAY, 2, "Public holiday by presidential decree"),),
         2009: ((APR, 22, "National and provincial government elections"),),
         2011: (
             (MAY, 18, "Local government elections"),
-            (DEC, 27, "By presidential decree"),
+            (DEC, 27, "Public holiday by presidential decree"),
         ),
         2014: ((MAY, 7, "National and provincial government elections"),),
         2016: (
             (AUG, 3, "Local government elections"),
-            (DEC, 27, "By presidential decree"),
+            (DEC, 27, "Public holiday by presidential decree"),
         ),
         2019: ((MAY, 8, "National and provincial government elections"),),
         2021: ((NOV, 1, "Municipal elections"),),
+        2022: ((DEC, 27, "Public holiday by presidential decree"),),
     }
 
     def _populate(self, year):

--- a/test/countries/test_south_africa.py
+++ b/test/countries/test_south_africa.py
@@ -51,6 +51,7 @@ class TestSouthAfrica(unittest.TestCase):
         self.assertIn("2016-08-03", self.holidays)
         self.assertIn("2019-05-08", self.holidays)
         self.assertIn("2021-11-01", self.holidays)
+        self.assertIn("2022-12-27", self.holidays)
 
     def test_presidential(self):
         self.assertIn("2008-05-02", self.holidays)


### PR DESCRIPTION
Alternative for #837 and #839, using `special_holidays`