### PR TITLE
Fix South Korea deprecation warnings.

### DIFF
--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -286,9 +286,9 @@ class Korea(SouthKorea):
         super().__init__(*args, **kwargs)
 
 
-class KR(Korea):
+class KR(SouthKorea):
     pass
 
 
-class KOR(Korea):
+class KOR(SouthKorea):
     pass


### PR DESCRIPTION
Change KO, KOR parent from `Korea` to `SouthKorea`.