### PR TITLE
Add 2022-12-27 as public holiday in South Africa

### DIFF
--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -114,6 +114,8 @@ class SouthAfrica(HolidayBase):
             self[date(2019, MAY, 8)] = national_election
         if year == 2021:
             self[date(2021, NOV, 1)] = municipal_election
+        if year == 2022:
+            self[date(2022, DEC, 27)] = presidential
 
         # As of 1995/1/1, whenever a public holiday falls on a Sunday,
         # it rolls over to the following Monday

--- a/test/countries/test_south_africa.py
+++ b/test/countries/test_south_africa.py
@@ -47,6 +47,7 @@ class TestSouthAfrica(unittest.TestCase):
         self.assertIn("2008-05-02", self.holidays)
         self.assertIn("2011-12-27", self.holidays)
         self.assertIn("2016-12-27", self.holidays)
+        self.assertIn("2022-12-27", self.holidays)
 
     def test_observed(self):
         self.assertIn("1995-01-02", self.holidays)


### PR DESCRIPTION
It was declared by the president. Ref: https://www.gov.za/speeches/president-cyril-ramaphosa-declares-27-december-public-holiday-8-dec-2022-0000