### PR TITLE
Addition 8th May 2023 to Special Holidays

### DIFF
--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -52,6 +52,7 @@ class UnitedKingdom(HolidayBase):
             (JUN, 3, "Platinum Jubilee of Elizabeth II"),
             (SEP, 19, "State Funeral of Queen Elizabeth II"),
         ),
+        2023: ((MAY, 8, "Coronation of King Charles III and Queen Camilla"),),
     }
     subdivisions = ["UK", "England", "Northern Ireland", "Scotland", "Wales"]
 


### PR DESCRIPTION
In 2023, an additional public holiday will occur on Monday 8 May to commemorate the Coronation of King Charles III and Queen Camilla.