### PR TITLE
Pin `coverage` version

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,7 +7,7 @@ hijri_converter
 # test requirements
 pytest
 pytest-cov
-coverage[toml]
+coverage[toml]<7.0.0
 pre-commit
 flake8
 sphinx


### PR DESCRIPTION
Add a temporary version pin in order to fix GH CI/CD.