### PR TITLE
Refactor days offset calculation: replace `relativedelta` with `timedelta`

### DIFF
--- a/holidays/countries/angola.py
+++ b/holidays/countries/angola.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -41,11 +42,11 @@ class Angola(HolidayBase):
                 self[date(year, DEC, 31)] = "Ano novo (Day off)"
 
         easter_date = easter(year)
-        self[(easter_date + timedelta(days=-2))] = "Sexta-feira Santa"
+        self[(easter_date + td(days=-2))] = "Sexta-feira Santa"
 
         # carnival is the Tuesday before Ash Wednesday
         # which is 40 days before easter excluding sundays
-        self[(easter_date + timedelta(days=-47))] = "Carnaval"
+        self[(easter_date + td(days=-47))] = "Carnaval"
 
         self[date(year, FEB, 4)] = "Dia do Início da Luta Armada"
         self[date(year, MAR, 8)] = "Dia Internacional da Mulher"
@@ -73,12 +74,12 @@ class Angola(HolidayBase):
                     continue
                 if year <= 2017:
                     if k.weekday() == SUN:
-                        self[k + timedelta(days=+1)] = v + " (Observed)"
+                        self[k + td(days=+1)] = v + " (Observed)"
                 else:
                     if k.weekday() == TUE and k != date(year, JAN, 1):
-                        self[k + timedelta(days=-1)] = v + " (Day off)"
+                        self[k + td(days=-1)] = v + " (Day off)"
                     elif k.weekday() == THU:
-                        self[k + timedelta(days=+1)] = v + " (Day off)"
+                        self[k + td(days=+1)] = v + " (Day off)"
 
 
 class AO(Angola):

--- a/holidays/countries/angola.py
+++ b/holidays/countries/angola.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, MAR, APR, MAY, SEP, NOV, DEC, MON
 from holidays.constants import TUE, THU, SUN
@@ -42,11 +41,11 @@ class Angola(HolidayBase):
                 self[date(year, DEC, 31)] = "Ano novo (Day off)"
 
         easter_date = easter(year)
-        self[(easter_date + rd(days=-2))] = "Sexta-feira Santa"
+        self[(easter_date + timedelta(days=-2))] = "Sexta-feira Santa"
 
         # carnival is the Tuesday before Ash Wednesday
         # which is 40 days before easter excluding sundays
-        self[(easter_date + rd(days=-47))] = "Carnaval"
+        self[(easter_date + timedelta(days=-47))] = "Carnaval"
 
         self[date(year, FEB, 4)] = "Dia do Início da Luta Armada"
         self[date(year, MAR, 8)] = "Dia Internacional da Mulher"
@@ -74,12 +73,12 @@ class Angola(HolidayBase):
                     continue
                 if year <= 2017:
                     if k.weekday() == SUN:
-                        self[k + rd(days=+1)] = v + " (Observed)"
+                        self[k + timedelta(days=+1)] = v + " (Observed)"
                 else:
                     if k.weekday() == TUE and k != date(year, JAN, 1):
-                        self[k + rd(days=-1)] = v + " (Day off)"
+                        self[k + timedelta(days=-1)] = v + " (Day off)"
                     elif k.weekday() == THU:
-                        self[k + rd(days=+1)] = v + " (Day off)"
+                        self[k + timedelta(days=+1)] = v + " (Day off)"
 
 
 class AO(Angola):

--- a/holidays/countries/argentina.py
+++ b/holidays/countries/argentina.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -41,8 +42,8 @@ class Argentina(HolidayBase):
         easter_date = easter(year)
         # Carnival days
         name = "Día de Carnaval [Carnival's Day]"
-        self[easter_date + timedelta(days=-48)] = name
-        self[easter_date + timedelta(days=-47)] = name
+        self[easter_date + td(days=-48)] = name
+        self[easter_date + td(days=-47)] = name
 
         # Memory's National Day for the Truth and Justice
         name = (
@@ -60,8 +61,8 @@ class Argentina(HolidayBase):
         name_fri = "Semana Santa (Viernes Santo) [Holy day (Holy Friday)]"
         name_easter = "Día de Pascuas [Easter Day]"
 
-        self[easter_date + timedelta(days=-3)] = name_thu
-        self[easter_date + timedelta(days=-2)] = name_fri
+        self[easter_date + td(days=-3)] = name_thu
+        self[easter_date + td(days=-2)] = name_fri
 
         if not self.observed and self._is_weekend(easter_date):
             pass

--- a/holidays/countries/argentina.py
+++ b/holidays/countries/argentina.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, APR, MAY, JUN, JUL, AUG, OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -42,8 +41,8 @@ class Argentina(HolidayBase):
         easter_date = easter(year)
         # Carnival days
         name = "Día de Carnaval [Carnival's Day]"
-        self[easter_date + rd(days=-48)] = name
-        self[easter_date + rd(days=-47)] = name
+        self[easter_date + timedelta(days=-48)] = name
+        self[easter_date + timedelta(days=-47)] = name
 
         # Memory's National Day for the Truth and Justice
         name = (
@@ -61,8 +60,8 @@ class Argentina(HolidayBase):
         name_fri = "Semana Santa (Viernes Santo) [Holy day (Holy Friday)]"
         name_easter = "Día de Pascuas [Easter Day]"
 
-        self[easter_date + rd(days=-3)] = name_thu
-        self[easter_date + rd(days=-2)] = name_fri
+        self[easter_date + timedelta(days=-3)] = name_thu
+        self[easter_date + timedelta(days=-2)] = name_fri
 
         if not self.observed and self._is_weekend(easter_date):
             pass

--- a/holidays/countries/aruba.py
+++ b/holidays/countries/aruba.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, APR, MAY, AUG, DEC, SUN
 from holidays.holiday_base import HolidayBase
@@ -38,7 +37,7 @@ class Aruba(HolidayBase):
         easter_date = easter(year)
         # Carnaval Monday
         self[
-            easter_date + rd(days=-48)
+            easter_date + timedelta(days=-48)
         ] = "Dialuna di Carnaval [Carnaval Monday]"
 
         # Dia di Himno y Bandera
@@ -47,18 +46,18 @@ class Aruba(HolidayBase):
         ] = "Dia di Himno y Bandera [National Anthem & Flag Day]"
 
         # Good Friday
-        self[easter_date + rd(days=-2)] = "Bierna Santo [Good Friday]"
+        self[easter_date + timedelta(days=-2)] = "Bierna Santo [Good Friday]"
 
         # Easter Monday
         self[
-            easter_date + rd(days=+1)
+            easter_date + timedelta(days=+1)
         ] = "Di Dos Dia di Pasco di Resureccion [Easter Monday]"
 
         # King's Day
         if year >= 2014:
             kings_day = date(year, APR, 27)
             if kings_day.weekday() == SUN:
-                kings_day += rd(days=-1)
+                kings_day += timedelta(days=-1)
 
             self[kings_day] = "Aña di Rey [King's Day]"
 
@@ -69,7 +68,9 @@ class Aruba(HolidayBase):
                 queens_day = date(year, AUG, 31)
 
             if queens_day.weekday() == SUN:
-                queens_day += rd(days=+1) if year < 1980 else rd(days=-1)
+                queens_day += (
+                    timedelta(days=+1) if year < 1980 else timedelta(days=-1)
+                )
 
             self[queens_day] = "Aña di La Reina [Queen's Day]"
 
@@ -77,7 +78,9 @@ class Aruba(HolidayBase):
         self[date(year, MAY, 1)] = "Dia di Obrero [Labour Day]"
 
         # Ascension Day
-        self[easter_date + rd(days=+39)] = "Dia di Asuncion [Ascension Day]"
+        self[
+            easter_date + timedelta(days=+39)
+        ] = "Dia di Asuncion [Ascension Day]"
 
         # Christmas Day
         self[date(year, DEC, 25)] = "Pasco di Nacemento [Christmas]"

--- a/holidays/countries/aruba.py
+++ b/holidays/countries/aruba.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -37,7 +38,7 @@ class Aruba(HolidayBase):
         easter_date = easter(year)
         # Carnaval Monday
         self[
-            easter_date + timedelta(days=-48)
+            easter_date + td(days=-48)
         ] = "Dialuna di Carnaval [Carnaval Monday]"
 
         # Dia di Himno y Bandera
@@ -46,18 +47,18 @@ class Aruba(HolidayBase):
         ] = "Dia di Himno y Bandera [National Anthem & Flag Day]"
 
         # Good Friday
-        self[easter_date + timedelta(days=-2)] = "Bierna Santo [Good Friday]"
+        self[easter_date + td(days=-2)] = "Bierna Santo [Good Friday]"
 
         # Easter Monday
         self[
-            easter_date + timedelta(days=+1)
+            easter_date + td(days=+1)
         ] = "Di Dos Dia di Pasco di Resureccion [Easter Monday]"
 
         # King's Day
         if year >= 2014:
             kings_day = date(year, APR, 27)
             if kings_day.weekday() == SUN:
-                kings_day += timedelta(days=-1)
+                kings_day += td(days=-1)
 
             self[kings_day] = "Aña di Rey [King's Day]"
 
@@ -68,9 +69,7 @@ class Aruba(HolidayBase):
                 queens_day = date(year, AUG, 31)
 
             if queens_day.weekday() == SUN:
-                queens_day += (
-                    timedelta(days=+1) if year < 1980 else timedelta(days=-1)
-                )
+                queens_day += td(days=+1) if year < 1980 else td(days=-1)
 
             self[queens_day] = "Aña di La Reina [Queen's Day]"
 
@@ -78,9 +77,7 @@ class Aruba(HolidayBase):
         self[date(year, MAY, 1)] = "Dia di Obrero [Labour Day]"
 
         # Ascension Day
-        self[
-            easter_date + timedelta(days=+39)
-        ] = "Dia di Asuncion [Ascension Day]"
+        self[easter_date + td(days=+39)] = "Dia di Asuncion [Ascension Day]"
 
         # Christmas Day
         self[date(year, DEC, 25)] = "Pasco di Nacemento [Christmas]"

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, TU, WE, FR
@@ -94,12 +95,12 @@ class Australia(HolidayBase):
 
         # Easter
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-2)] = "Good Friday"
         if self.subdiv in {"ACT", "NSW", "NT", "QLD", "SA", "VIC"}:
-            self[easter_date + timedelta(days=-1)] = "Easter Saturday"
+            self[easter_date + td(days=-1)] = "Easter Saturday"
         if self.subdiv in {"ACT", "NSW", "QLD", "VIC"}:
             self[easter_date] = "Easter Sunday"
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
 
         # Anzac Day
         if year > 1920:

--- a/holidays/countries/australia.py
+++ b/holidays/countries/australia.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, TU, WE, FR
@@ -94,12 +94,12 @@ class Australia(HolidayBase):
 
         # Easter
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
         if self.subdiv in {"ACT", "NSW", "NT", "QLD", "SA", "VIC"}:
-            self[easter_date + rd(days=-1)] = "Easter Saturday"
+            self[easter_date + timedelta(days=-1)] = "Easter Saturday"
         if self.subdiv in {"ACT", "NSW", "QLD", "VIC"}:
             self[easter_date] = "Easter Sunday"
-        self[easter_date + rd(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
         # Anzac Day
         if year > 1920:

--- a/holidays/countries/austria.py
+++ b/holidays/countries/austria.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, AUG, OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -37,11 +36,11 @@ class Austria(HolidayBase):
         self[date(year, JAN, 1)] = "Neujahr"
         self[date(year, JAN, 6)] = "Heilige Drei Könige"
         easter_date = easter(year)
-        self[easter_date + rd(days=+1)] = "Ostermontag"
+        self[easter_date + timedelta(days=+1)] = "Ostermontag"
         self[date(year, MAY, 1)] = "Staatsfeiertag"
-        self[easter_date + rd(days=+39)] = "Christi Himmelfahrt"
-        self[easter_date + rd(days=+50)] = "Pfingstmontag"
-        self[easter_date + rd(days=+60)] = "Fronleichnam"
+        self[easter_date + timedelta(days=+39)] = "Christi Himmelfahrt"
+        self[easter_date + timedelta(days=+50)] = "Pfingstmontag"
+        self[easter_date + timedelta(days=+60)] = "Fronleichnam"
         self[date(year, AUG, 15)] = "Mariä Himmelfahrt"
         if 1919 <= year <= 1934:
             self[date(year, NOV, 12)] = "Nationalfeiertag"

--- a/holidays/countries/austria.py
+++ b/holidays/countries/austria.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -36,11 +37,11 @@ class Austria(HolidayBase):
         self[date(year, JAN, 1)] = "Neujahr"
         self[date(year, JAN, 6)] = "Heilige Drei Könige"
         easter_date = easter(year)
-        self[easter_date + timedelta(days=+1)] = "Ostermontag"
+        self[easter_date + td(days=+1)] = "Ostermontag"
         self[date(year, MAY, 1)] = "Staatsfeiertag"
-        self[easter_date + timedelta(days=+39)] = "Christi Himmelfahrt"
-        self[easter_date + timedelta(days=+50)] = "Pfingstmontag"
-        self[easter_date + timedelta(days=+60)] = "Fronleichnam"
+        self[easter_date + td(days=+39)] = "Christi Himmelfahrt"
+        self[easter_date + td(days=+50)] = "Pfingstmontag"
+        self[easter_date + td(days=+60)] = "Fronleichnam"
         self[date(year, AUG, 15)] = "Mariä Himmelfahrt"
         if 1919 <= year <= 1934:
             self[date(year, NOV, 12)] = "Nationalfeiertag"

--- a/holidays/countries/azerbaijan.py
+++ b/holidays/countries/azerbaijan.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import JAN, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT
 from holidays.constants import NOV, DEC
@@ -26,11 +27,11 @@ class Azerbaijan(HolidayBase):
 
     def _populate(self, year: int) -> None:
         def _add_observed(hol_date: date, hol_name: str) -> None:
-            next_workday = hol_date + timedelta(days=+1)
+            next_workday = hol_date + td(days=+1)
             while next_workday.year == year and (
                 self._is_weekend(next_workday) or self.get(next_workday)
             ):
-                next_workday += timedelta(days=+1)
+                next_workday += td(days=+1)
             _add_holiday(next_workday, f"{hol_name} (Observed)")
 
         def _add_holiday(hol_date: date, hol_name: str) -> None:
@@ -147,13 +148,13 @@ class Azerbaijan(HolidayBase):
                         for date_obs in dates_obs[yr]:
                             _add_holiday(date(yr, *date_obs), name)
                             _add_holiday(
-                                date(yr, *date_obs) + timedelta(days=+1), name
+                                date(yr, *date_obs) + td(days=+1), name
                             )
                     else:
                         for dt in _islamic_to_gre(yr, hmonth, hday):
                             _add_holiday(dt, f"{name}* (*estimated)")
                             _add_holiday(
-                                dt + timedelta(days=+1),
+                                dt + td(days=+1),
                                 f"{name}* (*estimated)",
                             )
 

--- a/holidays/countries/azerbaijan.py
+++ b/holidays/countries/azerbaijan.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import JAN, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT
 from holidays.constants import NOV, DEC
@@ -28,11 +26,11 @@ class Azerbaijan(HolidayBase):
 
     def _populate(self, year: int) -> None:
         def _add_observed(hol_date: date, hol_name: str) -> None:
-            next_workday = hol_date + rd(days=+1)
+            next_workday = hol_date + timedelta(days=+1)
             while next_workday.year == year and (
                 self._is_weekend(next_workday) or self.get(next_workday)
             ):
-                next_workday += rd(days=+1)
+                next_workday += timedelta(days=+1)
             _add_holiday(next_workday, f"{hol_name} (Observed)")
 
         def _add_holiday(hol_date: date, hol_name: str) -> None:
@@ -149,13 +147,14 @@ class Azerbaijan(HolidayBase):
                         for date_obs in dates_obs[yr]:
                             _add_holiday(date(yr, *date_obs), name)
                             _add_holiday(
-                                date(yr, *date_obs) + rd(days=+1), name
+                                date(yr, *date_obs) + timedelta(days=+1), name
                             )
                     else:
                         for dt in _islamic_to_gre(yr, hmonth, hday):
                             _add_holiday(dt, f"{name}* (*estimated)")
                             _add_holiday(
-                                dt + rd(days=+1), f"{name}* (*estimated)"
+                                dt + timedelta(days=+1),
+                                f"{name}* (*estimated)",
                             )
 
         """

--- a/holidays/countries/bahrain.py
+++ b/holidays/countries/bahrain.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import FRI, SAT, JAN, MAY, JUL, AUG, OCT, DEC
 from holidays.holiday_base import HolidayBase
@@ -46,20 +47,16 @@ class Bahrain(HolidayBase):
             for dt in eid_al_fitr_mapping[year]:
                 eid_al_fitr_day = date(year, *dt)
                 self[eid_al_fitr_day] = eid_al_fitr
-                self[
-                    eid_al_fitr_day + timedelta(days=+1)
-                ] = f"{eid_al_fitr} Holiday"
-                self[
-                    eid_al_fitr_day + timedelta(days=+2)
-                ] = f"{eid_al_fitr} Holiday"
+                self[eid_al_fitr_day + td(days=+1)] = f"{eid_al_fitr} Holiday"
+                self[eid_al_fitr_day + td(days=+2)] = f"{eid_al_fitr} Holiday"
         else:
             for eid_al_fitr_day in _islamic_to_gre(year, 10, 1):
                 self[eid_al_fitr_day] = f"{eid_al_fitr}* (*estimated)"
                 self[
-                    eid_al_fitr_day + timedelta(days=+1)
+                    eid_al_fitr_day + td(days=+1)
                 ] = f"{eid_al_fitr} Holiday* (*estimated)"
                 self[
-                    eid_al_fitr_day + timedelta(days=+2)
+                    eid_al_fitr_day + td(days=+2)
                 ] = f"{eid_al_fitr} Holiday* (*estimated)"
 
         # Eid Al Adha.
@@ -71,22 +68,18 @@ class Bahrain(HolidayBase):
             for dt in eid_al_adha_mapping[year]:
                 eid_al_adha_day = date(year, *dt)
                 self[eid_al_adha_day] = eid_al_adha
-                self[
-                    eid_al_adha_day + timedelta(days=+1)
-                ] = f"{eid_al_adha} Holiday"
-                self[
-                    eid_al_adha_day + timedelta(days=+2)
-                ] = f"{eid_al_adha} Holiday"
+                self[eid_al_adha_day + td(days=+1)] = f"{eid_al_adha} Holiday"
+                self[eid_al_adha_day + td(days=+2)] = f"{eid_al_adha} Holiday"
         else:
             for eid_al_adha_day in _islamic_to_gre(year, 12, 9):
                 self[
-                    eid_al_adha_day + timedelta(days=+1)
+                    eid_al_adha_day + td(days=+1)
                 ] = f"{eid_al_adha}* (*estimated)"
                 self[
-                    eid_al_adha_day + timedelta(days=+2)
+                    eid_al_adha_day + td(days=+2)
                 ] = f"{eid_al_adha}* (*estimated)"
                 self[
-                    eid_al_adha_day + timedelta(days=+3)
+                    eid_al_adha_day + td(days=+3)
                 ] = f"{eid_al_adha}* (*estimated)"
 
         # Al Hijra New Year.
@@ -110,12 +103,12 @@ class Bahrain(HolidayBase):
             for dt in ashura_mapping[year]:
                 ashura_day = date(year, *dt)
                 self[ashura_day] = ashura
-                self[ashura_day + timedelta(days=+1)] = f"{ashura} Holiday"
+                self[ashura_day + td(days=+1)] = f"{ashura} Holiday"
         else:
             for ashura_day in _islamic_to_gre(year, 1, 9):
                 self[ashura_day] = f"{ashura}* (*estimated)"
                 self[
-                    ashura_day + timedelta(days=+1)
+                    ashura_day + td(days=+1)
                 ] = f"{ashura}* Holiday* (*estimated)"
 
         # Prophets Birthday.

--- a/holidays/countries/bahrain.py
+++ b/holidays/countries/bahrain.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import FRI, SAT, JAN, MAY, JUL, AUG, OCT, DEC
 from holidays.holiday_base import HolidayBase
@@ -48,16 +46,20 @@ class Bahrain(HolidayBase):
             for dt in eid_al_fitr_mapping[year]:
                 eid_al_fitr_day = date(year, *dt)
                 self[eid_al_fitr_day] = eid_al_fitr
-                self[eid_al_fitr_day + rd(days=+1)] = f"{eid_al_fitr} Holiday"
-                self[eid_al_fitr_day + rd(days=+2)] = f"{eid_al_fitr} Holiday"
+                self[
+                    eid_al_fitr_day + timedelta(days=+1)
+                ] = f"{eid_al_fitr} Holiday"
+                self[
+                    eid_al_fitr_day + timedelta(days=+2)
+                ] = f"{eid_al_fitr} Holiday"
         else:
             for eid_al_fitr_day in _islamic_to_gre(year, 10, 1):
                 self[eid_al_fitr_day] = f"{eid_al_fitr}* (*estimated)"
                 self[
-                    eid_al_fitr_day + rd(days=+1)
+                    eid_al_fitr_day + timedelta(days=+1)
                 ] = f"{eid_al_fitr} Holiday* (*estimated)"
                 self[
-                    eid_al_fitr_day + rd(days=+2)
+                    eid_al_fitr_day + timedelta(days=+2)
                 ] = f"{eid_al_fitr} Holiday* (*estimated)"
 
         # Eid Al Adha.
@@ -69,18 +71,22 @@ class Bahrain(HolidayBase):
             for dt in eid_al_adha_mapping[year]:
                 eid_al_adha_day = date(year, *dt)
                 self[eid_al_adha_day] = eid_al_adha
-                self[eid_al_adha_day + rd(days=+1)] = f"{eid_al_adha} Holiday"
-                self[eid_al_adha_day + rd(days=+2)] = f"{eid_al_adha} Holiday"
+                self[
+                    eid_al_adha_day + timedelta(days=+1)
+                ] = f"{eid_al_adha} Holiday"
+                self[
+                    eid_al_adha_day + timedelta(days=+2)
+                ] = f"{eid_al_adha} Holiday"
         else:
             for eid_al_adha_day in _islamic_to_gre(year, 12, 9):
                 self[
-                    eid_al_adha_day + rd(days=+1)
+                    eid_al_adha_day + timedelta(days=+1)
                 ] = f"{eid_al_adha}* (*estimated)"
                 self[
-                    eid_al_adha_day + rd(days=+2)
+                    eid_al_adha_day + timedelta(days=+2)
                 ] = f"{eid_al_adha}* (*estimated)"
                 self[
-                    eid_al_adha_day + rd(days=+3)
+                    eid_al_adha_day + timedelta(days=+3)
                 ] = f"{eid_al_adha}* (*estimated)"
 
         # Al Hijra New Year.
@@ -104,12 +110,12 @@ class Bahrain(HolidayBase):
             for dt in ashura_mapping[year]:
                 ashura_day = date(year, *dt)
                 self[ashura_day] = ashura
-                self[ashura_day + rd(days=+1)] = f"{ashura} Holiday"
+                self[ashura_day + timedelta(days=+1)] = f"{ashura} Holiday"
         else:
             for ashura_day in _islamic_to_gre(year, 1, 9):
                 self[ashura_day] = f"{ashura}* (*estimated)"
                 self[
-                    ashura_day + rd(days=+1)
+                    ashura_day + timedelta(days=+1)
                 ] = f"{ashura}* Holiday* (*estimated)"
 
         # Prophets Birthday.

--- a/holidays/countries/belarus.py
+++ b/holidays/countries/belarus.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -50,9 +51,7 @@ class Belarus(HolidayBase):
         self[date(year, MAR, 8)] = "День женщин"
 
         # Radunitsa ("Day of Rejoicing")
-        self[
-            easter(year, method=EASTER_ORTHODOX) + timedelta(days=+9)
-        ] = "Радуница"
+        self[easter(year, method=EASTER_ORTHODOX) + td(days=+9)] = "Радуница"
 
         # Labour Day
         self[date(year, MAY, 1)] = "Праздник труда"

--- a/holidays/countries/belarus.py
+++ b/holidays/countries/belarus.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import DEC, JAN, JUL, MAR, MAY, NOV
 from holidays.holiday_base import HolidayBase
@@ -51,7 +50,9 @@ class Belarus(HolidayBase):
         self[date(year, MAR, 8)] = "День женщин"
 
         # Radunitsa ("Day of Rejoicing")
-        self[easter(year, method=EASTER_ORTHODOX) + rd(days=+9)] = "Радуница"
+        self[
+            easter(year, method=EASTER_ORTHODOX) + timedelta(days=+9)
+        ] = "Радуница"
 
         # Labour Day
         self[date(year, MAY, 1)] = "Праздник труда"

--- a/holidays/countries/belgium.py
+++ b/holidays/countries/belgium.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -37,16 +38,16 @@ class Belgium(HolidayBase):
         self[easter_date] = "Pasen"
 
         # Second easter day
-        self[easter_date + timedelta(days=+1)] = "Paasmaandag"
+        self[easter_date + td(days=+1)] = "Paasmaandag"
 
         # Ascension day
-        self[easter_date + timedelta(days=+39)] = "O.L.H. Hemelvaart"
+        self[easter_date + td(days=+39)] = "O.L.H. Hemelvaart"
 
         # Pentecost
-        self[easter_date + timedelta(days=+49)] = "Pinksteren"
+        self[easter_date + td(days=+49)] = "Pinksteren"
 
         # Pentecost monday
-        self[easter_date + timedelta(days=+50)] = "Pinkstermaandag"
+        self[easter_date + td(days=+50)] = "Pinkstermaandag"
 
         # International Workers' Day
         self[date(year, MAY, 1)] = "Dag van de Arbeid"

--- a/holidays/countries/belgium.py
+++ b/holidays/countries/belgium.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUL, AUG, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -38,16 +37,16 @@ class Belgium(HolidayBase):
         self[easter_date] = "Pasen"
 
         # Second easter day
-        self[easter_date + rd(days=+1)] = "Paasmaandag"
+        self[easter_date + timedelta(days=+1)] = "Paasmaandag"
 
         # Ascension day
-        self[easter_date + rd(days=+39)] = "O.L.H. Hemelvaart"
+        self[easter_date + timedelta(days=+39)] = "O.L.H. Hemelvaart"
 
         # Pentecost
-        self[easter_date + rd(days=+49)] = "Pinksteren"
+        self[easter_date + timedelta(days=+49)] = "Pinksteren"
 
         # Pentecost monday
-        self[easter_date + rd(days=+50)] = "Pinkstermaandag"
+        self[easter_date + timedelta(days=+50)] = "Pinkstermaandag"
 
         # International Workers' Day
         self[date(year, MAY, 1)] = "Dag van de Arbeid"

--- a/holidays/countries/bolivia.py
+++ b/holidays/countries/bolivia.py
@@ -10,10 +10,9 @@
 #  License: MIT (see LICENSE file)
 #  Copyright: Kateryna Golovanova <kate@kgthreads.com>, 2022
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV
 from holidays.constants import DEC, FRI, SUN
@@ -48,7 +47,9 @@ class Bolivia(HolidayBase):
             self[date(year, JAN, 1)] = name
 
         if self.observed and date(year, JAN, 1).weekday() == SUN:
-            self[date(year, JAN, 1) + rd(days=+1)] = f"{name} (Observed)"
+            self[
+                date(year, JAN, 1) + timedelta(days=+1)
+            ] = f"{name} (Observed)"
 
         # Plurinational State Foundation Day.
         if year >= 2010:
@@ -58,7 +59,7 @@ class Bolivia(HolidayBase):
 
         # Good Friday.
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Viernes Santo"
+        self[easter_date + timedelta(days=-2)] = "Viernes Santo"
 
         # La Tablada.
         if self.subdiv == "T":
@@ -66,26 +67,28 @@ class Bolivia(HolidayBase):
 
         # Carnival in Oruro.
         if self.subdiv == "O":
-            self[easter_date + rd(days=-51)] = "Carnaval de Oruro"
+            self[easter_date + timedelta(days=-51)] = "Carnaval de Oruro"
 
         # Carnival Monday (Observed on Tuesday).
         name = "Feriado por Carnaval"
-        self[easter_date + rd(days=-48)] = name
-        self[easter_date + rd(days=-47)] = f"{name} (Observed)"
+        self[easter_date + timedelta(days=-48)] = name
+        self[easter_date + timedelta(days=-47)] = f"{name} (Observed)"
 
         # Labor Day.
         name = "Dia del trabajo"
         self[date(year, MAY, 1)] = name
 
         if self.observed and date(year, MAY, 1).weekday() == SUN:
-            self[date(year, MAY, 1) + rd(days=+1)] = f"{name} (Observed)"
+            self[
+                date(year, MAY, 1) + timedelta(days=+1)
+            ] = f"{name} (Observed)"
 
         # Chuquisaca Day.
         if self.subdiv == "H":
             self[date(year, MAY, 25)] = "Día del departamento de Chuquisaca"
 
         # Corpus Christi.
-        self[easter_date + rd(days=+60)] = "Corpus Christi"
+        self[easter_date + timedelta(days=+60)] = "Corpus Christi"
 
         # Andean New Year.
         name = "Año Nuevo Andino"
@@ -93,7 +96,9 @@ class Bolivia(HolidayBase):
             self[date(year, JUN, 21)] = name
 
         if self.observed and date(year, JUN, 21).weekday() == SUN:
-            self[date(year, JUN, 21) + rd(days=+1)] = f"{name} (Observed)"
+            self[
+                date(year, JUN, 21) + timedelta(days=+1)
+            ] = f"{name} (Observed)"
 
         # La Paz Day.
         if self.subdiv == "L":
@@ -109,7 +114,9 @@ class Bolivia(HolidayBase):
             self[date(year, AUG, 6)] = name
 
         if self.observed and date(year, AUG, 6).weekday() > FRI:
-            self[date(year, AUG, 6) + rd(days=+1)] = f"{name} (Observed)"
+            self[
+                date(year, AUG, 6) + timedelta(days=+1)
+            ] = f"{name} (Observed)"
 
         # Cochabamba Day.
         if self.subdiv == "C":
@@ -128,7 +135,9 @@ class Bolivia(HolidayBase):
         self[date(year, NOV, 2)] = name
 
         if self.observed and date(year, NOV, 2).weekday() == SUN:
-            self[date(year, NOV, 2) + rd(days=+1)] = f"{name} (Observed)"
+            self[
+                date(year, NOV, 2) + timedelta(days=+1)
+            ] = f"{name} (Observed)"
 
         # Potosí Day.
         if self.subdiv == "P":
@@ -143,7 +152,9 @@ class Bolivia(HolidayBase):
         self[date(year, DEC, 25)] = name
 
         if self.observed and date(year, DEC, 25).weekday() == SUN:
-            self[date(year, DEC, 25) + rd(days=+1)] = f"{name} (Observed)"
+            self[
+                date(year, DEC, 25) + timedelta(days=+1)
+            ] = f"{name} (Observed)"
 
 
 class BO(Bolivia):

--- a/holidays/countries/bolivia.py
+++ b/holidays/countries/bolivia.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 #  Copyright: Kateryna Golovanova <kate@kgthreads.com>, 2022
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -47,9 +48,7 @@ class Bolivia(HolidayBase):
             self[date(year, JAN, 1)] = name
 
         if self.observed and date(year, JAN, 1).weekday() == SUN:
-            self[
-                date(year, JAN, 1) + timedelta(days=+1)
-            ] = f"{name} (Observed)"
+            self[date(year, JAN, 1) + td(days=+1)] = f"{name} (Observed)"
 
         # Plurinational State Foundation Day.
         if year >= 2010:
@@ -59,7 +58,7 @@ class Bolivia(HolidayBase):
 
         # Good Friday.
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Viernes Santo"
+        self[easter_date + td(days=-2)] = "Viernes Santo"
 
         # La Tablada.
         if self.subdiv == "T":
@@ -67,28 +66,26 @@ class Bolivia(HolidayBase):
 
         # Carnival in Oruro.
         if self.subdiv == "O":
-            self[easter_date + timedelta(days=-51)] = "Carnaval de Oruro"
+            self[easter_date + td(days=-51)] = "Carnaval de Oruro"
 
         # Carnival Monday (Observed on Tuesday).
         name = "Feriado por Carnaval"
-        self[easter_date + timedelta(days=-48)] = name
-        self[easter_date + timedelta(days=-47)] = f"{name} (Observed)"
+        self[easter_date + td(days=-48)] = name
+        self[easter_date + td(days=-47)] = f"{name} (Observed)"
 
         # Labor Day.
         name = "Dia del trabajo"
         self[date(year, MAY, 1)] = name
 
         if self.observed and date(year, MAY, 1).weekday() == SUN:
-            self[
-                date(year, MAY, 1) + timedelta(days=+1)
-            ] = f"{name} (Observed)"
+            self[date(year, MAY, 1) + td(days=+1)] = f"{name} (Observed)"
 
         # Chuquisaca Day.
         if self.subdiv == "H":
             self[date(year, MAY, 25)] = "Día del departamento de Chuquisaca"
 
         # Corpus Christi.
-        self[easter_date + timedelta(days=+60)] = "Corpus Christi"
+        self[easter_date + td(days=+60)] = "Corpus Christi"
 
         # Andean New Year.
         name = "Año Nuevo Andino"
@@ -96,9 +93,7 @@ class Bolivia(HolidayBase):
             self[date(year, JUN, 21)] = name
 
         if self.observed and date(year, JUN, 21).weekday() == SUN:
-            self[
-                date(year, JUN, 21) + timedelta(days=+1)
-            ] = f"{name} (Observed)"
+            self[date(year, JUN, 21) + td(days=+1)] = f"{name} (Observed)"
 
         # La Paz Day.
         if self.subdiv == "L":
@@ -114,9 +109,7 @@ class Bolivia(HolidayBase):
             self[date(year, AUG, 6)] = name
 
         if self.observed and date(year, AUG, 6).weekday() > FRI:
-            self[
-                date(year, AUG, 6) + timedelta(days=+1)
-            ] = f"{name} (Observed)"
+            self[date(year, AUG, 6) + td(days=+1)] = f"{name} (Observed)"
 
         # Cochabamba Day.
         if self.subdiv == "C":
@@ -135,9 +128,7 @@ class Bolivia(HolidayBase):
         self[date(year, NOV, 2)] = name
 
         if self.observed and date(year, NOV, 2).weekday() == SUN:
-            self[
-                date(year, NOV, 2) + timedelta(days=+1)
-            ] = f"{name} (Observed)"
+            self[date(year, NOV, 2) + td(days=+1)] = f"{name} (Observed)"
 
         # Potosí Day.
         if self.subdiv == "P":
@@ -152,9 +143,7 @@ class Bolivia(HolidayBase):
         self[date(year, DEC, 25)] = name
 
         if self.observed and date(year, DEC, 25).weekday() == SUN:
-            self[
-                date(year, DEC, 25) + timedelta(days=+1)
-            ] = f"{name} (Observed)"
+            self[date(year, DEC, 25) + td(days=+1)] = f"{name} (Observed)"
 
 
 class BO(Bolivia):

--- a/holidays/countries/bosnia_and_herzegovina.py
+++ b/holidays/countries/bosnia_and_herzegovina.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 #  Copyright: Kateryna Golovanova <kate@kgthreads.com>, 2022
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -40,17 +41,15 @@ class BosniaAndHerzegovina(HolidayBase):
         self[date(year, JAN, 2)] = "Drugi dan Nove Godine"
 
         if self.observed and date(year, JAN, 1).weekday() == SUN:
-            self[
-                date(year, JAN, 1) + timedelta(days=+2)
-            ] = "Treći dan Nove Godine"
+            self[date(year, JAN, 1) + td(days=+2)] = "Treći dan Nove Godine"
 
         # Labor Day.
         may_1 = date(year, MAY, 1)
         self[may_1] = "Dan rada"
-        self[may_1 + timedelta(days=+1)] = "Drugi dan Dana rada"
+        self[may_1 + td(days=+1)] = "Drugi dan Dana rada"
 
         if self.observed and may_1.weekday() == SUN:
-            self[may_1 + timedelta(days=+2)] = "Treći dan Dana rada"
+            self[may_1 + td(days=+2)] = "Treći dan Dana rada"
 
         if self.subdiv == "FBiH":
             # Independence Day.
@@ -58,24 +57,22 @@ class BosniaAndHerzegovina(HolidayBase):
 
             easter_date = easter(year)
             # Catholic Good Friday.
-            self[easter_date + timedelta(days=-2)] = "Veliki Petak (Katolički)"
+            self[easter_date + td(days=-2)] = "Veliki Petak (Katolički)"
 
             # Catholic Easter.
             self[easter_date] = "Uskrs (Katolički)"
-            self[
-                easter_date + timedelta(days=+1)
-            ] = "Uskrsni ponedjeljak (Katolički)"
+            self[easter_date + td(days=+1)] = "Uskrsni ponedjeljak (Katolički)"
 
             # Corpus Cristi.
             self[
-                easter_date + timedelta(days=+60)
+                easter_date + td(days=+60)
             ] = "Tijelovo (Tijelo i Krv Kristova)"
 
             # Eid al-Fitr.
             # Date of observance is announced yearly, this is an estimate.
             for dt in _islamic_to_gre(year, 10, 1):
                 self[dt] = "Ramazanski Bajram"
-                self[dt + timedelta(days=+1)] = "Drugi Dan Ramazanski Bajram"
+                self[dt + td(days=+1)] = "Drugi Dan Ramazanski Bajram"
 
             # Eid ul-Adha.
             # Date of observance is announced yearly, this is an estimate.
@@ -83,7 +80,7 @@ class BosniaAndHerzegovina(HolidayBase):
             for dt in _islamic_to_gre(year, 12, 10):
                 self[dt] = name
                 for d in range(1, 4):
-                    self[dt + timedelta(days=+d)] = name
+                    self[dt + td(days=+d)] = name
 
             # Islamic New Year.
             for dt in _islamic_to_gre(year, 1, 1):
@@ -119,14 +116,12 @@ class BosniaAndHerzegovina(HolidayBase):
 
             easter_date = easter(year, method=EASTER_ORTHODOX)
             # Orthodox Good Friday.
-            self[
-                easter_date + timedelta(days=-2)
-            ] = "Veliki Petak (Pravoslavni)"
+            self[easter_date + td(days=-2)] = "Veliki Petak (Pravoslavni)"
 
             # Orthodox Easter.
             self[easter_date] = "Vaskrs (Pravoslavni)"
             self[
-                easter_date + timedelta(days=+1)
+                easter_date + td(days=+1)
             ] = "Uskrsni ponedjeljak (Pravoslavni)"
 
             # Victory Day.

--- a/holidays/countries/bosnia_and_herzegovina.py
+++ b/holidays/countries/bosnia_and_herzegovina.py
@@ -10,10 +10,9 @@
 #  License: MIT (see LICENSE file)
 #  Copyright: Kateryna Golovanova <kate@kgthreads.com>, 2022
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import DEC, JAN, JUN, MAR, MAY, NOV, SUN
 from holidays.holiday_base import HolidayBase
@@ -41,15 +40,17 @@ class BosniaAndHerzegovina(HolidayBase):
         self[date(year, JAN, 2)] = "Drugi dan Nove Godine"
 
         if self.observed and date(year, JAN, 1).weekday() == SUN:
-            self[date(year, JAN, 1) + rd(days=+2)] = "Treći dan Nove Godine"
+            self[
+                date(year, JAN, 1) + timedelta(days=+2)
+            ] = "Treći dan Nove Godine"
 
         # Labor Day.
         may_1 = date(year, MAY, 1)
         self[may_1] = "Dan rada"
-        self[may_1 + rd(days=+1)] = "Drugi dan Dana rada"
+        self[may_1 + timedelta(days=+1)] = "Drugi dan Dana rada"
 
         if self.observed and may_1.weekday() == SUN:
-            self[may_1 + rd(days=+2)] = "Treći dan Dana rada"
+            self[may_1 + timedelta(days=+2)] = "Treći dan Dana rada"
 
         if self.subdiv == "FBiH":
             # Independence Day.
@@ -57,22 +58,24 @@ class BosniaAndHerzegovina(HolidayBase):
 
             easter_date = easter(year)
             # Catholic Good Friday.
-            self[easter_date + rd(days=-2)] = "Veliki Petak (Katolički)"
+            self[easter_date + timedelta(days=-2)] = "Veliki Petak (Katolički)"
 
             # Catholic Easter.
             self[easter_date] = "Uskrs (Katolički)"
-            self[easter_date + rd(days=+1)] = "Uskrsni ponedjeljak (Katolički)"
+            self[
+                easter_date + timedelta(days=+1)
+            ] = "Uskrsni ponedjeljak (Katolički)"
 
             # Corpus Cristi.
             self[
-                easter_date + rd(days=+60)
+                easter_date + timedelta(days=+60)
             ] = "Tijelovo (Tijelo i Krv Kristova)"
 
             # Eid al-Fitr.
             # Date of observance is announced yearly, this is an estimate.
             for dt in _islamic_to_gre(year, 10, 1):
                 self[dt] = "Ramazanski Bajram"
-                self[dt + rd(days=+1)] = "Drugi Dan Ramazanski Bajram"
+                self[dt + timedelta(days=+1)] = "Drugi Dan Ramazanski Bajram"
 
             # Eid ul-Adha.
             # Date of observance is announced yearly, this is an estimate.
@@ -80,7 +83,7 @@ class BosniaAndHerzegovina(HolidayBase):
             for dt in _islamic_to_gre(year, 12, 10):
                 self[dt] = name
                 for d in range(1, 4):
-                    self[dt + rd(days=+d)] = name
+                    self[dt + timedelta(days=+d)] = name
 
             # Islamic New Year.
             for dt in _islamic_to_gre(year, 1, 1):
@@ -116,12 +119,14 @@ class BosniaAndHerzegovina(HolidayBase):
 
             easter_date = easter(year, method=EASTER_ORTHODOX)
             # Orthodox Good Friday.
-            self[easter_date + rd(days=-2)] = "Veliki Petak (Pravoslavni)"
+            self[
+                easter_date + timedelta(days=-2)
+            ] = "Veliki Petak (Pravoslavni)"
 
             # Orthodox Easter.
             self[easter_date] = "Vaskrs (Pravoslavni)"
             self[
-                easter_date + rd(days=+1)
+                easter_date + timedelta(days=+1)
             ] = "Uskrsni ponedjeljak (Pravoslavni)"
 
             # Victory Day.

--- a/holidays/countries/botswana.py
+++ b/holidays/countries/botswana.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -40,19 +41,19 @@ class Botswana(HolidayBase):
 
         # Easter and easter related calculations
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
-        self[easter_date + timedelta(days=-1)] = "Holy Saturday"
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-1)] = "Holy Saturday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
 
         self[date(year, MAY, 1)] = "Labour Day"
-        self[easter_date + timedelta(days=+39)] = "Ascension Day"
+        self[easter_date + td(days=+39)] = "Ascension Day"
 
         self[date(year, JUL, 1)] = "Sir Seretse Khama Day"
 
         # 3rd Monday of July = "President's Day"
         d = date(year, JUL, 1) + rd(weekday=MO(+3))
         self[d] = "President's Day"
-        self[d + timedelta(days=+1)] = "President's Day Holiday"
+        self[d + td(days=+1)] = "President's Day Holiday"
 
         self[date(year, SEP, 30)] = "Botswana Day"
         self[date(year, OCT, 1)] = "Botswana Day Holiday"
@@ -70,14 +71,14 @@ class Botswana(HolidayBase):
                     and v.upper() in {"BOXING DAY", "LABOUR DAY"}
                 ):
                     # Add the (Observed) holiday
-                    self[k + timedelta(days=+2)] = v + " Holiday"
+                    self[k + td(days=+2)] = v + " Holiday"
                 if (
                     1995 <= year == k.year
                     and k.weekday() == SUN
                     and v.upper() != "NEW YEAR'S DAY HOLIDAY"
                 ):
                     # Add the (Observed) holiday
-                    self[k + timedelta(days=+1)] = v + " (Observed)"
+                    self[k + td(days=+1)] = v + " (Observed)"
 
                 # If there is a holiday and an (Observed) holiday
                 # on the same day, add an (Observed) holiday for that holiday
@@ -89,7 +90,7 @@ class Botswana(HolidayBase):
                     # Add an (Observed) for the one that is not (Observed)
                     for name in hol_names:
                         if " (Observed)" not in name:
-                            self[k + timedelta(days=+1)] = (
+                            self[k + td(days=+1)] = (
                                 name.lstrip() + " (Observed)"
                             )
 

--- a/holidays/countries/botswana.py
+++ b/holidays/countries/botswana.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -40,19 +40,19 @@ class Botswana(HolidayBase):
 
         # Easter and easter related calculations
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
-        self[easter_date + rd(days=-1)] = "Holy Saturday"
-        self[easter_date + rd(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-1)] = "Holy Saturday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
         self[date(year, MAY, 1)] = "Labour Day"
-        self[easter_date + rd(days=+39)] = "Ascension Day"
+        self[easter_date + timedelta(days=+39)] = "Ascension Day"
 
         self[date(year, JUL, 1)] = "Sir Seretse Khama Day"
 
         # 3rd Monday of July = "President's Day"
         d = date(year, JUL, 1) + rd(weekday=MO(+3))
         self[d] = "President's Day"
-        self[d + rd(days=+1)] = "President's Day Holiday"
+        self[d + timedelta(days=+1)] = "President's Day Holiday"
 
         self[date(year, SEP, 30)] = "Botswana Day"
         self[date(year, OCT, 1)] = "Botswana Day Holiday"
@@ -70,14 +70,14 @@ class Botswana(HolidayBase):
                     and v.upper() in {"BOXING DAY", "LABOUR DAY"}
                 ):
                     # Add the (Observed) holiday
-                    self[k + rd(days=+2)] = v + " Holiday"
+                    self[k + timedelta(days=+2)] = v + " Holiday"
                 if (
                     1995 <= year == k.year
                     and k.weekday() == SUN
                     and v.upper() != "NEW YEAR'S DAY HOLIDAY"
                 ):
                     # Add the (Observed) holiday
-                    self[k + rd(days=+1)] = v + " (Observed)"
+                    self[k + timedelta(days=+1)] = v + " (Observed)"
 
                 # If there is a holiday and an (Observed) holiday
                 # on the same day, add an (Observed) holiday for that holiday
@@ -89,7 +89,7 @@ class Botswana(HolidayBase):
                     # Add an (Observed) for the one that is not (Observed)
                     for name in hol_names:
                         if " (Observed)" not in name:
-                            self[k + rd(days=+1)] = (
+                            self[k + timedelta(days=+1)] = (
                                 name.lstrip() + " (Observed)"
                             )
 

--- a/holidays/countries/brazil.py
+++ b/holidays/countries/brazil.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import SU
@@ -78,16 +79,16 @@ class Brazil(HolidayBase):
         self[date(year, DEC, 25)] = "Natal"
 
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Sexta-feira Santa"
+        self[easter_date + td(days=-2)] = "Sexta-feira Santa"
 
         self[easter_date] = "Páscoa"
 
-        self[easter_date + timedelta(days=+60)] = "Corpus Christi"
+        self[easter_date + td(days=+60)] = "Corpus Christi"
 
-        quaresma = easter_date + timedelta(days=-46)
+        quaresma = easter_date + td(days=-46)
         self[quaresma] = "Quarta-feira de cinzas (Início da Quaresma)"
 
-        self[quaresma + timedelta(days=-1)] = "Carnaval"
+        self[quaresma + td(days=-1)] = "Carnaval"
 
         if self.subdiv == "AC":
             self[date(year, JAN, 23)] = "Dia do evangélico"

--- a/holidays/countries/brazil.py
+++ b/holidays/countries/brazil.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import SU
@@ -78,16 +78,16 @@ class Brazil(HolidayBase):
         self[date(year, DEC, 25)] = "Natal"
 
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Sexta-feira Santa"
+        self[easter_date + timedelta(days=-2)] = "Sexta-feira Santa"
 
         self[easter_date] = "Páscoa"
 
-        self[easter_date + rd(days=+60)] = "Corpus Christi"
+        self[easter_date + timedelta(days=+60)] = "Corpus Christi"
 
-        quaresma = easter_date + rd(days=-46)
+        quaresma = easter_date + timedelta(days=-46)
         self[quaresma] = "Quarta-feira de cinzas (Início da Quaresma)"
 
-        self[quaresma + rd(days=-1)] = "Carnaval"
+        self[quaresma + timedelta(days=-1)] = "Carnaval"
 
         if self.subdiv == "AC":
             self[date(year, JAN, 23)] = "Dia do evangélico"

--- a/holidays/countries/bulgaria.py
+++ b/holidays/countries/bulgaria.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, MAY, SEP, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -87,10 +86,10 @@ class Bulgaria(HolidayBase):
 
         # Easter
         easter_date = easter(year, method=EASTER_ORTHODOX)
-        self[easter_date + rd(days=-2)] = "Велики петък"
-        self[easter_date + rd(days=-1)] = "Велика събота"
+        self[easter_date + timedelta(days=-2)] = "Велики петък"
+        self[easter_date + timedelta(days=-1)] = "Велика събота"
         self[easter_date] = "Великден"
-        self[easter_date + rd(days=+1)] = "Великден"
+        self[easter_date + timedelta(days=+1)] = "Великден"
 
 
 class BG(Bulgaria):

--- a/holidays/countries/bulgaria.py
+++ b/holidays/countries/bulgaria.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -86,10 +87,10 @@ class Bulgaria(HolidayBase):
 
         # Easter
         easter_date = easter(year, method=EASTER_ORTHODOX)
-        self[easter_date + timedelta(days=-2)] = "Велики петък"
-        self[easter_date + timedelta(days=-1)] = "Велика събота"
+        self[easter_date + td(days=-2)] = "Велики петък"
+        self[easter_date + td(days=-1)] = "Велика събота"
         self[easter_date] = "Великден"
-        self[easter_date + timedelta(days=+1)] = "Великден"
+        self[easter_date + td(days=+1)] = "Великден"
 
 
 class BG(Bulgaria):

--- a/holidays/countries/burundi.py
+++ b/holidays/countries/burundi.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -66,7 +67,7 @@ class Burundi(HolidayBase):
 
         # Ascension Day
         name = "Ascension Day"
-        self[easter(year) + timedelta(days=+39)] = name
+        self[easter(year) + td(days=+39)] = name
 
         # Independence Day post 1962
         name = "Independence Day"
@@ -81,7 +82,7 @@ class Burundi(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 10):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid Al Adha")
-                _add_holiday(hol_date + timedelta(days=+1), "Eid Al Adha")
+                _add_holiday(hol_date + td(days=+1), "Eid Al Adha")
 
         # Assumption Day
         name = "Assumption Day"

--- a/holidays/countries/burundi.py
+++ b/holidays/countries/burundi.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, APR, MAY, JUL, AUG, OCT, NOV, DEC, SUN
 from holidays.holiday_base import HolidayBase
@@ -67,7 +66,7 @@ class Burundi(HolidayBase):
 
         # Ascension Day
         name = "Ascension Day"
-        self[easter(year) + rd(days=+39)] = name
+        self[easter(year) + timedelta(days=+39)] = name
 
         # Independence Day post 1962
         name = "Independence Day"
@@ -82,7 +81,7 @@ class Burundi(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 10):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid Al Adha")
-                _add_holiday(hol_date + rd(days=+1), "Eid Al Adha")
+                _add_holiday(hol_date + timedelta(days=+1), "Eid Al Adha")
 
         # Assumption Day
         name = "Assumption Day"

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, SU
@@ -97,9 +97,9 @@ class Canada(HolidayBase):
             # Friday before the last Sunday in February
             dt = (
                 date(year, MAR, 1)
-                + rd(days=-1)
+                + timedelta(days=-1)
                 + rd(weekday=SU(-1))
-                + rd(days=-2)
+                + timedelta(days=-2)
             )
             self[dt] = "Heritage Day"
 
@@ -111,9 +111,9 @@ class Canada(HolidayBase):
 
         easter_date = easter(year)
         # Good Friday
-        self[easter_date + rd(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
         # Easter Monday
-        self[easter_date + rd(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
         # St. George's Day
         if self.subdiv == "NL" and year >= 1990:
@@ -144,7 +144,7 @@ class Canada(HolidayBase):
             dt = date(year, JUN, 24)
             self[dt] = name
             if self.observed and dt.weekday() == SUN:
-                self[dt + rd(days=+1)] = name + " (Observed)"
+                self[dt + timedelta(days=+1)] = name + " (Observed)"
 
         # Discovery Day
         if self.subdiv == "NL" and year >= 1997:
@@ -171,7 +171,7 @@ class Canada(HolidayBase):
                 dt = date(year, JUL, 9)
                 self[dt] = name
                 if self.observed and dt.weekday() == SUN:
-                    self[dt + rd(days=+1)] = name + " (Observed)"
+                    self[dt + timedelta(days=+1)] = name + " (Observed)"
             elif year == 2000:
                 self[date(2000, APR, 1)] = name
 
@@ -243,14 +243,14 @@ class Canada(HolidayBase):
         dt = date(year, DEC, 25)
         self[dt] = name
         if self.observed and self._is_weekend(dt):
-            self[dt + rd(days=+2)] = name + " (Observed)"
+            self[dt + timedelta(days=+2)] = name + " (Observed)"
 
         # Boxing Day
         name = "Boxing Day"
         dt = date(year, DEC, 26)
         self[dt] = name
         if self.observed and self._is_weekend(dt):
-            self[dt + rd(days=+2)] = name + " (Observed)"
+            self[dt + timedelta(days=+2)] = name + " (Observed)"
 
 
 class CA(Canada):

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, SU
@@ -97,9 +98,9 @@ class Canada(HolidayBase):
             # Friday before the last Sunday in February
             dt = (
                 date(year, MAR, 1)
-                + timedelta(days=-1)
+                + td(days=-1)
                 + rd(weekday=SU(-1))
-                + timedelta(days=-2)
+                + td(days=-2)
             )
             self[dt] = "Heritage Day"
 
@@ -111,9 +112,9 @@ class Canada(HolidayBase):
 
         easter_date = easter(year)
         # Good Friday
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-2)] = "Good Friday"
         # Easter Monday
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
 
         # St. George's Day
         if self.subdiv == "NL" and year >= 1990:
@@ -144,7 +145,7 @@ class Canada(HolidayBase):
             dt = date(year, JUN, 24)
             self[dt] = name
             if self.observed and dt.weekday() == SUN:
-                self[dt + timedelta(days=+1)] = name + " (Observed)"
+                self[dt + td(days=+1)] = name + " (Observed)"
 
         # Discovery Day
         if self.subdiv == "NL" and year >= 1997:
@@ -171,7 +172,7 @@ class Canada(HolidayBase):
                 dt = date(year, JUL, 9)
                 self[dt] = name
                 if self.observed and dt.weekday() == SUN:
-                    self[dt + timedelta(days=+1)] = name + " (Observed)"
+                    self[dt + td(days=+1)] = name + " (Observed)"
             elif year == 2000:
                 self[date(2000, APR, 1)] = name
 
@@ -243,14 +244,14 @@ class Canada(HolidayBase):
         dt = date(year, DEC, 25)
         self[dt] = name
         if self.observed and self._is_weekend(dt):
-            self[dt + timedelta(days=+2)] = name + " (Observed)"
+            self[dt + td(days=+2)] = name + " (Observed)"
 
         # Boxing Day
         name = "Boxing Day"
         dt = date(year, DEC, 26)
         self[dt] = name
         if self.observed and self._is_weekend(dt):
-            self[dt + timedelta(days=+2)] = name + " (Observed)"
+            self[dt + td(days=+2)] = name + " (Observed)"
 
 
 class CA(Canada):

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
+from datetime import timedelta as td
 
 from dateutil import tz
 from dateutil.easter import easter
@@ -71,25 +72,25 @@ class Chile(HolidayBase):
         # Holy Week (Law 2.977)
         easter_date = easter(year)
         self[
-            easter_date + timedelta(days=-2)
+            easter_date + td(days=-2)
         ] = "Semana Santa (Viernes Santo) [Good Friday)]"
         self[
-            easter_date + timedelta(days=-1)
+            easter_date + td(days=-1)
         ] = "Semana Santa (Sábado Santo) [Good Saturday)]"
 
         # Ascension
         if year <= 1967:
             self[
-                easter_date + timedelta(days=+39)
+                easter_date + td(days=+39)
             ] = "Ascensión del Señor [Ascension of Jesus]"
 
         # Corpus Christi
         if year <= 1967 or 1987 <= year <= 2006:
             # Law 19.668
             if year <= 1999:
-                dt = easter_date + timedelta(days=+60)
+                dt = easter_date + td(days=+60)
             else:
-                dt = easter_date + timedelta(days=+57)
+                dt = easter_date + td(days=+57)
             self[dt] = "Corpus Christi [Corpus Christi]"
 
         # Labour Day (Law 2.200, renamed with Law 18.018)
@@ -207,9 +208,9 @@ class Chile(HolidayBase):
             # if it falls on a Tuesday, or to the following Friday
             # if it falls on a Wednesday (Law 20.299)
             if dt.weekday() == WED:
-                dt += timedelta(days=+2)
+                dt += td(days=+2)
             elif dt.weekday() == TUE:
-                dt += timedelta(days=-4)
+                dt += td(days=-4)
             self[dt] = (
                 "Día Nacional de las Iglesias Evangélicas y Protestantes"
                 " [Reformation Day]"

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from dateutil import tz
 from dateutil.easter import easter
@@ -71,25 +71,25 @@ class Chile(HolidayBase):
         # Holy Week (Law 2.977)
         easter_date = easter(year)
         self[
-            easter_date + rd(days=-2)
+            easter_date + timedelta(days=-2)
         ] = "Semana Santa (Viernes Santo) [Good Friday)]"
         self[
-            easter_date + rd(days=-1)
+            easter_date + timedelta(days=-1)
         ] = "Semana Santa (Sábado Santo) [Good Saturday)]"
 
         # Ascension
         if year <= 1967:
             self[
-                easter_date + rd(days=+39)
+                easter_date + timedelta(days=+39)
             ] = "Ascensión del Señor [Ascension of Jesus]"
 
         # Corpus Christi
         if year <= 1967 or 1987 <= year <= 2006:
             # Law 19.668
             if year <= 1999:
-                dt = easter_date + rd(days=+60)
+                dt = easter_date + timedelta(days=+60)
             else:
-                dt = easter_date + rd(days=+57)
+                dt = easter_date + timedelta(days=+57)
             self[dt] = "Corpus Christi [Corpus Christi]"
 
         # Labour Day (Law 2.200, renamed with Law 18.018)
@@ -207,9 +207,9 @@ class Chile(HolidayBase):
             # if it falls on a Tuesday, or to the following Friday
             # if it falls on a Wednesday (Law 20.299)
             if dt.weekday() == WED:
-                dt += rd(days=+2)
+                dt += timedelta(days=+2)
             elif dt.weekday() == TUE:
-                dt += rd(days=-4)
+                dt += timedelta(days=-4)
             self[dt] = (
                 "Día Nacional de las Iglesias Evangélicas y Protestantes"
                 " [Reformation Day]"

--- a/holidays/countries/china.py
+++ b/holidays/countries/china.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import JAN, APR, MAY, OCT
 from holidays.holiday_base import HolidayBase
@@ -39,24 +40,24 @@ class China(HolidayBase):
         dt = date(year, MAY, 1)
         self[dt] = name
         if 2000 <= year <= 2007:
-            self[dt + timedelta(days=+1)] = name
-            self[dt + timedelta(days=+2)] = name
+            self[dt + td(days=+1)] = name
+            self[dt + td(days=+2)] = name
 
         name = "Chinese New Year (Spring Festival)"
         dt = self.cnls.lunar_n_y_date(year)
         self[dt] = name
-        self[dt + timedelta(days=+1)] = name
+        self[dt + td(days=+1)] = name
         if 2008 <= year <= 2013:
-            self[dt + timedelta(days=-1)] = name
+            self[dt + td(days=-1)] = name
         else:
-            self[dt + timedelta(days=+2)] = name
+            self[dt + td(days=+2)] = name
 
         name = "National Day"
         dt = date(year, OCT, 1)
         self[dt] = name
-        self[dt + timedelta(days=+1)] = name
+        self[dt + td(days=+1)] = name
         if year >= 2000:
-            self[dt + timedelta(days=+2)] = name
+            self[dt + td(days=+2)] = name
 
         if year >= 2008:
             self[date(year, APR, 5)] = "Tomb-Sweeping Day"

--- a/holidays/countries/china.py
+++ b/holidays/countries/china.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import JAN, APR, MAY, OCT
 from holidays.holiday_base import HolidayBase
@@ -41,24 +39,24 @@ class China(HolidayBase):
         dt = date(year, MAY, 1)
         self[dt] = name
         if 2000 <= year <= 2007:
-            self[dt + rd(days=+1)] = name
-            self[dt + rd(days=+2)] = name
+            self[dt + timedelta(days=+1)] = name
+            self[dt + timedelta(days=+2)] = name
 
         name = "Chinese New Year (Spring Festival)"
         dt = self.cnls.lunar_n_y_date(year)
         self[dt] = name
-        self[dt + rd(days=+1)] = name
+        self[dt + timedelta(days=+1)] = name
         if 2008 <= year <= 2013:
-            self[dt + rd(days=-1)] = name
+            self[dt + timedelta(days=-1)] = name
         else:
-            self[dt + rd(days=+2)] = name
+            self[dt + timedelta(days=+2)] = name
 
         name = "National Day"
         dt = date(year, OCT, 1)
         self[dt] = name
-        self[dt + rd(days=+1)] = name
+        self[dt + timedelta(days=+1)] = name
         if year >= 2000:
-            self[dt + rd(days=+2)] = name
+            self[dt + timedelta(days=+2)] = name
 
         if year >= 2008:
             self[date(year, APR, 5)] = "Tomb-Sweeping Day"

--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -149,31 +150,29 @@ class Colombia(HolidayBase):
     def _add_fixed_easter_based_holidays(self, _easter):
         if _easter.year > 1950:
             # Maundy Thursday
-            self[
-                _easter + timedelta(days=-3)
-            ] = "Jueves Santo [Maundy Thursday]"
+            self[_easter + td(days=-3)] = "Jueves Santo [Maundy Thursday]"
 
             # Good Friday
-            self[_easter + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
+            self[_easter + td(days=-2)] = "Viernes Santo [Good Friday]"
 
     def _add_flexible_easter_based_holidays(self, _easter):
         if _easter.year > 1950:
             # Ascension of Jesus
             self._add_with_bridge(
-                _easter + timedelta(days=+39),
+                _easter + td(days=+39),
                 "Ascensión del señor [Ascension of Jesus]",
             )
 
             # Corpus Christi
             self._add_with_bridge(
-                _easter + timedelta(days=+60),
+                _easter + td(days=+60),
                 "Corpus Christi [Corpus Christi]",
             )
 
         if _easter.year > 1983:
             # Sacred Heart
             self._add_with_bridge(
-                _easter + timedelta(days=+68),
+                _easter + td(days=+68),
                 "Sagrado Corazón [Sacred Heart]",
             )
 

--- a/holidays/countries/colombia.py
+++ b/holidays/countries/colombia.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -149,29 +149,31 @@ class Colombia(HolidayBase):
     def _add_fixed_easter_based_holidays(self, _easter):
         if _easter.year > 1950:
             # Maundy Thursday
-            self[_easter + rd(days=-3)] = "Jueves Santo [Maundy Thursday]"
+            self[
+                _easter + timedelta(days=-3)
+            ] = "Jueves Santo [Maundy Thursday]"
 
             # Good Friday
-            self[_easter + rd(days=-2)] = "Viernes Santo [Good Friday]"
+            self[_easter + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
 
     def _add_flexible_easter_based_holidays(self, _easter):
         if _easter.year > 1950:
             # Ascension of Jesus
             self._add_with_bridge(
-                _easter + rd(days=+39),
+                _easter + timedelta(days=+39),
                 "Ascensión del señor [Ascension of Jesus]",
             )
 
             # Corpus Christi
             self._add_with_bridge(
-                _easter + rd(days=+60),
+                _easter + timedelta(days=+60),
                 "Corpus Christi [Corpus Christi]",
             )
 
         if _easter.year > 1983:
             # Sacred Heart
             self._add_with_bridge(
-                _easter + rd(days=+68),
+                _easter + timedelta(days=+68),
                 "Sagrado Corazón [Sacred Heart]",
             )
 

--- a/holidays/countries/croatia.py
+++ b/holidays/countries/croatia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUN, AUG, OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -40,10 +39,10 @@ class Croatia(HolidayBase):
         # Easter
         self[easter_date] = "Uskrs"
         # Easter Monday
-        self[easter_date + rd(days=+1)] = "Uskrsni ponedjeljak"
+        self[easter_date + timedelta(days=+1)] = "Uskrsni ponedjeljak"
 
         # Corpus Christi
-        self[easter_date + rd(days=+60)] = "Tijelovo"
+        self[easter_date + timedelta(days=+60)] = "Tijelovo"
 
         # International Workers' Day
         self[date(year, MAY, 1)] = "Međunarodni praznik rada"

--- a/holidays/countries/croatia.py
+++ b/holidays/countries/croatia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -39,10 +40,10 @@ class Croatia(HolidayBase):
         # Easter
         self[easter_date] = "Uskrs"
         # Easter Monday
-        self[easter_date + timedelta(days=+1)] = "Uskrsni ponedjeljak"
+        self[easter_date + td(days=+1)] = "Uskrsni ponedjeljak"
 
         # Corpus Christi
-        self[easter_date + timedelta(days=+60)] = "Tijelovo"
+        self[easter_date + td(days=+60)] = "Tijelovo"
 
         # International Workers' Day
         self[date(year, MAY, 1)] = "Međunarodni praznik rada"

--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -57,7 +57,9 @@ class Cuba(HolidayBase):
         #   https://bit.ly/3v6bM18
         # Permanently granted in 2013 decree for 2014 and onwards.
         if year >= 2012:
-            self[easter(year) + rd(days=-2)] = "Viernes Santo [Good Friday]"
+            self[
+                easter(year) + timedelta(days=-2)
+            ] = "Viernes Santo [Good Friday]"
 
         name = "Día Internacional de los Trabajadores [Labour Day]"
         self[date(year, MAY, 1)] = name

--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -57,9 +58,7 @@ class Cuba(HolidayBase):
         #   https://bit.ly/3v6bM18
         # Permanently granted in 2013 decree for 2014 and onwards.
         if year >= 2012:
-            self[
-                easter(year) + timedelta(days=-2)
-            ] = "Viernes Santo [Good Friday]"
+            self[easter(year) + td(days=-2)] = "Viernes Santo [Good Friday]"
 
         name = "Día Internacional de los Trabajadores [Labour Day]"
         self[date(year, MAY, 1)] = name

--- a/holidays/countries/curacao.py
+++ b/holidays/countries/curacao.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, APR, MAY, JUL, AUG, OCT, DEC, SUN
 from holidays.holiday_base import HolidayBase
@@ -34,22 +33,22 @@ class Curacao(HolidayBase):
         easter_date = easter(year)
         # Carnaval Monday
         self[
-            easter_date + rd(days=-48)
+            easter_date + timedelta(days=-48)
         ] = "Maandag na de Grote Karnaval [Carnaval Monday]"
 
         # Good Friday
-        self[easter_date + rd(days=-2)] = "Goede Vrijdag [Good Friday]"
+        self[easter_date + timedelta(days=-2)] = "Goede Vrijdag [Good Friday]"
 
         # Easter Monday
         self[
-            easter_date + rd(days=+1)
+            easter_date + timedelta(days=+1)
         ] = "Di Dos Dia di Pasku di Resureccion [Easter Monday]"
 
         # King's Day
         if year >= 2014:
             kings_day = date(year, APR, 27)
             if kings_day.weekday() == SUN:
-                kings_day += rd(days=-1)
+                kings_day += timedelta(days=-1)
 
             self[kings_day] = "Koningsdag [King's Day]"
 
@@ -60,18 +59,22 @@ class Curacao(HolidayBase):
                 queens_day = date(year, AUG, 31)
 
             if queens_day.weekday() == SUN:
-                queens_day += rd(days=1) if year < 1980 else rd(days=-1)
+                queens_day += (
+                    timedelta(days=1) if year < 1980 else timedelta(days=-1)
+                )
 
             self[queens_day] = "Anja di La Reina [Queen's Day]"
 
         # Labour Day
         labour_day = date(year, MAY, 1)
         if labour_day.weekday() == SUN:
-            labour_day += rd(days=+1)
+            labour_day += timedelta(days=+1)
         self[labour_day] = "Dia di Obrero [Labour Day]"
 
         # Ascension Day
-        self[easter_date + rd(days=+39)] = "Hemelvaartsdag [Ascension Day]"
+        self[
+            easter_date + timedelta(days=+39)
+        ] = "Hemelvaartsdag [Ascension Day]"
 
         # Dia di Himno y Bandera
         self[

--- a/holidays/countries/curacao.py
+++ b/holidays/countries/curacao.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -33,22 +34,22 @@ class Curacao(HolidayBase):
         easter_date = easter(year)
         # Carnaval Monday
         self[
-            easter_date + timedelta(days=-48)
+            easter_date + td(days=-48)
         ] = "Maandag na de Grote Karnaval [Carnaval Monday]"
 
         # Good Friday
-        self[easter_date + timedelta(days=-2)] = "Goede Vrijdag [Good Friday]"
+        self[easter_date + td(days=-2)] = "Goede Vrijdag [Good Friday]"
 
         # Easter Monday
         self[
-            easter_date + timedelta(days=+1)
+            easter_date + td(days=+1)
         ] = "Di Dos Dia di Pasku di Resureccion [Easter Monday]"
 
         # King's Day
         if year >= 2014:
             kings_day = date(year, APR, 27)
             if kings_day.weekday() == SUN:
-                kings_day += timedelta(days=-1)
+                kings_day += td(days=-1)
 
             self[kings_day] = "Koningsdag [King's Day]"
 
@@ -59,22 +60,18 @@ class Curacao(HolidayBase):
                 queens_day = date(year, AUG, 31)
 
             if queens_day.weekday() == SUN:
-                queens_day += (
-                    timedelta(days=1) if year < 1980 else timedelta(days=-1)
-                )
+                queens_day += td(days=1) if year < 1980 else td(days=-1)
 
             self[queens_day] = "Anja di La Reina [Queen's Day]"
 
         # Labour Day
         labour_day = date(year, MAY, 1)
         if labour_day.weekday() == SUN:
-            labour_day += timedelta(days=+1)
+            labour_day += td(days=+1)
         self[labour_day] = "Dia di Obrero [Labour Day]"
 
         # Ascension Day
-        self[
-            easter_date + timedelta(days=+39)
-        ] = "Hemelvaartsdag [Ascension Day]"
+        self[easter_date + td(days=+39)] = "Hemelvaartsdag [Ascension Day]"
 
         # Dia di Himno y Bandera
         self[

--- a/holidays/countries/cyprus.py
+++ b/holidays/countries/cyprus.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -36,9 +37,7 @@ class Cyprus(HolidayBase):
         self[date(year, JAN, 6)] = "Θεοφάνεια [Epiphany]"
 
         # Clean Monday
-        self[
-            easter_date + timedelta(days=-48)
-        ] = "Καθαρά Δευτέρα [Clean Monday]"
+        self[easter_date + td(days=-48)] = "Καθαρά Δευτέρα [Clean Monday]"
 
         # Greek Independence Day
         self[
@@ -49,24 +48,20 @@ class Cyprus(HolidayBase):
         self[date(year, APR, 1)] = "1η Απριλίου [Cyprus National Day]"
 
         # Good Friday
-        self[
-            easter_date + timedelta(days=-2)
-        ] = "Μεγάλη Παρασκευή [Good Friday]"
+        self[easter_date + td(days=-2)] = "Μεγάλη Παρασκευή [Good Friday]"
 
         # Easter Sunday
         self[easter_date] = "Κυριακή του Πάσχα [Easter Sunday]"
 
         # Easter Monday
-        self[
-            easter_date + timedelta(days=+1)
-        ] = "Δευτέρα του Πάσχα [Easter Monday]"
+        self[easter_date + td(days=+1)] = "Δευτέρα του Πάσχα [Easter Monday]"
 
         # Labour Day
         self[date(year, MAY, 1)] = "Εργατική Πρωτομαγιά [Labour day]"
 
         # Monday of the Holy Spirit
         self[
-            easter_date + timedelta(days=+50)
+            easter_date + td(days=+50)
         ] = "Δευτέρα του Αγίου Πνεύματος [Monday of the Holy Spirit]"
 
         # Assumption of Mary

--- a/holidays/countries/cyprus.py
+++ b/holidays/countries/cyprus.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, APR, MAY, AUG, OCT, DEC
 from holidays.holiday_base import HolidayBase
@@ -37,7 +36,9 @@ class Cyprus(HolidayBase):
         self[date(year, JAN, 6)] = "Θεοφάνεια [Epiphany]"
 
         # Clean Monday
-        self[easter_date + rd(days=-48)] = "Καθαρά Δευτέρα [Clean Monday]"
+        self[
+            easter_date + timedelta(days=-48)
+        ] = "Καθαρά Δευτέρα [Clean Monday]"
 
         # Greek Independence Day
         self[
@@ -48,20 +49,24 @@ class Cyprus(HolidayBase):
         self[date(year, APR, 1)] = "1η Απριλίου [Cyprus National Day]"
 
         # Good Friday
-        self[easter_date + rd(days=-2)] = "Μεγάλη Παρασκευή [Good Friday]"
+        self[
+            easter_date + timedelta(days=-2)
+        ] = "Μεγάλη Παρασκευή [Good Friday]"
 
         # Easter Sunday
         self[easter_date] = "Κυριακή του Πάσχα [Easter Sunday]"
 
         # Easter Monday
-        self[easter_date + rd(days=+1)] = "Δευτέρα του Πάσχα [Easter Monday]"
+        self[
+            easter_date + timedelta(days=+1)
+        ] = "Δευτέρα του Πάσχα [Easter Monday]"
 
         # Labour Day
         self[date(year, MAY, 1)] = "Εργατική Πρωτομαγιά [Labour day]"
 
         # Monday of the Holy Spirit
         self[
-            easter_date + rd(days=+50)
+            easter_date + timedelta(days=+50)
         ] = "Δευτέρα του Αγίου Πνεύματος [Monday of the Holy Spirit]"
 
         # Assumption of Mary

--- a/holidays/countries/czechia.py
+++ b/holidays/countries/czechia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -35,8 +36,8 @@ class Czechia(HolidayBase):
 
         easter_date = easter(year)
         if year <= 1951 or year >= 2016:
-            self[easter_date + timedelta(days=-2)] = "Velký pátek"
-        self[easter_date + timedelta(days=+1)] = "Velikonoční pondělí"
+            self[easter_date + td(days=-2)] = "Velký pátek"
+        self[easter_date + td(days=+1)] = "Velikonoční pondělí"
 
         if year >= 1951:
             self[date(year, MAY, 1)] = "Svátek práce"

--- a/holidays/countries/czechia.py
+++ b/holidays/countries/czechia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUL, SEP, OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -36,8 +35,8 @@ class Czechia(HolidayBase):
 
         easter_date = easter(year)
         if year <= 1951 or year >= 2016:
-            self[easter_date + rd(days=-2)] = "Velký pátek"
-        self[easter_date + rd(days=+1)] = "Velikonoční pondělí"
+            self[easter_date + timedelta(days=-2)] = "Velký pátek"
+        self[easter_date + timedelta(days=+1)] = "Velikonoční pondělí"
 
         if year >= 1951:
             self[date(year, MAY, 1)] = "Svátek práce"

--- a/holidays/countries/denmark.py
+++ b/holidays/countries/denmark.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -30,15 +31,15 @@ class Denmark(HolidayBase):
         easter_date = easter(year)
         # Public holidays
         self[date(year, JAN, 1)] = "Nytårsdag"
-        self[easter_date + timedelta(days=-7)] = "Palmesøndag"
-        self[easter_date + timedelta(days=-3)] = "Skærtorsdag"
-        self[easter_date + timedelta(days=-2)] = "Langfredag"
+        self[easter_date + td(days=-7)] = "Palmesøndag"
+        self[easter_date + td(days=-3)] = "Skærtorsdag"
+        self[easter_date + td(days=-2)] = "Langfredag"
         self[easter_date] = "Påskedag"
-        self[easter_date + timedelta(days=+1)] = "Anden påskedag"
-        self[easter_date + timedelta(days=+26)] = "Store bededag"
-        self[easter_date + timedelta(days=+39)] = "Kristi himmelfartsdag"
-        self[easter_date + timedelta(days=+49)] = "Pinsedag"
-        self[easter_date + timedelta(days=+50)] = "Anden pinsedag"
+        self[easter_date + td(days=+1)] = "Anden påskedag"
+        self[easter_date + td(days=+26)] = "Store bededag"
+        self[easter_date + td(days=+39)] = "Kristi himmelfartsdag"
+        self[easter_date + td(days=+49)] = "Pinsedag"
+        self[easter_date + td(days=+50)] = "Anden pinsedag"
         self[date(year, DEC, 25)] = "Juledag"
         self[date(year, DEC, 26)] = "Anden juledag"
 

--- a/holidays/countries/denmark.py
+++ b/holidays/countries/denmark.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, DEC
 from holidays.holiday_base import HolidayBase
@@ -31,15 +30,15 @@ class Denmark(HolidayBase):
         easter_date = easter(year)
         # Public holidays
         self[date(year, JAN, 1)] = "Nytårsdag"
-        self[easter_date + rd(days=-7)] = "Palmesøndag"
-        self[easter_date + rd(days=-3)] = "Skærtorsdag"
-        self[easter_date + rd(days=-2)] = "Langfredag"
+        self[easter_date + timedelta(days=-7)] = "Palmesøndag"
+        self[easter_date + timedelta(days=-3)] = "Skærtorsdag"
+        self[easter_date + timedelta(days=-2)] = "Langfredag"
         self[easter_date] = "Påskedag"
-        self[easter_date + rd(days=+1)] = "Anden påskedag"
-        self[easter_date + rd(days=+26)] = "Store bededag"
-        self[easter_date + rd(days=+39)] = "Kristi himmelfartsdag"
-        self[easter_date + rd(days=+49)] = "Pinsedag"
-        self[easter_date + rd(days=+50)] = "Anden pinsedag"
+        self[easter_date + timedelta(days=+1)] = "Anden påskedag"
+        self[easter_date + timedelta(days=+26)] = "Store bededag"
+        self[easter_date + timedelta(days=+39)] = "Kristi himmelfartsdag"
+        self[easter_date + timedelta(days=+49)] = "Pinsedag"
+        self[easter_date + timedelta(days=+50)] = "Anden pinsedag"
         self[date(year, DEC, 25)] = "Juledag"
         self[date(year, DEC, 26)] = "Anden juledag"
 

--- a/holidays/countries/djibouti.py
+++ b/holidays/countries/djibouti.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import JAN, MAY, JUN, FRI, SAT
 from holidays.holiday_base import HolidayBase
@@ -77,7 +75,7 @@ class Djibouti(HolidayBase):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid al-Fitr")
                 _add_holiday(
-                    hol_date + rd(days=+1), "Eid al-Fitr deuxième jour"
+                    hol_date + timedelta(days=+1), "Eid al-Fitr deuxième jour"
                 )
 
         # Arafat & Eid al-Adha - Scarfice Festive
@@ -86,9 +84,9 @@ class Djibouti(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 9):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Arafat")
-                _add_holiday(hol_date + rd(days=+1), "Eid al-Adha")
+                _add_holiday(hol_date + timedelta(days=+1), "Eid al-Adha")
                 _add_holiday(
-                    hol_date + rd(days=+2), "Eid al-Adha deuxième jour"
+                    hol_date + timedelta(days=+2), "Eid al-Adha deuxième jour"
                 )
 
         # Islamic New Year - (hijari_year, 1, 1)

--- a/holidays/countries/djibouti.py
+++ b/holidays/countries/djibouti.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import JAN, MAY, JUN, FRI, SAT
 from holidays.holiday_base import HolidayBase
@@ -75,7 +76,7 @@ class Djibouti(HolidayBase):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid al-Fitr")
                 _add_holiday(
-                    hol_date + timedelta(days=+1), "Eid al-Fitr deuxième jour"
+                    hol_date + td(days=+1), "Eid al-Fitr deuxième jour"
                 )
 
         # Arafat & Eid al-Adha - Scarfice Festive
@@ -84,9 +85,9 @@ class Djibouti(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 9):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Arafat")
-                _add_holiday(hol_date + timedelta(days=+1), "Eid al-Adha")
+                _add_holiday(hol_date + td(days=+1), "Eid al-Adha")
                 _add_holiday(
-                    hol_date + timedelta(days=+2), "Eid al-Adha deuxième jour"
+                    hol_date + td(days=+2), "Eid al-Adha deuxième jour"
                 )
 
         # Islamic New Year - (hijari_year, 1, 1)

--- a/holidays/countries/dominican_republic.py
+++ b/holidays/countries/dominican_republic.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -59,7 +60,7 @@ class DominicanRepublic(HolidayBase):
         self[date(year, FEB, 27)] = "Día de Independencia [Independence Day]"
 
         # Good Friday
-        self[easter(year) + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter(year) + td(days=-2)] = "Viernes Santo [Good Friday]"
 
         # Labor Day
         labor_day = self.__change_day_by_law(date(year, MAY, 1), (3, 4, 6))

--- a/holidays/countries/dominican_republic.py
+++ b/holidays/countries/dominican_republic.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -59,7 +59,7 @@ class DominicanRepublic(HolidayBase):
         self[date(year, FEB, 27)] = "Día de Independencia [Independence Day]"
 
         # Good Friday
-        self[easter(year) + rd(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter(year) + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
 
         # Labor Day
         labor_day = self.__change_day_by_law(date(year, MAY, 1), (3, 4, 6))

--- a/holidays/countries/egypt.py
+++ b/holidays/countries/egypt.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -65,7 +66,7 @@ class Egypt(HolidayBase):
         self[easter_date] = "Coptic Easter Sunday"
 
         # Sham El Nessim - Spring Festival
-        self[easter_date + timedelta(days=+1)] = "Sham El Nessim"
+        self[easter_date + td(days=+1)] = "Sham El Nessim"
 
         # Sinai Libration Day
         if year > 1982:
@@ -94,12 +95,8 @@ class Egypt(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 10, 1):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid al-Fitr")
-                _add_holiday(
-                    hol_date + timedelta(days=+1), "Eid al-Fitr Holiday"
-                )
-                _add_holiday(
-                    hol_date + timedelta(days=+2), "Eid al-Fitr Holiday"
-                )
+                _add_holiday(hol_date + td(days=+1), "Eid al-Fitr Holiday")
+                _add_holiday(hol_date + td(days=+2), "Eid al-Fitr Holiday")
 
         # Arafat Day & Eid al-Adha - Scarfice Festive
         # date of observance is announced yearly
@@ -107,13 +104,9 @@ class Egypt(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 9):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Arafat Day")
-                _add_holiday(hol_date + timedelta(days=+1), "Eid al-Adha")
-                _add_holiday(
-                    hol_date + timedelta(days=+2), "Eid al-Adha Holiday"
-                )
-                _add_holiday(
-                    hol_date + timedelta(days=+3), "Eid al-Adha Holiday"
-                )
+                _add_holiday(hol_date + td(days=+1), "Eid al-Adha")
+                _add_holiday(hol_date + td(days=+2), "Eid al-Adha Holiday")
+                _add_holiday(hol_date + td(days=+3), "Eid al-Adha Holiday")
 
         # Islamic New Year - (hijari_year, 1, 1)
         for date_obs in _islamic_to_gre(year, 1, 1):

--- a/holidays/countries/egypt.py
+++ b/holidays/countries/egypt.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, APR, MAY, JUN, JUL, OCT
 from holidays.holiday_base import HolidayBase
@@ -66,7 +65,7 @@ class Egypt(HolidayBase):
         self[easter_date] = "Coptic Easter Sunday"
 
         # Sham El Nessim - Spring Festival
-        self[easter_date + rd(days=+1)] = "Sham El Nessim"
+        self[easter_date + timedelta(days=+1)] = "Sham El Nessim"
 
         # Sinai Libration Day
         if year > 1982:
@@ -95,8 +94,12 @@ class Egypt(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 10, 1):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid al-Fitr")
-                _add_holiday(hol_date + rd(days=+1), "Eid al-Fitr Holiday")
-                _add_holiday(hol_date + rd(days=+2), "Eid al-Fitr Holiday")
+                _add_holiday(
+                    hol_date + timedelta(days=+1), "Eid al-Fitr Holiday"
+                )
+                _add_holiday(
+                    hol_date + timedelta(days=+2), "Eid al-Fitr Holiday"
+                )
 
         # Arafat Day & Eid al-Adha - Scarfice Festive
         # date of observance is announced yearly
@@ -104,9 +107,13 @@ class Egypt(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 9):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Arafat Day")
-                _add_holiday(hol_date + rd(days=+1), "Eid al-Adha")
-                _add_holiday(hol_date + rd(days=+2), "Eid al-Adha Holiday")
-                _add_holiday(hol_date + rd(days=+3), "Eid al-Adha Holiday")
+                _add_holiday(hol_date + timedelta(days=+1), "Eid al-Adha")
+                _add_holiday(
+                    hol_date + timedelta(days=+2), "Eid al-Adha Holiday"
+                )
+                _add_holiday(
+                    hol_date + timedelta(days=+3), "Eid al-Adha Holiday"
+                )
 
         # Islamic New Year - (hijari_year, 1, 1)
         for date_obs in _islamic_to_gre(year, 1, 1):

--- a/holidays/countries/estonia.py
+++ b/holidays/countries/estonia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, MAY, JUN, AUG, DEC
 from holidays.holiday_base import HolidayBase
@@ -34,7 +33,7 @@ class Estonia(HolidayBase):
         self[date(year, FEB, 24)] = "iseseisvuspäev"
 
         # Good Friday
-        self[easter_date + rd(days=-2)] = "suur reede"
+        self[easter_date + timedelta(days=-2)] = "suur reede"
 
         # Easter Sunday
         self[easter_date] = "ülestõusmispühade 1. püha"
@@ -43,7 +42,7 @@ class Estonia(HolidayBase):
         self[date(year, MAY, 1)] = "kevadpüha"
 
         # Pentecost
-        self[easter_date + rd(days=+49)] = "nelipühade 1. püha"
+        self[easter_date + timedelta(days=+49)] = "nelipühade 1. püha"
 
         # Victory Day
         self[date(year, JUN, 23)] = "võidupüha"

--- a/holidays/countries/estonia.py
+++ b/holidays/countries/estonia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -33,7 +34,7 @@ class Estonia(HolidayBase):
         self[date(year, FEB, 24)] = "iseseisvuspäev"
 
         # Good Friday
-        self[easter_date + timedelta(days=-2)] = "suur reede"
+        self[easter_date + td(days=-2)] = "suur reede"
 
         # Easter Sunday
         self[easter_date] = "ülestõusmispühade 1. püha"
@@ -42,7 +43,7 @@ class Estonia(HolidayBase):
         self[date(year, MAY, 1)] = "kevadpüha"
 
         # Pentecost
-        self[easter_date + timedelta(days=+49)] = "nelipühade 1. püha"
+        self[easter_date + td(days=+49)] = "nelipühade 1. püha"
 
         # Victory Day
         self[date(year, JUN, 23)] = "võidupüha"

--- a/holidays/countries/eswatini.py
+++ b/holidays/countries/eswatini.py
@@ -10,10 +10,9 @@
 #  License: MIT (see LICENSE file)
 
 import warnings
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, APR, MAY, JUL, SEP, DEC, SUN
 from holidays.holiday_base import HolidayBase
@@ -41,9 +40,9 @@ class Eswatini(HolidayBase):
         self[date(year, JAN, 1)] = "New Year's Day"
 
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
-        self[easter_date + rd(days=+1)] = "Easter Monday"
-        self[easter_date + rd(days=+39)] = "Ascension Day"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=+39)] = "Ascension Day"
 
         if year >= 1969:
             self[date(year, APR, 25)] = "National Flag Day"
@@ -67,9 +66,9 @@ class Eswatini(HolidayBase):
         if self.observed and year >= 2021:
             for k, v in list(self.items()):
                 if k.weekday() == SUN and k.year == year:
-                    dt = k + rd(days=+1)
+                    dt = k + timedelta(days=+1)
                     while self.get(dt):
-                        dt += rd(days=+1)
+                        dt += timedelta(days=+1)
                     self[dt] = v + " (Observed)"
 
 

--- a/holidays/countries/eswatini.py
+++ b/holidays/countries/eswatini.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import warnings
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -40,9 +41,9 @@ class Eswatini(HolidayBase):
         self[date(year, JAN, 1)] = "New Year's Day"
 
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
-        self[easter_date + timedelta(days=+39)] = "Ascension Day"
+        self[easter_date + td(days=-2)] = "Good Friday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=+39)] = "Ascension Day"
 
         if year >= 1969:
             self[date(year, APR, 25)] = "National Flag Day"
@@ -66,9 +67,9 @@ class Eswatini(HolidayBase):
         if self.observed and year >= 2021:
             for k, v in list(self.items()):
                 if k.weekday() == SUN and k.year == year:
-                    dt = k + timedelta(days=+1)
+                    dt = k + td(days=+1)
                     while self.get(dt):
-                        dt += timedelta(days=+1)
+                        dt += td(days=+1)
                     self[dt] = v + " (Observed)"
 
 

--- a/holidays/countries/ethiopia.py
+++ b/holidays/countries/ethiopia.py
@@ -10,10 +10,9 @@
 #  License: MIT (see LICENSE file)
 
 from calendar import isleap
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter, EASTER_ORTHODOX
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, MAY, SEP
 from holidays.holiday_base import HolidayBase
@@ -66,7 +65,7 @@ class Ethiopia(HolidayBase):
 
         # Ethiopian Good Friday
         easter_date = easter(year, EASTER_ORTHODOX)
-        self[easter_date + rd(days=-2)] = "ስቅለት/Ethiopian Good Friday"
+        self[easter_date + timedelta(days=-2)] = "ስቅለት/Ethiopian Good Friday"
 
         # Ethiopian  Easter - Orthodox Easter
         self[easter_date] = "ፋሲካ/Ethiopian Easter"
@@ -108,12 +107,14 @@ class Ethiopia(HolidayBase):
         # date of observance is announced yearly
         for date_obs in _islamic_to_gre(year, 12, 9):
             hol_date = date_obs
-            self[hol_date + rd(days=+1)] = "አረፋ/Eid-Al-Adha"
+            self[hol_date + timedelta(days=+1)] = "አረፋ/Eid-Al-Adha"
 
         # Prophet Muhammad's Birthday - (hijari_year, 3, 12)
         for date_obs in _islamic_to_gre(year, 3, 12):
             hol_date = date_obs
-            self[hol_date + rd(days=+1)] = "መውሊድ/Prophet Muhammad's Birthday"
+            self[
+                hol_date + timedelta(days=+1)
+            ] = "መውሊድ/Prophet Muhammad's Birthday"
 
     # Ethiopian leap years are coincident with leap years in the Gregorian
     # calendar until the end of February 2100. It starts earlier from new year

--- a/holidays/countries/ethiopia.py
+++ b/holidays/countries/ethiopia.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 from calendar import isleap
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter, EASTER_ORTHODOX
 
@@ -65,7 +66,7 @@ class Ethiopia(HolidayBase):
 
         # Ethiopian Good Friday
         easter_date = easter(year, EASTER_ORTHODOX)
-        self[easter_date + timedelta(days=-2)] = "ስቅለት/Ethiopian Good Friday"
+        self[easter_date + td(days=-2)] = "ስቅለት/Ethiopian Good Friday"
 
         # Ethiopian  Easter - Orthodox Easter
         self[easter_date] = "ፋሲካ/Ethiopian Easter"
@@ -107,14 +108,12 @@ class Ethiopia(HolidayBase):
         # date of observance is announced yearly
         for date_obs in _islamic_to_gre(year, 12, 9):
             hol_date = date_obs
-            self[hol_date + timedelta(days=+1)] = "አረፋ/Eid-Al-Adha"
+            self[hol_date + td(days=+1)] = "አረፋ/Eid-Al-Adha"
 
         # Prophet Muhammad's Birthday - (hijari_year, 3, 12)
         for date_obs in _islamic_to_gre(year, 3, 12):
             hol_date = date_obs
-            self[
-                hol_date + timedelta(days=+1)
-            ] = "መውሊድ/Prophet Muhammad's Birthday"
+            self[hol_date + td(days=+1)] = "መውሊድ/Prophet Muhammad's Birthday"
 
     # Ethiopian leap years are coincident with leap years in the Gregorian
     # calendar until the end of February 2100. It starts earlier from new year

--- a/holidays/countries/finland.py
+++ b/holidays/countries/finland.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import FR, SA
@@ -33,12 +34,12 @@ class Finland(HolidayBase):
 
         self[date(year, JAN, 1)] = "Uudenvuodenpäivä"
         self[date(year, JAN, 6)] = "Loppiainen"
-        self[easter_date + timedelta(days=-2)] = "Pitkäperjantai"
+        self[easter_date + td(days=-2)] = "Pitkäperjantai"
         self[easter_date] = "Pääsiäispäivä"
-        self[easter_date + timedelta(days=+1)] = "2. pääsiäispäivä"
+        self[easter_date + td(days=+1)] = "2. pääsiäispäivä"
         self[date(year, MAY, 1)] = "Vappu"
-        self[easter_date + timedelta(days=+39)] = "Helatorstai"
-        self[easter_date + timedelta(days=+49)] = "Helluntaipäivä"
+        self[easter_date + td(days=+39)] = "Helatorstai"
+        self[easter_date + td(days=+49)] = "Helluntaipäivä"
         self[date(year, JUN, 20) + rd(weekday=SA)] = "Juhannuspäivä"
         self[date(year, OCT, 31) + rd(weekday=SA)] = "Pyhäinpäivä"
         self[date(year, DEC, 6)] = "Itsenäisyyspäivä"

--- a/holidays/countries/finland.py
+++ b/holidays/countries/finland.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import FR, SA
@@ -33,12 +33,12 @@ class Finland(HolidayBase):
 
         self[date(year, JAN, 1)] = "Uudenvuodenpäivä"
         self[date(year, JAN, 6)] = "Loppiainen"
-        self[easter_date + rd(days=-2)] = "Pitkäperjantai"
+        self[easter_date + timedelta(days=-2)] = "Pitkäperjantai"
         self[easter_date] = "Pääsiäispäivä"
-        self[easter_date + rd(days=+1)] = "2. pääsiäispäivä"
+        self[easter_date + timedelta(days=+1)] = "2. pääsiäispäivä"
         self[date(year, MAY, 1)] = "Vappu"
-        self[easter_date + rd(days=+39)] = "Helatorstai"
-        self[easter_date + rd(days=+49)] = "Helluntaipäivä"
+        self[easter_date + timedelta(days=+39)] = "Helatorstai"
+        self[easter_date + timedelta(days=+49)] = "Helluntaipäivä"
         self[date(year, JUN, 20) + rd(weekday=SA)] = "Juhannuspäivä"
         self[date(year, OCT, 31) + rd(weekday=SA)] = "Pyhäinpäivä"
         self[date(year, DEC, 6)] = "Itsenäisyyspäivä"

--- a/holidays/countries/france.py
+++ b/holidays/countries/france.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, APR, MAY, JUN, JUL, AUG, SEP, OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -87,17 +86,17 @@ class France(HolidayBase):
             "Martinique",
             "Polynésie Française",
         }:
-            self[easter_date + rd(days=-2)] = "Vendredi saint"
+            self[easter_date + timedelta(days=-2)] = "Vendredi saint"
 
         if self.subdiv == "Alsace-Moselle":
             self[date(year, DEC, 26)] = "Deuxième jour de Noël"
 
         if year >= 1886:
-            self[easter_date + rd(days=+1)] = "Lundi de Pâques"
-            self[easter_date + rd(days=+50)] = "Lundi de Pentecôte"
+            self[easter_date + timedelta(days=+1)] = "Lundi de Pâques"
+            self[easter_date + timedelta(days=+50)] = "Lundi de Pentecôte"
 
         if year >= 1802:
-            self[easter_date + rd(days=+39)] = "Ascension"
+            self[easter_date + timedelta(days=+39)] = "Ascension"
             self[date(year, AUG, 15)] = "Assomption"
             self[date(year, NOV, 1)] = "Toussaint"
 

--- a/holidays/countries/france.py
+++ b/holidays/countries/france.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -86,17 +87,17 @@ class France(HolidayBase):
             "Martinique",
             "Polynésie Française",
         }:
-            self[easter_date + timedelta(days=-2)] = "Vendredi saint"
+            self[easter_date + td(days=-2)] = "Vendredi saint"
 
         if self.subdiv == "Alsace-Moselle":
             self[date(year, DEC, 26)] = "Deuxième jour de Noël"
 
         if year >= 1886:
-            self[easter_date + timedelta(days=+1)] = "Lundi de Pâques"
-            self[easter_date + timedelta(days=+50)] = "Lundi de Pentecôte"
+            self[easter_date + td(days=+1)] = "Lundi de Pâques"
+            self[easter_date + td(days=+50)] = "Lundi de Pentecôte"
 
         if year >= 1802:
-            self[easter_date + timedelta(days=+39)] = "Ascension"
+            self[easter_date + td(days=+39)] = "Ascension"
             self[date(year, AUG, 15)] = "Assomption"
             self[date(year, NOV, 1)] = "Toussaint"
 

--- a/holidays/countries/georgia.py
+++ b/holidays/countries/georgia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -54,11 +55,11 @@ class Georgia(HolidayBase):
         easter_date = easter(year, method=EASTER_ORTHODOX)
         # Orthodox Good Friday
         name = "წითელი პარასკევი"
-        self[easter_date + timedelta(days=-2)] = name
+        self[easter_date + td(days=-2)] = name
 
         # Orthodox Holy Saturday
         name = "დიდი შაბათი"
-        self[easter_date + timedelta(days=-1)] = name
+        self[easter_date + td(days=-1)] = name
 
         # Orthodox Easter Sunday
         name = "აღდგომა"
@@ -66,7 +67,7 @@ class Georgia(HolidayBase):
 
         # Orthodox Easter Monday
         name = "შავი ორშაბათი"
-        self[easter_date + timedelta(days=+1)] = name
+        self[easter_date + td(days=+1)] = name
 
         # National Unity Day
         name = "ეროვნული ერთიანობის დღე"

--- a/holidays/countries/georgia.py
+++ b/holidays/countries/georgia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, APR, MAY, AUG, OCT, NOV
 from holidays.holiday_base import HolidayBase
@@ -55,11 +54,11 @@ class Georgia(HolidayBase):
         easter_date = easter(year, method=EASTER_ORTHODOX)
         # Orthodox Good Friday
         name = "წითელი პარასკევი"
-        self[easter_date + rd(days=-2)] = name
+        self[easter_date + timedelta(days=-2)] = name
 
         # Orthodox Holy Saturday
         name = "დიდი შაბათი"
-        self[easter_date + rd(days=-1)] = name
+        self[easter_date + timedelta(days=-1)] = name
 
         # Orthodox Easter Sunday
         name = "აღდგომა"
@@ -67,7 +66,7 @@ class Georgia(HolidayBase):
 
         # Orthodox Easter Monday
         name = "შავი ორშაბათი"
-        self[easter_date + rd(days=+1)] = name
+        self[easter_date + timedelta(days=+1)] = name
 
         # National Unity Day
         name = "ეროვნული ერთიანობის დღე"

--- a/holidays/countries/germany.py
+++ b/holidays/countries/germany.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import WE
@@ -90,7 +91,7 @@ class Germany(HolidayBase):
 
             easter_date = easter(year)
 
-            self[easter_date + timedelta(days=-2)] = "Karfreitag"
+            self[easter_date + td(days=-2)] = "Karfreitag"
 
             if self.subdiv == "BB":
                 # will always be a Sunday and we have no "observed" rule so
@@ -98,7 +99,7 @@ class Germany(HolidayBase):
                 # holiday by law
                 self[easter_date] = "Ostersonntag"
 
-            self[easter_date + timedelta(days=+1)] = "Ostermontag"
+            self[easter_date + td(days=+1)] = "Ostermontag"
 
             self[date(year, MAY, 1)] = "Erster Mai"
 
@@ -108,18 +109,18 @@ class Germany(HolidayBase):
                     "und der Beendigung des Zweiten Weltkriegs in Europa"
                 )
 
-            self[easter_date + timedelta(days=+39)] = "Christi Himmelfahrt"
+            self[easter_date + td(days=+39)] = "Christi Himmelfahrt"
 
             if self.subdiv == "BB":
                 # will always be a Sunday and we have no "observed" rule so
                 # this is pretty pointless but it's nonetheless an official
                 # holiday by law
-                self[easter_date + timedelta(days=+49)] = "Pfingstsonntag"
+                self[easter_date + td(days=+49)] = "Pfingstsonntag"
 
-            self[easter_date + timedelta(days=+50)] = "Pfingstmontag"
+            self[easter_date + td(days=+50)] = "Pfingstmontag"
 
             if self.subdiv in {"BW", "BY", "BYP", "HE", "NW", "RP", "SL"}:
-                self[easter_date + timedelta(days=+60)] = "Fronleichnam"
+                self[easter_date + td(days=+60)] = "Fronleichnam"
 
             if self.subdiv in {"BY", "SL"}:
                 self[date(year, AUG, 15)] = "Mariä Himmelfahrt"

--- a/holidays/countries/germany.py
+++ b/holidays/countries/germany.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import WE
@@ -90,7 +90,7 @@ class Germany(HolidayBase):
 
             easter_date = easter(year)
 
-            self[easter_date + rd(days=-2)] = "Karfreitag"
+            self[easter_date + timedelta(days=-2)] = "Karfreitag"
 
             if self.subdiv == "BB":
                 # will always be a Sunday and we have no "observed" rule so
@@ -98,7 +98,7 @@ class Germany(HolidayBase):
                 # holiday by law
                 self[easter_date] = "Ostersonntag"
 
-            self[easter_date + rd(days=+1)] = "Ostermontag"
+            self[easter_date + timedelta(days=+1)] = "Ostermontag"
 
             self[date(year, MAY, 1)] = "Erster Mai"
 
@@ -108,18 +108,18 @@ class Germany(HolidayBase):
                     "und der Beendigung des Zweiten Weltkriegs in Europa"
                 )
 
-            self[easter_date + rd(days=+39)] = "Christi Himmelfahrt"
+            self[easter_date + timedelta(days=+39)] = "Christi Himmelfahrt"
 
             if self.subdiv == "BB":
                 # will always be a Sunday and we have no "observed" rule so
                 # this is pretty pointless but it's nonetheless an official
                 # holiday by law
-                self[easter_date + rd(days=+49)] = "Pfingstsonntag"
+                self[easter_date + timedelta(days=+49)] = "Pfingstsonntag"
 
-            self[easter_date + rd(days=+50)] = "Pfingstmontag"
+            self[easter_date + timedelta(days=+50)] = "Pfingstmontag"
 
             if self.subdiv in {"BW", "BY", "BYP", "HE", "NW", "RP", "SL"}:
-                self[easter_date + rd(days=+60)] = "Fronleichnam"
+                self[easter_date + timedelta(days=+60)] = "Fronleichnam"
 
             if self.subdiv in {"BY", "SL"}:
                 self[date(year, AUG, 15)] = "Mariä Himmelfahrt"

--- a/holidays/countries/greece.py
+++ b/holidays/countries/greece.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 from dateutil.relativedelta import MO, TU
@@ -37,21 +38,17 @@ class Greece(HolidayBase):
         self[date(year, JAN, 6)] = "Θεοφάνεια [Epiphany]"
 
         # Clean Monday
-        self[
-            easter_date + timedelta(days=-48)
-        ] = "Καθαρά Δευτέρα [Clean Monday]"
+        self[easter_date + td(days=-48)] = "Καθαρά Δευτέρα [Clean Monday]"
 
         # Independence Day
         self[date(year, MAR, 25)] = "Εικοστή Πέμπτη Μαρτίου [Independence Day]"
 
         # Easter Monday
-        self[
-            easter_date + timedelta(days=+1)
-        ] = "Δευτέρα του Πάσχα [Easter Monday]"
+        self[easter_date + td(days=+1)] = "Δευτέρα του Πάσχα [Easter Monday]"
 
         # Monday of the Holy Spirit
         self[
-            easter_date + timedelta(days=+50)
+            easter_date + td(days=+50)
         ] = "Δευτέρα του Αγίου Πνεύματος [Monday of the Holy Spirit]"
 
         # Labour Day

--- a/holidays/countries/greece.py
+++ b/holidays/countries/greece.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 from dateutil.relativedelta import MO, TU
@@ -37,17 +37,21 @@ class Greece(HolidayBase):
         self[date(year, JAN, 6)] = "Θεοφάνεια [Epiphany]"
 
         # Clean Monday
-        self[easter_date + rd(days=-48)] = "Καθαρά Δευτέρα [Clean Monday]"
+        self[
+            easter_date + timedelta(days=-48)
+        ] = "Καθαρά Δευτέρα [Clean Monday]"
 
         # Independence Day
         self[date(year, MAR, 25)] = "Εικοστή Πέμπτη Μαρτίου [Independence Day]"
 
         # Easter Monday
-        self[easter_date + rd(days=+1)] = "Δευτέρα του Πάσχα [Easter Monday]"
+        self[
+            easter_date + timedelta(days=+1)
+        ] = "Δευτέρα του Πάσχα [Easter Monday]"
 
         # Monday of the Holy Spirit
         self[
-            easter_date + rd(days=+50)
+            easter_date + timedelta(days=+50)
         ] = "Δευτέρα του Αγίου Πνεύματος [Monday of the Holy Spirit]"
 
         # Labour Day

--- a/holidays/countries/honduras.py
+++ b/holidays/countries/honduras.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import WE
@@ -33,17 +34,13 @@ class Honduras(HolidayBase):
 
         easter_date = easter(year)
         # Maundy Thursday
-        self[
-            easter_date + timedelta(days=-3)
-        ] = "Jueves Santo [Maundy Thursday]"
+        self[easter_date + td(days=-3)] = "Jueves Santo [Maundy Thursday]"
 
         # Good Friday
-        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter_date + td(days=-2)] = "Viernes Santo [Good Friday]"
 
         # Holy Saturday
-        self[
-            easter_date + timedelta(days=-1)
-        ] = "Sábado de Gloria [Holy Saturday]"
+        self[easter_date + td(days=-1)] = "Sábado de Gloria [Holy Saturday]"
 
         # Panamerican Day
         self[date(year, APR, 14)] = "Día de las Américas [Panamerican Day]"
@@ -72,8 +69,8 @@ class Honduras(HolidayBase):
             holiday_name = "Semana Morazánica [Morazan Weekend]"
             first_wednesday = date(year, OCT, 1) + rd(weekday=WE(+1))
             self[first_wednesday] = holiday_name
-            self[first_wednesday + timedelta(days=+1)] = holiday_name
-            self[first_wednesday + timedelta(days=+2)] = holiday_name
+            self[first_wednesday + td(days=+1)] = holiday_name
+            self[first_wednesday + td(days=+2)] = holiday_name
 
         # Christmas
         self[date(year, DEC, 25)] = "Navidad [Christmas]"

--- a/holidays/countries/honduras.py
+++ b/holidays/countries/honduras.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import WE
@@ -33,13 +33,17 @@ class Honduras(HolidayBase):
 
         easter_date = easter(year)
         # Maundy Thursday
-        self[easter_date + rd(days=-3)] = "Jueves Santo [Maundy Thursday]"
+        self[
+            easter_date + timedelta(days=-3)
+        ] = "Jueves Santo [Maundy Thursday]"
 
         # Good Friday
-        self[easter_date + rd(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
 
         # Holy Saturday
-        self[easter_date + rd(days=-1)] = "Sábado de Gloria [Holy Saturday]"
+        self[
+            easter_date + timedelta(days=-1)
+        ] = "Sábado de Gloria [Holy Saturday]"
 
         # Panamerican Day
         self[date(year, APR, 14)] = "Día de las Américas [Panamerican Day]"
@@ -68,8 +72,8 @@ class Honduras(HolidayBase):
             holiday_name = "Semana Morazánica [Morazan Weekend]"
             first_wednesday = date(year, OCT, 1) + rd(weekday=WE(+1))
             self[first_wednesday] = holiday_name
-            self[first_wednesday + rd(days=+1)] = holiday_name
-            self[first_wednesday + rd(days=+2)] = holiday_name
+            self[first_wednesday + timedelta(days=+1)] = holiday_name
+            self[first_wednesday + timedelta(days=+2)] = holiday_name
 
         # Christmas
         self[date(year, DEC, 25)] = "Navidad [Christmas]"

--- a/holidays/countries/hongkong.py
+++ b/holidays/countries/hongkong.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -58,7 +59,7 @@ class HongKong(HolidayBase):
         # The first day of January
         first_date = date(year, JAN, 1)
         if self.observed and first_date.weekday() == SUN:
-            self[first_date + timedelta(days=+1)] = (
+            self[first_date + td(days=+1)] = (
                 day_following + "the first day of January"
             )
         else:
@@ -75,40 +76,38 @@ class HongKong(HolidayBase):
             self[new_year_date] = name
             if new_year_date.weekday() in {MON, TUE, WED, THU}:
                 self[new_year_date] = name
-                self[new_year_date + timedelta(days=+1)] = second_day_lunar
-                self[new_year_date + timedelta(days=+2)] = third_day_lunar
+                self[new_year_date + td(days=+1)] = second_day_lunar
+                self[new_year_date + td(days=+2)] = third_day_lunar
             if new_year_date.weekday() == FRI:
                 self[new_year_date] = name
-                self[new_year_date + timedelta(days=+1)] = second_day_lunar
-                self[new_year_date + timedelta(days=+3)] = fourth_day_lunar
+                self[new_year_date + td(days=+1)] = second_day_lunar
+                self[new_year_date + td(days=+3)] = fourth_day_lunar
             if new_year_date.weekday() == SAT:
                 self[new_year_date] = name
-                self[new_year_date + timedelta(days=+2)] = third_day_lunar
-                self[new_year_date + timedelta(days=+3)] = fourth_day_lunar
+                self[new_year_date + td(days=+2)] = third_day_lunar
+                self[new_year_date + td(days=+3)] = fourth_day_lunar
             if new_year_date.weekday() == SUN:
                 if year in {2006, 2007, 2010}:
-                    self[
-                        new_year_date + timedelta(days=-1)
-                    ] = preceding_day_lunar
+                    self[new_year_date + td(days=-1)] = preceding_day_lunar
                 else:
-                    self[new_year_date + timedelta(days=+3)] = fourth_day_lunar
+                    self[new_year_date + td(days=+3)] = fourth_day_lunar
             else:
                 self[new_year_date] = name
             if new_year_date.weekday() == SAT:
-                self[new_year_date + timedelta(days=+3)] = fourth_day_lunar
+                self[new_year_date + td(days=+3)] = fourth_day_lunar
             else:
-                self[new_year_date + timedelta(days=+1)] = second_day_lunar
+                self[new_year_date + td(days=+1)] = second_day_lunar
             if new_year_date.weekday() == FRI:
-                self[new_year_date + timedelta(days=+3)] = fourth_day_lunar
+                self[new_year_date + td(days=+3)] = fourth_day_lunar
             else:
-                self[new_year_date + timedelta(days=+2)] = third_day_lunar
+                self[new_year_date + td(days=+2)] = third_day_lunar
         else:
             self[new_year_date] = name
-            self[new_year_date + timedelta(days=+1)] = second_day_lunar
-            self[new_year_date + timedelta(days=+2)] = third_day_lunar
+            self[new_year_date + td(days=+1)] = second_day_lunar
+            self[new_year_date + td(days=+2)] = third_day_lunar
 
         easter_date = easter(year)
-        easter_monday_date = easter_date + timedelta(days=+1)
+        easter_monday_date = easter_date + td(days=+1)
         # Ching Ming Festival
         name = "Ching Ming Festival"
         if self.is_leap_year(year) or (
@@ -121,17 +120,17 @@ class HongKong(HolidayBase):
             ching_ming_date.weekday() == SUN
             or ching_ming_date == easter_monday_date
         ):
-            self[ching_ming_date + timedelta(days=+1)] = day_following + name
+            self[ching_ming_date + td(days=+1)] = day_following + name
         else:
             self[ching_ming_date] = name
 
         # Easter Holiday
         good_friday = "Good Friday"
         easter_monday = "Easter Monday"
-        self[easter_date + timedelta(days=-2)] = good_friday
-        self[easter_date + timedelta(days=-1)] = day_following + good_friday
+        self[easter_date + td(days=-2)] = good_friday
+        self[easter_date + td(days=-1)] = day_following + good_friday
         if self.observed and self.get(easter_monday_date):
-            self[easter_monday_date + timedelta(days=+1)] = (
+            self[easter_monday_date + td(days=+1)] = (
                 day_following + easter_monday
             )
         else:
@@ -142,7 +141,7 @@ class HongKong(HolidayBase):
             name = "The Birthday of the Buddha"
             buddha_date = self.cnls.lunar_to_gre(year, 4, 8)
             if self.observed and buddha_date.weekday() == SUN:
-                self[buddha_date + timedelta(days=+1)] = day_following + name
+                self[buddha_date + td(days=+1)] = day_following + name
             else:
                 self[buddha_date] = name
 
@@ -151,7 +150,7 @@ class HongKong(HolidayBase):
             name = "Labour Day"
             labour_date = date(year, MAY, 1)
             if self.observed and labour_date.weekday() == SUN:
-                self[labour_date + timedelta(days=+1)] = day_following + name
+                self[labour_date + td(days=+1)] = day_following + name
             else:
                 self[labour_date] = name
 
@@ -159,7 +158,7 @@ class HongKong(HolidayBase):
         name = "Tuen Ng Festival"
         tuen_ng_date = self.cnls.lunar_to_gre(year, 5, 5)
         if self.observed and tuen_ng_date.weekday() == SUN:
-            self[tuen_ng_date + timedelta(days=+1)] = day_following + name
+            self[tuen_ng_date + td(days=+1)] = day_following + name
         else:
             self[tuen_ng_date] = name
 
@@ -168,7 +167,7 @@ class HongKong(HolidayBase):
             name = "Hong Kong Special Administrative Region Establishment Day"
             hksar_date = date(year, JUL, 1)
             if self.observed and hksar_date.weekday() == SUN:
-                self[hksar_date + timedelta(days=+1)] = day_following + name
+                self[hksar_date + td(days=+1)] = day_following + name
             else:
                 self[hksar_date] = name
 
@@ -184,11 +183,11 @@ class HongKong(HolidayBase):
                 if 1983 <= year <= 2010:
                     self[mid_autumn_date] = name
                 else:
-                    self[mid_autumn_date + timedelta(days=+2)] = (
+                    self[mid_autumn_date + td(days=+2)] = (
                         "The second day of the " + name + " (Monday)"
                     )
             else:
-                self[mid_autumn_date + timedelta(days=+1)] = (
+                self[mid_autumn_date + td(days=+1)] = (
                     day_following + "the " + name
                 )
         else:
@@ -201,7 +200,7 @@ class HongKong(HolidayBase):
             if self.observed and (
                 national_date.weekday() == SUN or self.get(national_date)
             ):
-                self[national_date + timedelta(days=+1)] = day_following + name
+                self[national_date + td(days=+1)] = day_following + name
             else:
                 self[national_date] = name
 
@@ -209,7 +208,7 @@ class HongKong(HolidayBase):
         name = "Chung Yeung Festival"
         chung_yeung_date = self.cnls.lunar_to_gre(year, 9, 9)
         if self.observed and chung_yeung_date.weekday() == SUN:
-            self[chung_yeung_date + timedelta(days=+1)] = day_following + name
+            self[chung_yeung_date + td(days=+1)] = day_following + name
         else:
             self[chung_yeung_date] = name
 
@@ -220,25 +219,17 @@ class HongKong(HolidayBase):
         christmas_date = date(year, DEC, 25)
         if self.observed:
             if christmas_date.weekday() == SUN:
-                self[
-                    christmas_date + timedelta(days=+1)
-                ] = first_after_christmas
-                self[
-                    christmas_date + timedelta(days=+2)
-                ] = second_after_christmas
+                self[christmas_date + td(days=+1)] = first_after_christmas
+                self[christmas_date + td(days=+2)] = second_after_christmas
             elif christmas_date.weekday() == SAT:
                 self[christmas_date] = name
-                self[
-                    christmas_date + timedelta(days=+2)
-                ] = first_after_christmas
+                self[christmas_date + td(days=+2)] = first_after_christmas
             else:
                 self[christmas_date] = name
-                self[
-                    christmas_date + timedelta(days=+1)
-                ] = first_after_christmas
+                self[christmas_date + td(days=+1)] = first_after_christmas
         else:
             self[christmas_date] = name
-            self[christmas_date + timedelta(days=+1)] = day_following + name
+            self[christmas_date + td(days=+1)] = day_following + name
 
         # Previous holidays
         if 1952 <= year <= 1997:
@@ -253,7 +244,7 @@ class HongKong(HolidayBase):
 
             # Anniversary of the victory in the Second Sino-Japanese War
             self[
-                dt + timedelta(days=-1)
+                dt + td(days=-1)
             ] = "Anniversary of the victory in the Second Sino-Japanese War"
 
     @staticmethod

--- a/holidays/countries/hongkong.py
+++ b/holidays/countries/hongkong.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -58,7 +58,7 @@ class HongKong(HolidayBase):
         # The first day of January
         first_date = date(year, JAN, 1)
         if self.observed and first_date.weekday() == SUN:
-            self[first_date + rd(days=+1)] = (
+            self[first_date + timedelta(days=+1)] = (
                 day_following + "the first day of January"
             )
         else:
@@ -75,38 +75,40 @@ class HongKong(HolidayBase):
             self[new_year_date] = name
             if new_year_date.weekday() in {MON, TUE, WED, THU}:
                 self[new_year_date] = name
-                self[new_year_date + rd(days=+1)] = second_day_lunar
-                self[new_year_date + rd(days=+2)] = third_day_lunar
+                self[new_year_date + timedelta(days=+1)] = second_day_lunar
+                self[new_year_date + timedelta(days=+2)] = third_day_lunar
             if new_year_date.weekday() == FRI:
                 self[new_year_date] = name
-                self[new_year_date + rd(days=+1)] = second_day_lunar
-                self[new_year_date + rd(days=+3)] = fourth_day_lunar
+                self[new_year_date + timedelta(days=+1)] = second_day_lunar
+                self[new_year_date + timedelta(days=+3)] = fourth_day_lunar
             if new_year_date.weekday() == SAT:
                 self[new_year_date] = name
-                self[new_year_date + rd(days=+2)] = third_day_lunar
-                self[new_year_date + rd(days=+3)] = fourth_day_lunar
+                self[new_year_date + timedelta(days=+2)] = third_day_lunar
+                self[new_year_date + timedelta(days=+3)] = fourth_day_lunar
             if new_year_date.weekday() == SUN:
                 if year in {2006, 2007, 2010}:
-                    self[new_year_date + rd(days=-1)] = preceding_day_lunar
+                    self[
+                        new_year_date + timedelta(days=-1)
+                    ] = preceding_day_lunar
                 else:
-                    self[new_year_date + rd(days=+3)] = fourth_day_lunar
+                    self[new_year_date + timedelta(days=+3)] = fourth_day_lunar
             else:
                 self[new_year_date] = name
             if new_year_date.weekday() == SAT:
-                self[new_year_date + rd(days=+3)] = fourth_day_lunar
+                self[new_year_date + timedelta(days=+3)] = fourth_day_lunar
             else:
-                self[new_year_date + rd(days=+1)] = second_day_lunar
+                self[new_year_date + timedelta(days=+1)] = second_day_lunar
             if new_year_date.weekday() == FRI:
-                self[new_year_date + rd(days=+3)] = fourth_day_lunar
+                self[new_year_date + timedelta(days=+3)] = fourth_day_lunar
             else:
-                self[new_year_date + rd(days=+2)] = third_day_lunar
+                self[new_year_date + timedelta(days=+2)] = third_day_lunar
         else:
             self[new_year_date] = name
-            self[new_year_date + rd(days=+1)] = second_day_lunar
-            self[new_year_date + rd(days=+2)] = third_day_lunar
+            self[new_year_date + timedelta(days=+1)] = second_day_lunar
+            self[new_year_date + timedelta(days=+2)] = third_day_lunar
 
         easter_date = easter(year)
-        easter_monday_date = easter_date + rd(days=+1)
+        easter_monday_date = easter_date + timedelta(days=+1)
         # Ching Ming Festival
         name = "Ching Ming Festival"
         if self.is_leap_year(year) or (
@@ -119,17 +121,17 @@ class HongKong(HolidayBase):
             ching_ming_date.weekday() == SUN
             or ching_ming_date == easter_monday_date
         ):
-            self[ching_ming_date + rd(days=+1)] = day_following + name
+            self[ching_ming_date + timedelta(days=+1)] = day_following + name
         else:
             self[ching_ming_date] = name
 
         # Easter Holiday
         good_friday = "Good Friday"
         easter_monday = "Easter Monday"
-        self[easter_date + rd(days=-2)] = good_friday
-        self[easter_date + rd(days=-1)] = day_following + good_friday
+        self[easter_date + timedelta(days=-2)] = good_friday
+        self[easter_date + timedelta(days=-1)] = day_following + good_friday
         if self.observed and self.get(easter_monday_date):
-            self[easter_monday_date + rd(days=+1)] = (
+            self[easter_monday_date + timedelta(days=+1)] = (
                 day_following + easter_monday
             )
         else:
@@ -140,7 +142,7 @@ class HongKong(HolidayBase):
             name = "The Birthday of the Buddha"
             buddha_date = self.cnls.lunar_to_gre(year, 4, 8)
             if self.observed and buddha_date.weekday() == SUN:
-                self[buddha_date + rd(days=+1)] = day_following + name
+                self[buddha_date + timedelta(days=+1)] = day_following + name
             else:
                 self[buddha_date] = name
 
@@ -149,7 +151,7 @@ class HongKong(HolidayBase):
             name = "Labour Day"
             labour_date = date(year, MAY, 1)
             if self.observed and labour_date.weekday() == SUN:
-                self[labour_date + rd(days=+1)] = day_following + name
+                self[labour_date + timedelta(days=+1)] = day_following + name
             else:
                 self[labour_date] = name
 
@@ -157,7 +159,7 @@ class HongKong(HolidayBase):
         name = "Tuen Ng Festival"
         tuen_ng_date = self.cnls.lunar_to_gre(year, 5, 5)
         if self.observed and tuen_ng_date.weekday() == SUN:
-            self[tuen_ng_date + rd(days=+1)] = day_following + name
+            self[tuen_ng_date + timedelta(days=+1)] = day_following + name
         else:
             self[tuen_ng_date] = name
 
@@ -166,7 +168,7 @@ class HongKong(HolidayBase):
             name = "Hong Kong Special Administrative Region Establishment Day"
             hksar_date = date(year, JUL, 1)
             if self.observed and hksar_date.weekday() == SUN:
-                self[hksar_date + rd(days=+1)] = day_following + name
+                self[hksar_date + timedelta(days=+1)] = day_following + name
             else:
                 self[hksar_date] = name
 
@@ -182,11 +184,11 @@ class HongKong(HolidayBase):
                 if 1983 <= year <= 2010:
                     self[mid_autumn_date] = name
                 else:
-                    self[mid_autumn_date + rd(days=+2)] = (
+                    self[mid_autumn_date + timedelta(days=+2)] = (
                         "The second day of the " + name + " (Monday)"
                     )
             else:
-                self[mid_autumn_date + rd(days=+1)] = (
+                self[mid_autumn_date + timedelta(days=+1)] = (
                     day_following + "the " + name
                 )
         else:
@@ -199,7 +201,7 @@ class HongKong(HolidayBase):
             if self.observed and (
                 national_date.weekday() == SUN or self.get(national_date)
             ):
-                self[national_date + rd(days=+1)] = day_following + name
+                self[national_date + timedelta(days=+1)] = day_following + name
             else:
                 self[national_date] = name
 
@@ -207,7 +209,7 @@ class HongKong(HolidayBase):
         name = "Chung Yeung Festival"
         chung_yeung_date = self.cnls.lunar_to_gre(year, 9, 9)
         if self.observed and chung_yeung_date.weekday() == SUN:
-            self[chung_yeung_date + rd(days=+1)] = day_following + name
+            self[chung_yeung_date + timedelta(days=+1)] = day_following + name
         else:
             self[chung_yeung_date] = name
 
@@ -218,17 +220,25 @@ class HongKong(HolidayBase):
         christmas_date = date(year, DEC, 25)
         if self.observed:
             if christmas_date.weekday() == SUN:
-                self[christmas_date + rd(days=+1)] = first_after_christmas
-                self[christmas_date + rd(days=+2)] = second_after_christmas
+                self[
+                    christmas_date + timedelta(days=+1)
+                ] = first_after_christmas
+                self[
+                    christmas_date + timedelta(days=+2)
+                ] = second_after_christmas
             elif christmas_date.weekday() == SAT:
                 self[christmas_date] = name
-                self[christmas_date + rd(days=+2)] = first_after_christmas
+                self[
+                    christmas_date + timedelta(days=+2)
+                ] = first_after_christmas
             else:
                 self[christmas_date] = name
-                self[christmas_date + rd(days=+1)] = first_after_christmas
+                self[
+                    christmas_date + timedelta(days=+1)
+                ] = first_after_christmas
         else:
             self[christmas_date] = name
-            self[christmas_date + rd(days=+1)] = day_following + name
+            self[christmas_date + timedelta(days=+1)] = day_following + name
 
         # Previous holidays
         if 1952 <= year <= 1997:
@@ -243,7 +253,7 @@ class HongKong(HolidayBase):
 
             # Anniversary of the victory in the Second Sino-Japanese War
             self[
-                dt + rd(days=-1)
+                dt + timedelta(days=-1)
             ] = "Anniversary of the victory in the Second Sino-Japanese War"
 
     @staticmethod

--- a/holidays/countries/hungary.py
+++ b/holidays/countries/hungary.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -60,21 +61,21 @@ class Hungary(HolidayBase):
 
         # Good Friday
         if 2017 <= year:
-            self[easter_date + timedelta(days=-2)] = "Nagypéntek"
+            self[easter_date + td(days=-2)] = "Nagypéntek"
 
         # Easter
         self[easter_date] = "Húsvét"
 
         # Second easter day
         if 1955 != year:
-            self[easter_date + timedelta(days=+1)] = "Húsvét Hétfő"
+            self[easter_date + td(days=+1)] = "Húsvét Hétfő"
 
         # Pentecost
-        self[easter_date + timedelta(days=+49)] = "Pünkösd"
+        self[easter_date + td(days=+49)] = "Pünkösd"
 
         # Pentecost monday
         if year <= 1952 or 1992 <= year:
-            self[easter_date + timedelta(days=+50)] = "Pünkösdhétfő"
+            self[easter_date + td(days=+50)] = "Pünkösdhétfő"
 
         # International Workers' Day
         if 1946 <= year:
@@ -149,9 +150,9 @@ class Hungary(HolidayBase):
         # TODO: should it be a separate flag?
         if self.observed and since <= day.year:
             if day.weekday() == TUE and before:
-                self[day + timedelta(days=-1)] = desc + " előtti pihenőnap"
+                self[day + td(days=-1)] = desc + " előtti pihenőnap"
             elif day.weekday() == THU and after:
-                self[day + timedelta(days=+1)] = desc + " utáni pihenőnap"
+                self[day + td(days=+1)] = desc + " utáni pihenőnap"
 
 
 class HU(Hungary):

--- a/holidays/countries/hungary.py
+++ b/holidays/countries/hungary.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, APR, MAY, AUG, OCT, NOV, DEC, MON
 from holidays.constants import TUE, THU
@@ -61,21 +60,21 @@ class Hungary(HolidayBase):
 
         # Good Friday
         if 2017 <= year:
-            self[easter_date + rd(days=-2)] = "Nagypéntek"
+            self[easter_date + timedelta(days=-2)] = "Nagypéntek"
 
         # Easter
         self[easter_date] = "Húsvét"
 
         # Second easter day
         if 1955 != year:
-            self[easter_date + rd(days=+1)] = "Húsvét Hétfő"
+            self[easter_date + timedelta(days=+1)] = "Húsvét Hétfő"
 
         # Pentecost
-        self[easter_date + rd(days=+49)] = "Pünkösd"
+        self[easter_date + timedelta(days=+49)] = "Pünkösd"
 
         # Pentecost monday
         if year <= 1952 or 1992 <= year:
-            self[easter_date + rd(days=+50)] = "Pünkösdhétfő"
+            self[easter_date + timedelta(days=+50)] = "Pünkösdhétfő"
 
         # International Workers' Day
         if 1946 <= year:
@@ -150,9 +149,9 @@ class Hungary(HolidayBase):
         # TODO: should it be a separate flag?
         if self.observed and since <= day.year:
             if day.weekday() == TUE and before:
-                self[day + rd(days=-1)] = desc + " előtti pihenőnap"
+                self[day + timedelta(days=-1)] = desc + " előtti pihenőnap"
             elif day.weekday() == THU and after:
-                self[day + rd(days=+1)] = desc + " utáni pihenőnap"
+                self[day + timedelta(days=+1)] = desc + " utáni pihenőnap"
 
 
 class HU(Hungary):

--- a/holidays/countries/iceland.py
+++ b/holidays/countries/iceland.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, TH
@@ -33,15 +34,15 @@ class Iceland(HolidayBase):
         # Public holidays
         self[date(year, JAN, 1)] = "Nýársdagur"
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-3)] = "Skírdagur"
-        self[easter_date + timedelta(days=-2)] = "Föstudagurinn langi"
+        self[easter_date + td(days=-3)] = "Skírdagur"
+        self[easter_date + td(days=-2)] = "Föstudagurinn langi"
         self[easter_date] = "Páskadagur"
-        self[easter_date + timedelta(days=+1)] = "Annar í páskum"
+        self[easter_date + td(days=+1)] = "Annar í páskum"
         self[date(year, APR, 19) + rd(weekday=TH(+1))] = "Sumardagurinn fyrsti"
         self[date(year, MAY, 1)] = "Verkalýðsdagurinn"
-        self[easter_date + timedelta(days=+39)] = "Uppstigningardagur"
-        self[easter_date + timedelta(days=+49)] = "Hvítasunnudagur"
-        self[easter_date + timedelta(days=+50)] = "Annar í hvítasunnu"
+        self[easter_date + td(days=+39)] = "Uppstigningardagur"
+        self[easter_date + td(days=+49)] = "Hvítasunnudagur"
+        self[easter_date + td(days=+50)] = "Annar í hvítasunnu"
         self[date(year, JUN, 17)] = "Þjóðhátíðardagurinn"
         # First Monday of August
         self[

--- a/holidays/countries/iceland.py
+++ b/holidays/countries/iceland.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, TH
@@ -33,15 +33,15 @@ class Iceland(HolidayBase):
         # Public holidays
         self[date(year, JAN, 1)] = "Nýársdagur"
         easter_date = easter(year)
-        self[easter_date + rd(days=-3)] = "Skírdagur"
-        self[easter_date + rd(days=-2)] = "Föstudagurinn langi"
+        self[easter_date + timedelta(days=-3)] = "Skírdagur"
+        self[easter_date + timedelta(days=-2)] = "Föstudagurinn langi"
         self[easter_date] = "Páskadagur"
-        self[easter_date + rd(days=+1)] = "Annar í páskum"
+        self[easter_date + timedelta(days=+1)] = "Annar í páskum"
         self[date(year, APR, 19) + rd(weekday=TH(+1))] = "Sumardagurinn fyrsti"
         self[date(year, MAY, 1)] = "Verkalýðsdagurinn"
-        self[easter_date + rd(days=+39)] = "Uppstigningardagur"
-        self[easter_date + rd(days=+49)] = "Hvítasunnudagur"
-        self[easter_date + rd(days=+50)] = "Annar í hvítasunnu"
+        self[easter_date + timedelta(days=+39)] = "Uppstigningardagur"
+        self[easter_date + timedelta(days=+49)] = "Hvítasunnudagur"
+        self[easter_date + timedelta(days=+50)] = "Annar í hvítasunnu"
         self[date(year, JUN, 17)] = "Þjóðhátíðardagurinn"
         # First Monday of August
         self[

--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import warnings
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -268,20 +269,20 @@ class India(HolidayBase):
         name = "Eid ul-Fitr"
         for dt in _islamic_to_gre(year, 10, 1):
             self[dt] = f"{name}* (*estimated)"
-            self[dt + timedelta(days=+1)] = f"{name}* (*estimated)"
+            self[dt + td(days=+1)] = f"{name}* (*estimated)"
 
         # Eid al-Adha, i.e., Feast of the Sacrifice
         name = "Eid al-Adha"
         for dt in _islamic_to_gre(year, 12, 10):
             self[dt] = f"{name}* (*estimated)"
-            self[dt + timedelta(days=+1)] = f"{name}* (*estimated)"
+            self[dt + td(days=+1)] = f"{name}* (*estimated)"
 
         # Christian holidays
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-7)] = "Palm Sunday"
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-7)] = "Palm Sunday"
+        self[easter_date + td(days=-2)] = "Good Friday"
         self[easter_date] = "Easter Sunday"
-        self[easter_date + timedelta(days=+49)] = "Feast of Pentecost"
+        self[easter_date + td(days=+49)] = "Feast of Pentecost"
         self[date(year, DEC, 25)] = "Christmas Day"
 
 

--- a/holidays/countries/india.py
+++ b/holidays/countries/india.py
@@ -10,10 +10,9 @@
 #  License: MIT (see LICENSE file)
 
 import warnings
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, APR, MAY, JUN, AUG, OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -269,20 +268,20 @@ class India(HolidayBase):
         name = "Eid ul-Fitr"
         for dt in _islamic_to_gre(year, 10, 1):
             self[dt] = f"{name}* (*estimated)"
-            self[dt + rd(days=+1)] = f"{name}* (*estimated)"
+            self[dt + timedelta(days=+1)] = f"{name}* (*estimated)"
 
         # Eid al-Adha, i.e., Feast of the Sacrifice
         name = "Eid al-Adha"
         for dt in _islamic_to_gre(year, 12, 10):
             self[dt] = f"{name}* (*estimated)"
-            self[dt + rd(days=+1)] = f"{name}* (*estimated)"
+            self[dt + timedelta(days=+1)] = f"{name}* (*estimated)"
 
         # Christian holidays
         easter_date = easter(year)
-        self[easter_date + rd(days=-7)] = "Palm Sunday"
-        self[easter_date + rd(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-7)] = "Palm Sunday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
         self[easter_date] = "Easter Sunday"
-        self[easter_date + rd(days=+49)] = "Feast of Pentecost"
+        self[easter_date + timedelta(days=+49)] = "Feast of Pentecost"
         self[date(year, DEC, 25)] = "Christmas Day"
 
 

--- a/holidays/countries/indonesia.py
+++ b/holidays/countries/indonesia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -104,14 +105,14 @@ class Indonesia(HolidayBase):
                 hol_date = date(year, *date_obs)
                 self[hol_date] = "Hari Raya Idul Fitri"
                 self[
-                    hol_date + timedelta(days=+1)
+                    hol_date + td(days=+1)
                 ] = "Hari kedua dari Hari Raya Idul Fitri"
         else:
             for date_obs in _islamic_to_gre(year, 10, 1):
                 hol_date = date_obs
                 self[hol_date] = "Hari Raya Idul Fitri* (*estimated)"
                 self[
-                    hol_date + timedelta(days=+1)
+                    hol_date + td(days=+1)
                 ] = "Hari kedua dari Hari Raya Idul Fitri* (*estimated)"
 
         # Eid al-Adha
@@ -247,7 +248,7 @@ class Indonesia(HolidayBase):
                 self[hol_date] = "Isra' Mi'raj Nabi Muhammad* (*estimated)"
 
         # Good Friday
-        self[easter(year) + timedelta(days=-2)] = "Wafat Yesus Kristus"
+        self[easter(year) + td(days=-2)] = "Wafat Yesus Kristus"
 
         # Buddha's Birthday
         if year >= 1983:
@@ -282,7 +283,7 @@ class Indonesia(HolidayBase):
             self[date(year, MAY, 1)] = "Hari Buruh Internasional"
 
         # Ascension Day
-        self[easter(year) + timedelta(days=+39)] = "Kenaikan Yesus Kristus"
+        self[easter(year) + td(days=+39)] = "Kenaikan Yesus Kristus"
 
         # Pancasila Day
         if year >= 2017:

--- a/holidays/countries/indonesia.py
+++ b/holidays/countries/indonesia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP
 from holidays.constants import OCT, NOV, DEC
@@ -105,14 +104,14 @@ class Indonesia(HolidayBase):
                 hol_date = date(year, *date_obs)
                 self[hol_date] = "Hari Raya Idul Fitri"
                 self[
-                    hol_date + rd(days=+1)
+                    hol_date + timedelta(days=+1)
                 ] = "Hari kedua dari Hari Raya Idul Fitri"
         else:
             for date_obs in _islamic_to_gre(year, 10, 1):
                 hol_date = date_obs
                 self[hol_date] = "Hari Raya Idul Fitri* (*estimated)"
                 self[
-                    hol_date + rd(days=+1)
+                    hol_date + timedelta(days=+1)
                 ] = "Hari kedua dari Hari Raya Idul Fitri* (*estimated)"
 
         # Eid al-Adha
@@ -248,7 +247,7 @@ class Indonesia(HolidayBase):
                 self[hol_date] = "Isra' Mi'raj Nabi Muhammad* (*estimated)"
 
         # Good Friday
-        self[easter(year) + rd(days=-2)] = "Wafat Yesus Kristus"
+        self[easter(year) + timedelta(days=-2)] = "Wafat Yesus Kristus"
 
         # Buddha's Birthday
         if year >= 1983:
@@ -283,7 +282,7 @@ class Indonesia(HolidayBase):
             self[date(year, MAY, 1)] = "Hari Buruh Internasional"
 
         # Ascension Day
-        self[easter(year) + rd(days=+39)] = "Kenaikan Yesus Kristus"
+        self[easter(year) + timedelta(days=+39)] = "Kenaikan Yesus Kristus"
 
         # Pancasila Day
         if year >= 2017:

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -52,7 +53,7 @@ class Ireland(HolidayBase):
             self[dt + rd(weekday=MO)] = name + " (Observed)"
 
         # Easter Monday
-        self[easter(year) + timedelta(days=+1)] = "Easter Monday"
+        self[easter(year) + td(days=+1)] = "Easter Monday"
 
         # May bank holiday (first Monday in May)
         if year >= 1978:
@@ -84,7 +85,7 @@ class Ireland(HolidayBase):
         dt = date(year, DEC, 26)
         self[dt] = name
         if self.observed and self._is_weekend(dt):
-            self[dt + timedelta(days=+2)] = name + " (Observed)"
+            self[dt + td(days=+2)] = name + " (Observed)"
 
 
 class IE(Ireland):

--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -8,7 +8,8 @@
 #           ryanss <ryanssdev@icloud.com> (c) 2014-2017
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
-from datetime import date
+
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -51,7 +52,7 @@ class Ireland(HolidayBase):
             self[dt + rd(weekday=MO)] = name + " (Observed)"
 
         # Easter Monday
-        self[easter(year) + rd(days=+1)] = "Easter Monday"
+        self[easter(year) + timedelta(days=+1)] = "Easter Monday"
 
         # May bank holiday (first Monday in May)
         if year >= 1978:
@@ -83,7 +84,7 @@ class Ireland(HolidayBase):
         dt = date(year, DEC, 26)
         self[dt] = name
         if self.observed and self._is_weekend(dt):
-            self[dt + rd(days=+2)] = name + " (Observed)"
+            self[dt + timedelta(days=+2)] = name + " (Observed)"
 
 
 class IE(Ireland):

--- a/holidays/countries/israel.py
+++ b/holidays/countries/israel.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from convertdate import gregorian, hebrew
 from convertdate.holidays import hanukkah, lag_baomer, passover, purim
@@ -31,17 +32,15 @@ class Israel(HolidayBase):
         name = "Passover I"
         passover_start_dt = date(*passover(year, eve=True))
         self[passover_start_dt] = name + " - Eve"
-        self[passover_start_dt + timedelta(days=+1)] = name
+        self[passover_start_dt + td(days=+1)] = name
 
         name = "Passover"
         for offset in range(2, 6):
-            self[passover_start_dt + timedelta(days=offset)] = (
-                name + " - Chol HaMoed"
-            )
+            self[passover_start_dt + td(days=offset)] = name + " - Chol HaMoed"
 
         name = "Passover VII"
-        self[passover_start_dt + timedelta(days=+6)] = name + " - Eve"
-        self[passover_start_dt + timedelta(days=+7)] = name
+        self[passover_start_dt + td(days=+6)] = name + " - Eve"
+        self[passover_start_dt + td(days=+7)] = name
 
         # Memorial Day
         name = "Memorial Day"
@@ -50,7 +49,7 @@ class Israel(HolidayBase):
                 hebrew.to_jd_gregorianyear(year, hebrew.IYYAR, 3)
             )
         )
-        self[memorial_day_dt + timedelta(days=+1)] = name
+        self[memorial_day_dt + td(days=+1)] = name
 
         observed_delta = 0
         if self.observed:
@@ -61,16 +60,16 @@ class Israel(HolidayBase):
                 observed_delta = 1
 
             if observed_delta != 0:
-                self[memorial_day_dt + timedelta(days=observed_delta + 1)] = (
+                self[memorial_day_dt + td(days=observed_delta + 1)] = (
                     name + " (Observed)"
                 )
 
         # Independence Day
         name = "Independence Day"
-        self[memorial_day_dt + timedelta(days=+2)] = name
+        self[memorial_day_dt + td(days=+2)] = name
 
         if self.observed and observed_delta != 0:
-            self[memorial_day_dt + timedelta(days=observed_delta + 2)] = (
+            self[memorial_day_dt + td(days=observed_delta + 2)] = (
                 name + " (Observed)"
             )
 
@@ -83,48 +82,46 @@ class Israel(HolidayBase):
         name = "Shavuot"
         shavuot_dt = date(*shavuot(year, eve=True))
         self[shavuot_dt] = name + " - Eve"
-        self[shavuot_dt + timedelta(days=+1)] = name
+        self[shavuot_dt + td(days=+1)] = name
 
         # Rosh Hashana
         name = "Rosh Hashanah"
         rosh_hashanah_dt = date(*rosh_hashanah(year, eve=True))
         self[rosh_hashanah_dt] = name + " - Eve"
-        self[rosh_hashanah_dt + timedelta(days=+1)] = name
-        self[rosh_hashanah_dt + timedelta(days=+2)] = name
+        self[rosh_hashanah_dt + td(days=+1)] = name
+        self[rosh_hashanah_dt + td(days=+2)] = name
 
         # Yom Kippur
         name = "Yom Kippur"
         yom_kippur_dt = date(*yom_kippur(year, eve=True))
         self[yom_kippur_dt] = name + " - Eve"
-        self[yom_kippur_dt + timedelta(days=+1)] = name
+        self[yom_kippur_dt + td(days=+1)] = name
 
         # Sukkot
         name = "Sukkot I"
         sukkot_start_dt = date(*sukkot(year, eve=True))
         self[sukkot_start_dt] = name + " - Eve"
-        self[sukkot_start_dt + timedelta(days=+1)] = name
+        self[sukkot_start_dt + td(days=+1)] = name
 
         name = "Sukkot"
         for offset in range(2, 7):
-            self[sukkot_start_dt + timedelta(days=offset)] = (
-                name + " - Chol HaMoed"
-            )
+            self[sukkot_start_dt + td(days=offset)] = name + " - Chol HaMoed"
 
         name = "Sukkot VII"
-        self[sukkot_start_dt + timedelta(days=+7)] = name + " - Eve"
-        self[sukkot_start_dt + timedelta(days=+8)] = name
+        self[sukkot_start_dt + td(days=+7)] = name + " - Eve"
+        self[sukkot_start_dt + td(days=+8)] = name
 
         # Hanukkah
         name = "Hanukkah"
         hk_start_date = date(*hanukkah(year, eve=False))
         for offset in range(8):
-            hk_date = hk_start_date + timedelta(days=offset)
+            hk_date = hk_start_date + td(days=offset)
             if hk_date.year == year:
                 self[hk_date] = name
         # Some o prior's year Hannukah may fall in current year.
         hk_start_date = date(*hanukkah(year - 1, eve=False))
         for offset in range(8):
-            hk_date = hk_start_date + timedelta(days=offset)
+            hk_date = hk_start_date + td(days=offset)
             if hk_date.year == year:
                 self[hk_date] = name
 
@@ -132,8 +129,8 @@ class Israel(HolidayBase):
         name = "Purim"
         purim_date = date(*purim(year, eve=True))
         self[purim_date] = name + " - Eve"
-        self[purim_date + timedelta(days=+1)] = name
-        self[purim_date + timedelta(days=+2)] = "Shushan Purim"
+        self[purim_date + td(days=+1)] = name
+        self[purim_date + td(days=+2)] = "Shushan Purim"
 
 
 class IL(Israel):

--- a/holidays/countries/israel.py
+++ b/holidays/countries/israel.py
@@ -10,12 +10,11 @@
 #  License: MIT (see LICENSE file)
 
 
-from datetime import date
+from datetime import date, timedelta
 
 from convertdate import gregorian, hebrew
 from convertdate.holidays import hanukkah, lag_baomer, passover, purim
 from convertdate.holidays import rosh_hashanah, shavuot, sukkot, yom_kippur
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import WED, THU, SAT
 from holidays.holiday_base import HolidayBase
@@ -32,15 +31,17 @@ class Israel(HolidayBase):
         name = "Passover I"
         passover_start_dt = date(*passover(year, eve=True))
         self[passover_start_dt] = name + " - Eve"
-        self[passover_start_dt + rd(days=+1)] = name
+        self[passover_start_dt + timedelta(days=+1)] = name
 
         name = "Passover"
         for offset in range(2, 6):
-            self[passover_start_dt + rd(days=offset)] = name + " - Chol HaMoed"
+            self[passover_start_dt + timedelta(days=offset)] = (
+                name + " - Chol HaMoed"
+            )
 
         name = "Passover VII"
-        self[passover_start_dt + rd(days=+6)] = name + " - Eve"
-        self[passover_start_dt + rd(days=+7)] = name
+        self[passover_start_dt + timedelta(days=+6)] = name + " - Eve"
+        self[passover_start_dt + timedelta(days=+7)] = name
 
         # Memorial Day
         name = "Memorial Day"
@@ -49,7 +50,7 @@ class Israel(HolidayBase):
                 hebrew.to_jd_gregorianyear(year, hebrew.IYYAR, 3)
             )
         )
-        self[memorial_day_dt + rd(days=+1)] = name
+        self[memorial_day_dt + timedelta(days=+1)] = name
 
         observed_delta = 0
         if self.observed:
@@ -60,16 +61,16 @@ class Israel(HolidayBase):
                 observed_delta = 1
 
             if observed_delta != 0:
-                self[memorial_day_dt + rd(days=observed_delta + 1)] = (
+                self[memorial_day_dt + timedelta(days=observed_delta + 1)] = (
                     name + " (Observed)"
                 )
 
         # Independence Day
         name = "Independence Day"
-        self[memorial_day_dt + rd(days=+2)] = name
+        self[memorial_day_dt + timedelta(days=+2)] = name
 
         if self.observed and observed_delta != 0:
-            self[memorial_day_dt + rd(days=observed_delta + 2)] = (
+            self[memorial_day_dt + timedelta(days=observed_delta + 2)] = (
                 name + " (Observed)"
             )
 
@@ -82,46 +83,48 @@ class Israel(HolidayBase):
         name = "Shavuot"
         shavuot_dt = date(*shavuot(year, eve=True))
         self[shavuot_dt] = name + " - Eve"
-        self[shavuot_dt + rd(days=+1)] = name
+        self[shavuot_dt + timedelta(days=+1)] = name
 
         # Rosh Hashana
         name = "Rosh Hashanah"
         rosh_hashanah_dt = date(*rosh_hashanah(year, eve=True))
         self[rosh_hashanah_dt] = name + " - Eve"
-        self[rosh_hashanah_dt + rd(days=+1)] = name
-        self[rosh_hashanah_dt + rd(days=+2)] = name
+        self[rosh_hashanah_dt + timedelta(days=+1)] = name
+        self[rosh_hashanah_dt + timedelta(days=+2)] = name
 
         # Yom Kippur
         name = "Yom Kippur"
         yom_kippur_dt = date(*yom_kippur(year, eve=True))
         self[yom_kippur_dt] = name + " - Eve"
-        self[yom_kippur_dt + rd(days=+1)] = name
+        self[yom_kippur_dt + timedelta(days=+1)] = name
 
         # Sukkot
         name = "Sukkot I"
         sukkot_start_dt = date(*sukkot(year, eve=True))
         self[sukkot_start_dt] = name + " - Eve"
-        self[sukkot_start_dt + rd(days=+1)] = name
+        self[sukkot_start_dt + timedelta(days=+1)] = name
 
         name = "Sukkot"
         for offset in range(2, 7):
-            self[sukkot_start_dt + rd(days=offset)] = name + " - Chol HaMoed"
+            self[sukkot_start_dt + timedelta(days=offset)] = (
+                name + " - Chol HaMoed"
+            )
 
         name = "Sukkot VII"
-        self[sukkot_start_dt + rd(days=+7)] = name + " - Eve"
-        self[sukkot_start_dt + rd(days=+8)] = name
+        self[sukkot_start_dt + timedelta(days=+7)] = name + " - Eve"
+        self[sukkot_start_dt + timedelta(days=+8)] = name
 
         # Hanukkah
         name = "Hanukkah"
         hk_start_date = date(*hanukkah(year, eve=False))
         for offset in range(8):
-            hk_date = hk_start_date + rd(days=offset)
+            hk_date = hk_start_date + timedelta(days=offset)
             if hk_date.year == year:
                 self[hk_date] = name
         # Some o prior's year Hannukah may fall in current year.
         hk_start_date = date(*hanukkah(year - 1, eve=False))
         for offset in range(8):
-            hk_date = hk_start_date + rd(days=offset)
+            hk_date = hk_start_date + timedelta(days=offset)
             if hk_date.year == year:
                 self[hk_date] = name
 
@@ -129,8 +132,8 @@ class Israel(HolidayBase):
         name = "Purim"
         purim_date = date(*purim(year, eve=True))
         self[purim_date] = name + " - Eve"
-        self[purim_date + rd(days=+1)] = name
-        self[purim_date + rd(days=+2)] = "Shushan Purim"
+        self[purim_date + timedelta(days=+1)] = name
+        self[purim_date + timedelta(days=+2)] = "Shushan Purim"
 
 
 class IL(Israel):

--- a/holidays/countries/italy.py
+++ b/holidays/countries/italy.py
@@ -10,7 +10,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd
@@ -158,7 +159,7 @@ class Italy(HolidayBase):
         self[date(year, JAN, 6)] = "Epifania del Signore"
         easter_date = easter(year)
         self[easter_date] = "Pasqua di Resurrezione"
-        self[easter_date + timedelta(days=+1)] = "Lunedì dell'Angelo"
+        self[easter_date + td(days=+1)] = "Lunedì dell'Angelo"
         if year >= 1946:
             self[date(year, APR, 25)] = "Festa della Liberazione"
         self[date(year, MAY, 1)] = "Festa dei Lavoratori"
@@ -223,9 +224,7 @@ class Italy(HolidayBase):
             if self.subdiv in {"BT", "Trani"}:
                 self[date(year, MAY, 3)] = "San Nicola Pellegrino"
             elif self.subdiv == "BZ":
-                self[
-                    easter_date + timedelta(days=+50)
-                ] = "Lunedì di Pentecoste"
+                self[easter_date + td(days=+50)] = "Lunedì di Pentecoste"
                 self[date(year, AUG, 15)] = "Maria Santissima Assunta"
             elif self.subdiv == "CA":
                 self[date(year, OCT, 30)] = "San Saturnino di Cagliari"

--- a/holidays/countries/italy.py
+++ b/holidays/countries/italy.py
@@ -10,7 +10,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd
@@ -158,7 +158,7 @@ class Italy(HolidayBase):
         self[date(year, JAN, 6)] = "Epifania del Signore"
         easter_date = easter(year)
         self[easter_date] = "Pasqua di Resurrezione"
-        self[easter_date + rd(days=+1)] = "Lunedì dell'Angelo"
+        self[easter_date + timedelta(days=+1)] = "Lunedì dell'Angelo"
         if year >= 1946:
             self[date(year, APR, 25)] = "Festa della Liberazione"
         self[date(year, MAY, 1)] = "Festa dei Lavoratori"
@@ -223,7 +223,9 @@ class Italy(HolidayBase):
             if self.subdiv in {"BT", "Trani"}:
                 self[date(year, MAY, 3)] = "San Nicola Pellegrino"
             elif self.subdiv == "BZ":
-                self[easter_date + rd(days=+50)] = "Lunedì di Pentecoste"
+                self[
+                    easter_date + timedelta(days=+50)
+                ] = "Lunedì di Pentecoste"
                 self[date(year, AUG, 15)] = "Maria Santissima Assunta"
             elif self.subdiv == "CA":
                 self[date(year, OCT, 30)] = "San Saturnino di Cagliari"

--- a/holidays/countries/jamaica.py
+++ b/holidays/countries/jamaica.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, SU
@@ -86,16 +87,16 @@ class Jamaica(HolidayBase):
         easter_date = easter(year)
 
         # Ash Wednesday
-        self[easter_date + timedelta(days=-46)] = "Ash Wednesday"
+        self[easter_date + td(days=-46)] = "Ash Wednesday"
 
         # Good Friday
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-2)] = "Good Friday"
 
         # Easter
         self[easter_date] = "Easter"
 
         # Easter
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
 
 
 class JM(Jamaica):

--- a/holidays/countries/jamaica.py
+++ b/holidays/countries/jamaica.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, SU
@@ -86,16 +86,16 @@ class Jamaica(HolidayBase):
         easter_date = easter(year)
 
         # Ash Wednesday
-        self[easter_date + rd(days=-46)] = "Ash Wednesday"
+        self[easter_date + timedelta(days=-46)] = "Ash Wednesday"
 
         # Good Friday
-        self[easter_date + rd(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
 
         # Easter
         self[easter_date] = "Easter"
 
         # Easter
-        self[easter_date + rd(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
 
 class JM(Jamaica):

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
+from datetime import timedelta as td
 
 from dateutil import tz
 from dateutil.relativedelta import MO
@@ -148,16 +149,16 @@ class Japan(HolidayBase):
             # shall become a public holiday (振替休日) - substitute holidays
             for dt in list(self.keys()):
                 if dt.year == year and dt.weekday() == SUN:
-                    hol_date = dt + timedelta(days=+1)
+                    hol_date = dt + td(days=+1)
                     while hol_date in self:
-                        hol_date += timedelta(days=+1)
+                        hol_date += td(days=+1)
                     self[hol_date] = "振替休日"
 
             # A weekday between national holidays becomes
             # a holiday too (国民の休日) - citizens' holidays
             for dt in list(self.keys()):
-                if dt.year == year and dt + timedelta(days=+2) in self:
-                    hol_date = dt + timedelta(days=+1)
+                if dt.year == year and dt + td(days=+2) in self:
+                    hol_date = dt + td(days=+1)
                     if hol_date.weekday() != SUN and hol_date not in self:
                         self[hol_date] = "国民の休日"
 

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from dateutil import tz
 from dateutil.relativedelta import MO
@@ -148,16 +148,16 @@ class Japan(HolidayBase):
             # shall become a public holiday (振替休日) - substitute holidays
             for dt in list(self.keys()):
                 if dt.year == year and dt.weekday() == SUN:
-                    hol_date = dt + rd(days=+1)
+                    hol_date = dt + timedelta(days=+1)
                     while hol_date in self:
-                        hol_date += rd(days=+1)
+                        hol_date += timedelta(days=+1)
                     self[hol_date] = "振替休日"
 
             # A weekday between national holidays becomes
             # a holiday too (国民の休日) - citizens' holidays
             for dt in list(self.keys()):
-                if dt.year == year and dt + rd(days=+2) in self:
-                    hol_date = dt + rd(days=+1)
+                if dt.year == year and dt + timedelta(days=+2) in self:
+                    hol_date = dt + timedelta(days=+1)
                     if hol_date.weekday() != SUN and hol_date not in self:
                         self[hol_date] = "国民の休日"
 

--- a/holidays/countries/kazakhstan.py
+++ b/holidays/countries/kazakhstan.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import JAN, MAR, MAY, JUL, AUG, OCT, DEC
 from holidays.holiday_base import HolidayBase
@@ -83,11 +84,11 @@ class Kazakhstan(HolidayBase):
         if self.observed and year >= 2002:
             for k, v in list(self.items()):
                 if self._is_weekend(k) and k.year == year:
-                    next_workday = k + timedelta(days=+1)
+                    next_workday = k + td(days=+1)
                     while self._is_weekend(next_workday) or self.get(
                         next_workday
                     ):
-                        next_workday += timedelta(days=+1)
+                        next_workday += td(days=+1)
                     self[next_workday] = v + " (Observed)"
 
         # Nonworking days (without extending)

--- a/holidays/countries/kazakhstan.py
+++ b/holidays/countries/kazakhstan.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import JAN, MAR, MAY, JUL, AUG, OCT, DEC
 from holidays.holiday_base import HolidayBase
@@ -85,11 +83,11 @@ class Kazakhstan(HolidayBase):
         if self.observed and year >= 2002:
             for k, v in list(self.items()):
                 if self._is_weekend(k) and k.year == year:
-                    next_workday = k + rd(days=+1)
+                    next_workday = k + timedelta(days=+1)
                     while self._is_weekend(next_workday) or self.get(
                         next_workday
                     ):
-                        next_workday += rd(days=+1)
+                        next_workday += timedelta(days=+1)
                     self[next_workday] = v + " (Observed)"
 
         # Nonworking days (without extending)

--- a/holidays/countries/kenya.py
+++ b/holidays/countries/kenya.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUN, OCT, DEC, SUN
 from holidays.holiday_base import HolidayBase
@@ -43,11 +42,11 @@ class Kenya(HolidayBase):
         if self.observed:
             for k, v in list(self.items()):
                 if k.weekday() == SUN and k.year == year:
-                    self[k + rd(days=+1)] = v + " (Observed)"
+                    self[k + timedelta(days=+1)] = v + " (Observed)"
 
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
-        self[easter_date + rd(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
 
 class KE(Kenya):

--- a/holidays/countries/kenya.py
+++ b/holidays/countries/kenya.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -42,11 +43,11 @@ class Kenya(HolidayBase):
         if self.observed:
             for k, v in list(self.items()):
                 if k.weekday() == SUN and k.year == year:
-                    self[k + timedelta(days=+1)] = v + " (Observed)"
+                    self[k + td(days=+1)] = v + " (Observed)"
 
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=-2)] = "Good Friday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
 
 
 class KE(Kenya):

--- a/holidays/countries/kyrgyzstan.py
+++ b/holidays/countries/kyrgyzstan.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import JAN, FEB, MAR, APR, MAY, AUG, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -73,7 +74,7 @@ class Kyrgyzstan(HolidayBase):
         name = "Orozo Ait"
         for dt in _islamic_to_gre(year, 10, 1):
             self[dt] = name
-            self[dt + timedelta(days=+1)] = name
+            self[dt + td(days=+1)] = name
 
         # Kurman Ait.
         for dt in _islamic_to_gre(year, 12, 10):

--- a/holidays/countries/kyrgyzstan.py
+++ b/holidays/countries/kyrgyzstan.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import JAN, FEB, MAR, APR, MAY, AUG, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -75,7 +73,7 @@ class Kyrgyzstan(HolidayBase):
         name = "Orozo Ait"
         for dt in _islamic_to_gre(year, 10, 1):
             self[dt] = name
-            self[dt + rd(days=+1)] = name
+            self[dt + timedelta(days=+1)] = name
 
         # Kurman Ait.
         for dt in _islamic_to_gre(year, 12, 10):

--- a/holidays/countries/latvia.py
+++ b/holidays/countries/latvia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.holiday_base import HolidayBase
 
@@ -33,13 +32,13 @@ class Latvia(HolidayBase):
 
         # Good Friday
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Lielā Piektdiena"
+        self[easter_date + timedelta(days=-2)] = "Lielā Piektdiena"
 
         # Easter
         self[easter_date] = "Lieldienas"
 
         # Easter 2nd day
-        self[easter_date + rd(days=+1)] = "Otrās Lieldienas"
+        self[easter_date + timedelta(days=+1)] = "Otrās Lieldienas"
 
         # International Workers' Day
         self[date(year, 5, 1)] = "Darba svētki"

--- a/holidays/countries/latvia.py
+++ b/holidays/countries/latvia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -32,13 +33,13 @@ class Latvia(HolidayBase):
 
         # Good Friday
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Lielā Piektdiena"
+        self[easter_date + td(days=-2)] = "Lielā Piektdiena"
 
         # Easter
         self[easter_date] = "Lieldienas"
 
         # Easter 2nd day
-        self[easter_date + timedelta(days=+1)] = "Otrās Lieldienas"
+        self[easter_date + td(days=+1)] = "Otrās Lieldienas"
 
         # International Workers' Day
         self[date(year, 5, 1)] = "Darba svētki"

--- a/holidays/countries/lesotho.py
+++ b/holidays/countries/lesotho.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -44,9 +45,9 @@ class Lesotho(HolidayBase):
                 self[date(year, MAY, 25)] = "Africa/Heroes Day"
 
             easter_date = easter(year)
-            self[easter_date + timedelta(days=-2)] = "Good Friday"
-            self[easter_date + timedelta(days=+1)] = "Easter Monday"
-            self[easter_date + timedelta(days=+39)] = "Ascension Day"
+            self[easter_date + td(days=-2)] = "Good Friday"
+            self[easter_date + td(days=+1)] = "Easter Monday"
+            self[easter_date + td(days=+39)] = "Ascension Day"
             self[date(year, MAY, 1)] = "Workers' Day"
 
             if year > 1997:

--- a/holidays/countries/lesotho.py
+++ b/holidays/countries/lesotho.py
@@ -8,10 +8,10 @@
 #           ryanss <ryanssdev@icloud.com> (c) 2014-2017
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
-from datetime import date
+
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, APR, MAY, JUL, OCT, DEC
 from holidays.holiday_base import HolidayBase
@@ -44,9 +44,9 @@ class Lesotho(HolidayBase):
                 self[date(year, MAY, 25)] = "Africa/Heroes Day"
 
             easter_date = easter(year)
-            self[easter_date + rd(days=-2)] = "Good Friday"
-            self[easter_date + rd(days=+1)] = "Easter Monday"
-            self[easter_date + rd(days=+39)] = "Ascension Day"
+            self[easter_date + timedelta(days=-2)] = "Good Friday"
+            self[easter_date + timedelta(days=+1)] = "Easter Monday"
+            self[easter_date + timedelta(days=+39)] = "Ascension Day"
             self[date(year, MAY, 1)] = "Workers' Day"
 
             if year > 1997:

--- a/holidays/countries/liechtenstein.py
+++ b/holidays/countries/liechtenstein.py
@@ -10,10 +10,9 @@
 #  License: MIT (see LICENSE file)
 #  Copyright: Kateryna Golovanova <kate@kgthreads.com>, 2022
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import AUG, DEC, FEB, JAN, MAR, MAY, NOV, SEP
 from holidays.holiday_base import HolidayBase
@@ -43,34 +42,34 @@ class Liechtenstein(HolidayBase):
 
         easter_date = easter(year)
         # Shrove Tuesday.
-        self[easter_date + rd(days=-47)] = "Fasnachtsdienstag"
+        self[easter_date + timedelta(days=-47)] = "Fasnachtsdienstag"
 
         # Saint Joseph's Day.
         self[date(year, MAR, 19)] = "Josefstag"
 
         # Good Friday.
-        self[easter_date + rd(days=-2)] = "Karfreitag"
+        self[easter_date + timedelta(days=-2)] = "Karfreitag"
 
         # Easter.
         self[easter_date] = "Ostersonntag"
 
         # Easter Monday.
-        self[easter_date + rd(days=+1)] = "Ostermontag"
+        self[easter_date + timedelta(days=+1)] = "Ostermontag"
 
         # Labor Day.
         self[date(year, MAY, 1)] = "Tag der Arbeit"
 
         # Ascension Day.
-        self[easter_date + rd(days=+39)] = "Auffahrt"
+        self[easter_date + timedelta(days=+39)] = "Auffahrt"
 
         # Pentecost.
-        self[easter_date + rd(days=+49)] = "Pfingstsonntag"
+        self[easter_date + timedelta(days=+49)] = "Pfingstsonntag"
 
         # Whit Monday.
-        self[easter_date + rd(days=+50)] = "Pfingstmontag"
+        self[easter_date + timedelta(days=+50)] = "Pfingstmontag"
 
         # Corpus Christi.
-        self[easter_date + rd(days=+60)] = "Fronleichnam"
+        self[easter_date + timedelta(days=+60)] = "Fronleichnam"
 
         # National Day.
         self[date(year, AUG, 15)] = "Staatsfeiertag"

--- a/holidays/countries/liechtenstein.py
+++ b/holidays/countries/liechtenstein.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 #  Copyright: Kateryna Golovanova <kate@kgthreads.com>, 2022
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -42,34 +43,34 @@ class Liechtenstein(HolidayBase):
 
         easter_date = easter(year)
         # Shrove Tuesday.
-        self[easter_date + timedelta(days=-47)] = "Fasnachtsdienstag"
+        self[easter_date + td(days=-47)] = "Fasnachtsdienstag"
 
         # Saint Joseph's Day.
         self[date(year, MAR, 19)] = "Josefstag"
 
         # Good Friday.
-        self[easter_date + timedelta(days=-2)] = "Karfreitag"
+        self[easter_date + td(days=-2)] = "Karfreitag"
 
         # Easter.
         self[easter_date] = "Ostersonntag"
 
         # Easter Monday.
-        self[easter_date + timedelta(days=+1)] = "Ostermontag"
+        self[easter_date + td(days=+1)] = "Ostermontag"
 
         # Labor Day.
         self[date(year, MAY, 1)] = "Tag der Arbeit"
 
         # Ascension Day.
-        self[easter_date + timedelta(days=+39)] = "Auffahrt"
+        self[easter_date + td(days=+39)] = "Auffahrt"
 
         # Pentecost.
-        self[easter_date + timedelta(days=+49)] = "Pfingstsonntag"
+        self[easter_date + td(days=+49)] = "Pfingstsonntag"
 
         # Whit Monday.
-        self[easter_date + timedelta(days=+50)] = "Pfingstmontag"
+        self[easter_date + td(days=+50)] = "Pfingstmontag"
 
         # Corpus Christi.
-        self[easter_date + timedelta(days=+60)] = "Fronleichnam"
+        self[easter_date + td(days=+60)] = "Fronleichnam"
 
         # National Day.
         self[date(year, AUG, 15)] = "Staatsfeiertag"

--- a/holidays/countries/lithuania.py
+++ b/holidays/countries/lithuania.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import SU
@@ -48,7 +48,7 @@ class Lithuania(HolidayBase):
         self[easter_date] = "Velykos"
 
         # Easter 2nd day
-        self[easter_date + rd(days=+1)] = "Velykų antroji diena"
+        self[easter_date + timedelta(days=+1)] = "Velykų antroji diena"
 
         # International Workers' Day
         self[date(year, 5, 1)] = "Tarptautinė darbo diena"

--- a/holidays/countries/lithuania.py
+++ b/holidays/countries/lithuania.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import SU
@@ -48,7 +49,7 @@ class Lithuania(HolidayBase):
         self[easter_date] = "Velykos"
 
         # Easter 2nd day
-        self[easter_date + timedelta(days=+1)] = "Velykų antroji diena"
+        self[easter_date + td(days=+1)] = "Velykų antroji diena"
 
         # International Workers' Day
         self[date(year, 5, 1)] = "Tarptautinė darbo diena"

--- a/holidays/countries/luxembourg.py
+++ b/holidays/countries/luxembourg.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUN, AUG, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -31,13 +30,13 @@ class Luxembourg(HolidayBase):
         # Public holidays
         self[date(year, JAN, 1)] = "Neijoerschdag"
         easter_date = easter(year)
-        self[easter_date + rd(days=+1)] = "Ouschterméindeg"
+        self[easter_date + timedelta(days=+1)] = "Ouschterméindeg"
         self[date(year, MAY, 1)] = "Dag vun der Aarbecht"
         if year >= 2019:
             # Europe Day: not in legislation yet, but introduced starting 2019
             self[date(year, MAY, 9)] = "Europadag"
-        self[easter_date + rd(days=+39)] = "Christi Himmelfaart"
-        self[easter_date + rd(days=+50)] = "Péngschtméindeg"
+        self[easter_date + timedelta(days=+39)] = "Christi Himmelfaart"
+        self[easter_date + timedelta(days=+50)] = "Péngschtméindeg"
         self[date(year, JUN, 23)] = "Nationalfeierdag"
         self[date(year, AUG, 15)] = "Léiffrawëschdag"
         self[date(year, NOV, 1)] = "Allerhellgen"

--- a/holidays/countries/luxembourg.py
+++ b/holidays/countries/luxembourg.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -30,13 +31,13 @@ class Luxembourg(HolidayBase):
         # Public holidays
         self[date(year, JAN, 1)] = "Neijoerschdag"
         easter_date = easter(year)
-        self[easter_date + timedelta(days=+1)] = "Ouschterméindeg"
+        self[easter_date + td(days=+1)] = "Ouschterméindeg"
         self[date(year, MAY, 1)] = "Dag vun der Aarbecht"
         if year >= 2019:
             # Europe Day: not in legislation yet, but introduced starting 2019
             self[date(year, MAY, 9)] = "Europadag"
-        self[easter_date + timedelta(days=+39)] = "Christi Himmelfaart"
-        self[easter_date + timedelta(days=+50)] = "Péngschtméindeg"
+        self[easter_date + td(days=+39)] = "Christi Himmelfaart"
+        self[easter_date + td(days=+50)] = "Péngschtméindeg"
         self[date(year, JUN, 23)] = "Nationalfeierdag"
         self[date(year, AUG, 15)] = "Léiffrawëschdag"
         self[date(year, NOV, 1)] = "Allerhellgen"

--- a/holidays/countries/madagascar.py
+++ b/holidays/countries/madagascar.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import SU
@@ -57,23 +58,21 @@ class Madagascar(HolidayBase):
 
         easter_date = easter(year)
         self[easter_date] = "Fetin'ny paska / Easter Sunday"
+        self[easter_date + td(days=+1)] = "Alatsinain'ny paska / Easter Monday"
         self[
-            easter_date + timedelta(days=+1)
-        ] = "Alatsinain'ny paska / Easter Monday"
-        self[
-            easter_date + timedelta(days=+39)
+            easter_date + td(days=+39)
         ] = "Fiakaran'ny Jesosy kristy tany an-danitra / Ascension Day"
 
-        whit_sunday = easter_date + timedelta(days=+49)
+        whit_sunday = easter_date + td(days=+49)
         self[whit_sunday] = "Pentekosta / Whit Sunday"
 
         self[
-            easter_date + timedelta(days=+50)
+            easter_date + td(days=+50)
         ] = "Alatsinain'ny pentekosta / Whit Monday"
 
         dt = date(year, MAY, 31) + rd(weekday=SU(-1))
         if dt == whit_sunday:
-            dt += timedelta(days=+7)
+            dt += td(days=+7)
         self[dt] = "Fetin'ny Reny / Mother's Day"
 
 

--- a/holidays/countries/madagascar.py
+++ b/holidays/countries/madagascar.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import SU
@@ -57,21 +57,23 @@ class Madagascar(HolidayBase):
 
         easter_date = easter(year)
         self[easter_date] = "Fetin'ny paska / Easter Sunday"
-        self[easter_date + rd(days=+1)] = "Alatsinain'ny paska / Easter Monday"
         self[
-            easter_date + rd(days=+39)
+            easter_date + timedelta(days=+1)
+        ] = "Alatsinain'ny paska / Easter Monday"
+        self[
+            easter_date + timedelta(days=+39)
         ] = "Fiakaran'ny Jesosy kristy tany an-danitra / Ascension Day"
 
-        whit_sunday = easter_date + rd(days=+49)
+        whit_sunday = easter_date + timedelta(days=+49)
         self[whit_sunday] = "Pentekosta / Whit Sunday"
 
         self[
-            easter_date + rd(days=+50)
+            easter_date + timedelta(days=+50)
         ] = "Alatsinain'ny pentekosta / Whit Monday"
 
         dt = date(year, MAY, 31) + rd(weekday=SU(-1))
         if dt == whit_sunday:
-            dt += rd(days=+7)
+            dt += timedelta(days=+7)
         self[dt] = "Fetin'ny Reny / Mother's Day"
 
 

--- a/holidays/countries/malawi.py
+++ b/holidays/countries/malawi.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd
@@ -36,8 +36,8 @@ class Malawi(HolidayBase):
         self[date(year, JAN, 1)] = "New Year's Day"
 
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
-        self[easter_date + rd(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
         self[date(year, JAN, 15)] = "John Chilembwe Day"
         self[date(year, MAR, 3)] = "Martyrs Day"

--- a/holidays/countries/malawi.py
+++ b/holidays/countries/malawi.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import relativedelta as rd
@@ -36,8 +37,8 @@ class Malawi(HolidayBase):
         self[date(year, JAN, 1)] = "New Year's Day"
 
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=-2)] = "Good Friday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
 
         self[date(year, JAN, 15)] = "John Chilembwe Day"
         self[date(year, MAR, 3)] = "Martyrs Day"

--- a/holidays/countries/malaysia.py
+++ b/holidays/countries/malaysia.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 from typing import Iterable, Optional, Union
 
 from dateutil.easter import easter
@@ -118,7 +118,7 @@ class Malaysia(HolidayBase):
         # The second day of Chinese New Year is not a federal holiday in
         # Kelantan and Terengganu. However, it is gazetted as a state holiday
         # in both states, effectively making it a nationwide holiday.
-        self[hol_date + rd(days=+1)] = "Chinese New Year Holiday"
+        self[hol_date + timedelta(days=+1)] = "Chinese New Year Holiday"
 
         # Wesak Day.
         # Date of observance is announced yearly
@@ -297,7 +297,8 @@ class Malaysia(HolidayBase):
         for hol_date, hol_suffix in hol_dates:
             _add_holiday(hol_date, f"{name}{hol_suffix}")
             _add_holiday(
-                hol_date + rd(days=+1), f"Second day of {name}{hol_suffix}"
+                hol_date + timedelta(days=+1),
+                f"Second day of {name}{hol_suffix}",
             )
 
         # Hari Raya Haji and Arafat Day.
@@ -342,11 +343,14 @@ class Malaysia(HolidayBase):
             _add_holiday(hol_date, f"{name}{hol_suffix}")
             if self.subdiv == "TRG":
                 # Arafat Day is one day before Eid al-Adha
-                _add_holiday(hol_date + rd(days=-1), f"Arafat Day{hol_suffix}")
+                _add_holiday(
+                    hol_date + timedelta(days=-1), f"Arafat Day{hol_suffix}"
+                )
             if self.subdiv in {"KDH", "KTN", "PLS", "TRG"}:
                 # Second day
                 _add_holiday(
-                    hol_date + rd(days=+1), f"{name} Holiday{hol_suffix}"
+                    hol_date + timedelta(days=+1),
+                    f"{name} Holiday{hol_suffix}",
                 )
 
         # ---------------------------------------------------------#
@@ -613,23 +617,23 @@ class Malaysia(HolidayBase):
                 continue
             in_lieu_date = None
             if hol_date.weekday() == FRI and self.subdiv in {"JHR", "KDH"}:
-                in_lieu_date = hol_date + rd(days=+2)
+                in_lieu_date = hol_date + timedelta(days=+2)
             elif hol_date.weekday() == SAT and self.subdiv in {
                 "KTN",
                 "TRG",
             }:
-                in_lieu_date = hol_date + rd(days=+1)
+                in_lieu_date = hol_date + timedelta(days=+1)
             elif hol_date.weekday() == SUN and self.subdiv not in {
                 "JHR",
                 "KDH",
                 "KTN",
                 "TRG",
             }:
-                in_lieu_date = hol_date + rd(days=+1)
+                in_lieu_date = hol_date + timedelta(days=+1)
             if not in_lieu_date:
                 continue
             while in_lieu_date.year == year and in_lieu_date in self:
-                in_lieu_date += rd(days=+1)
+                in_lieu_date += timedelta(days=+1)
             _add_holiday(in_lieu_date, f"{hol_name} [In lieu]")
 
         # The last two days in May (Pesta Kaamatan).
@@ -705,7 +709,7 @@ class Malaysia(HolidayBase):
 
         # Good Friday.
         if self.subdiv in {"SBH", "SWK"}:
-            self[easter(year) + rd(days=-2)] = "Good Friday"
+            self[easter(year) + timedelta(days=-2)] = "Good Friday"
 
         # -----------------------------
         # State holidays (single state)

--- a/holidays/countries/malaysia.py
+++ b/holidays/countries/malaysia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 from typing import Iterable, Optional, Union
 
 from dateutil.easter import easter
@@ -118,7 +119,7 @@ class Malaysia(HolidayBase):
         # The second day of Chinese New Year is not a federal holiday in
         # Kelantan and Terengganu. However, it is gazetted as a state holiday
         # in both states, effectively making it a nationwide holiday.
-        self[hol_date + timedelta(days=+1)] = "Chinese New Year Holiday"
+        self[hol_date + td(days=+1)] = "Chinese New Year Holiday"
 
         # Wesak Day.
         # Date of observance is announced yearly
@@ -297,7 +298,7 @@ class Malaysia(HolidayBase):
         for hol_date, hol_suffix in hol_dates:
             _add_holiday(hol_date, f"{name}{hol_suffix}")
             _add_holiday(
-                hol_date + timedelta(days=+1),
+                hol_date + td(days=+1),
                 f"Second day of {name}{hol_suffix}",
             )
 
@@ -343,13 +344,11 @@ class Malaysia(HolidayBase):
             _add_holiday(hol_date, f"{name}{hol_suffix}")
             if self.subdiv == "TRG":
                 # Arafat Day is one day before Eid al-Adha
-                _add_holiday(
-                    hol_date + timedelta(days=-1), f"Arafat Day{hol_suffix}"
-                )
+                _add_holiday(hol_date + td(days=-1), f"Arafat Day{hol_suffix}")
             if self.subdiv in {"KDH", "KTN", "PLS", "TRG"}:
                 # Second day
                 _add_holiday(
-                    hol_date + timedelta(days=+1),
+                    hol_date + td(days=+1),
                     f"{name} Holiday{hol_suffix}",
                 )
 
@@ -617,23 +616,23 @@ class Malaysia(HolidayBase):
                 continue
             in_lieu_date = None
             if hol_date.weekday() == FRI and self.subdiv in {"JHR", "KDH"}:
-                in_lieu_date = hol_date + timedelta(days=+2)
+                in_lieu_date = hol_date + td(days=+2)
             elif hol_date.weekday() == SAT and self.subdiv in {
                 "KTN",
                 "TRG",
             }:
-                in_lieu_date = hol_date + timedelta(days=+1)
+                in_lieu_date = hol_date + td(days=+1)
             elif hol_date.weekday() == SUN and self.subdiv not in {
                 "JHR",
                 "KDH",
                 "KTN",
                 "TRG",
             }:
-                in_lieu_date = hol_date + timedelta(days=+1)
+                in_lieu_date = hol_date + td(days=+1)
             if not in_lieu_date:
                 continue
             while in_lieu_date.year == year and in_lieu_date in self:
-                in_lieu_date += timedelta(days=+1)
+                in_lieu_date += td(days=+1)
             _add_holiday(in_lieu_date, f"{hol_name} [In lieu]")
 
         # The last two days in May (Pesta Kaamatan).
@@ -709,7 +708,7 @@ class Malaysia(HolidayBase):
 
         # Good Friday.
         if self.subdiv in {"SBH", "SWK"}:
-            self[easter(year) + timedelta(days=-2)] = "Good Friday"
+            self[easter(year) + td(days=-2)] = "Good Friday"
 
         # -----------------------------
         # State holidays (single state)

--- a/holidays/countries/malta.py
+++ b/holidays/countries/malta.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -33,7 +34,7 @@ class Malta(HolidayBase):
         self[date(year, MAR, 31)] = "Freedom Day"
 
         # Easter and easter related calculations
-        good_friday = easter(year) + timedelta(days=-2)
+        good_friday = easter(year) + td(days=-2)
         self[good_friday] = "Good Friday"
 
         self[date(year, MAY, 1)] = "Worker's Day"

--- a/holidays/countries/malta.py
+++ b/holidays/countries/malta.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, MAR, MAY, JUN, AUG, SEP, DEC
 from holidays.holiday_base import HolidayBase
@@ -34,7 +33,7 @@ class Malta(HolidayBase):
         self[date(year, MAR, 31)] = "Freedom Day"
 
         # Easter and easter related calculations
-        good_friday = easter(year) + rd(days=-2)
+        good_friday = easter(year) + timedelta(days=-2)
         self[good_friday] = "Good Friday"
 
         self[date(year, MAY, 1)] = "Worker's Day"

--- a/holidays/countries/mexico.py
+++ b/holidays/countries/mexico.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.relativedelta import MO
 from dateutil.relativedelta import relativedelta as rd
@@ -25,9 +26,9 @@ class Mexico(HolidayBase):
     def _add_with_observed(self, holiday: date, name: str):
         self[holiday] = name
         if self.observed and holiday.weekday() == SAT:
-            self[holiday + timedelta(days=-1)] = name + " (Observed)"
+            self[holiday + td(days=-1)] = name + " (Observed)"
         elif self.observed and holiday.weekday() == SUN:
-            self[holiday + timedelta(days=+1)] = name + " (Observed)"
+            self[holiday + td(days=+1)] = name + " (Observed)"
 
     def _populate(self, year):
         super()._populate(year)
@@ -37,7 +38,7 @@ class Mexico(HolidayBase):
         dt = date(year, JAN, 1)
         self[dt] = name
         if self.observed and dt.weekday() == SUN:
-            self[dt + timedelta(days=+1)] = name + " (Observed)"
+            self[dt + td(days=+1)] = name + " (Observed)"
         # The next year's observed New Year's Day can be in this year
         # when it falls on a Friday (Jan 1st is a Saturday)
         if self.observed and date(year, DEC, 31).weekday() == FRI:

--- a/holidays/countries/mexico.py
+++ b/holidays/countries/mexico.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.relativedelta import MO
 from dateutil.relativedelta import relativedelta as rd
@@ -25,9 +25,9 @@ class Mexico(HolidayBase):
     def _add_with_observed(self, holiday: date, name: str):
         self[holiday] = name
         if self.observed and holiday.weekday() == SAT:
-            self[holiday + rd(days=-1)] = name + " (Observed)"
+            self[holiday + timedelta(days=-1)] = name + " (Observed)"
         elif self.observed and holiday.weekday() == SUN:
-            self[holiday + rd(days=+1)] = name + " (Observed)"
+            self[holiday + timedelta(days=+1)] = name + " (Observed)"
 
     def _populate(self, year):
         super()._populate(year)
@@ -37,7 +37,7 @@ class Mexico(HolidayBase):
         dt = date(year, JAN, 1)
         self[dt] = name
         if self.observed and dt.weekday() == SUN:
-            self[dt + rd(days=+1)] = name + " (Observed)"
+            self[dt + timedelta(days=+1)] = name + " (Observed)"
         # The next year's observed New Year's Day can be in this year
         # when it falls on a Friday (Jan 1st is a Saturday)
         if self.observed and date(year, DEC, 31).weekday() == FRI:

--- a/holidays/countries/moldova.py
+++ b/holidays/countries/moldova.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, MAY, JUN, AUG, OCT, DEC
 from holidays.holiday_base import HolidayBase
@@ -42,10 +41,10 @@ class Moldova(HolidayBase):
 
         # Orthodox Easter
         for day_after_easter in [-2, 0, 1]:
-            self[easter_date + rd(days=day_after_easter)] = "Paştele"
+            self[easter_date + timedelta(days=day_after_easter)] = "Paştele"
 
         # Paştele Blajinilor
-        self[easter_date + rd(days=+9)] = "Paştele Blajinilor"
+        self[easter_date + timedelta(days=+9)] = "Paştele Blajinilor"
 
         # Labour Day
         self[date(year, MAY, 1)] = "Ziua Internatională a Muncii"

--- a/holidays/countries/moldova.py
+++ b/holidays/countries/moldova.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -41,10 +42,10 @@ class Moldova(HolidayBase):
 
         # Orthodox Easter
         for day_after_easter in [-2, 0, 1]:
-            self[easter_date + timedelta(days=day_after_easter)] = "Paştele"
+            self[easter_date + td(days=day_after_easter)] = "Paştele"
 
         # Paştele Blajinilor
-        self[easter_date + timedelta(days=+9)] = "Paştele Blajinilor"
+        self[easter_date + td(days=+9)] = "Paştele Blajinilor"
 
         # Labour Day
         self[date(year, MAY, 1)] = "Ziua Internatională a Muncii"

--- a/holidays/countries/monaco.py
+++ b/holidays/countries/monaco.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -32,7 +33,7 @@ class Monaco(HolidayBase):
         def _add_with_observed(hol_date: date, hol_name: str) -> None:
             self[hol_date] = hol_name
             if self.observed and hol_date.weekday() == SUN:
-                self[hol_date + timedelta(days=+1)] = f"{hol_name} (Observed)"
+                self[hol_date + td(days=+1)] = f"{hol_name} (Observed)"
 
         super()._populate(year)
 
@@ -47,9 +48,7 @@ class Monaco(HolidayBase):
         easter_date = easter(year)
 
         # Easter Monday
-        self[
-            easter_date + timedelta(days=+1)
-        ] = "Le lundi de Pâques [Easter Monday]"
+        self[easter_date + td(days=+1)] = "Le lundi de Pâques [Easter Monday]"
 
         # Labour Day
         _add_with_observed(
@@ -57,19 +56,15 @@ class Monaco(HolidayBase):
         )
 
         # Ascension's Day
-        self[
-            easter_date + timedelta(days=+39)
-        ] = "L'Ascension [Ascension's Day]"
+        self[easter_date + td(days=+39)] = "L'Ascension [Ascension's Day]"
 
         # Whit Monday
         self[
-            easter_date + timedelta(days=+50)
+            easter_date + td(days=+50)
         ] = "Le lundi de Pentecôte [Whit Monday]"
 
         # Corpus Christi
-        self[
-            easter_date + timedelta(days=+60)
-        ] = "La Fête Dieu [Corpus Christi]"
+        self[easter_date + td(days=+60)] = "La Fête Dieu [Corpus Christi]"
 
         # Assumption's Day
         _add_with_observed(
@@ -89,7 +84,7 @@ class Monaco(HolidayBase):
         # Immaculate Conception's Day
         dt = date(year, DEC, 8)
         if year >= 2019 and dt.weekday() == SUN:
-            dt += timedelta(days=+1)
+            dt += td(days=+1)
         self[dt] = "L'Immaculée Conception [Immaculate Conception's Day]"
 
         # Christmas Day

--- a/holidays/countries/monaco.py
+++ b/holidays/countries/monaco.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import SUN, JAN, MAY, AUG, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -33,7 +32,7 @@ class Monaco(HolidayBase):
         def _add_with_observed(hol_date: date, hol_name: str) -> None:
             self[hol_date] = hol_name
             if self.observed and hol_date.weekday() == SUN:
-                self[hol_date + rd(days=+1)] = f"{hol_name} (Observed)"
+                self[hol_date + timedelta(days=+1)] = f"{hol_name} (Observed)"
 
         super()._populate(year)
 
@@ -48,7 +47,9 @@ class Monaco(HolidayBase):
         easter_date = easter(year)
 
         # Easter Monday
-        self[easter_date + rd(days=+1)] = "Le lundi de Pâques [Easter Monday]"
+        self[
+            easter_date + timedelta(days=+1)
+        ] = "Le lundi de Pâques [Easter Monday]"
 
         # Labour Day
         _add_with_observed(
@@ -56,15 +57,19 @@ class Monaco(HolidayBase):
         )
 
         # Ascension's Day
-        self[easter_date + rd(days=+39)] = "L'Ascension [Ascension's Day]"
+        self[
+            easter_date + timedelta(days=+39)
+        ] = "L'Ascension [Ascension's Day]"
 
         # Whit Monday
         self[
-            easter_date + rd(days=+50)
+            easter_date + timedelta(days=+50)
         ] = "Le lundi de Pentecôte [Whit Monday]"
 
         # Corpus Christi
-        self[easter_date + rd(days=+60)] = "La Fête Dieu [Corpus Christi]"
+        self[
+            easter_date + timedelta(days=+60)
+        ] = "La Fête Dieu [Corpus Christi]"
 
         # Assumption's Day
         _add_with_observed(
@@ -84,7 +89,7 @@ class Monaco(HolidayBase):
         # Immaculate Conception's Day
         dt = date(year, DEC, 8)
         if year >= 2019 and dt.weekday() == SUN:
-            dt += rd(days=+1)
+            dt += timedelta(days=+1)
         self[dt] = "L'Immaculée Conception [Immaculate Conception's Day]"
 
         # Christmas Day

--- a/holidays/countries/morocco.py
+++ b/holidays/countries/morocco.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import JAN, MAR, MAY, JUL, AUG, NOV
 from holidays.holiday_base import HolidayBase
@@ -101,7 +102,7 @@ class Morocco(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 10, 1):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid al-Fitr")
-                _add_holiday(hol_date + timedelta(days=+1), "Eid al-Fitr")
+                _add_holiday(hol_date + td(days=+1), "Eid al-Fitr")
 
         # Eid al-Adha - Sacrifice Festive
         # date of observance is announced yearly
@@ -109,7 +110,7 @@ class Morocco(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 10):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid al-Adha")
-                _add_holiday(hol_date + timedelta(days=+1), "Eid al-Adha")
+                _add_holiday(hol_date + td(days=+1), "Eid al-Adha")
 
         # Islamic New Year - (hijari_year, 1, 1)
         for date_obs in _islamic_to_gre(year, 1, 1):
@@ -121,9 +122,7 @@ class Morocco(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 3, 12):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Aid al Mawlid Annabawi")
-                _add_holiday(
-                    hol_date + timedelta(days=+1), "Aid al Mawlid Annabawi"
-                )
+                _add_holiday(hol_date + td(days=+1), "Aid al Mawlid Annabawi")
 
 
 class MA(Morocco):

--- a/holidays/countries/morocco.py
+++ b/holidays/countries/morocco.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import JAN, MAR, MAY, JUL, AUG, NOV
 from holidays.holiday_base import HolidayBase
@@ -103,7 +101,7 @@ class Morocco(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 10, 1):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid al-Fitr")
-                _add_holiday(hol_date + rd(days=+1), "Eid al-Fitr")
+                _add_holiday(hol_date + timedelta(days=+1), "Eid al-Fitr")
 
         # Eid al-Adha - Sacrifice Festive
         # date of observance is announced yearly
@@ -111,7 +109,7 @@ class Morocco(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 10):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid al-Adha")
-                _add_holiday(hol_date + rd(days=+1), "Eid al-Adha")
+                _add_holiday(hol_date + timedelta(days=+1), "Eid al-Adha")
 
         # Islamic New Year - (hijari_year, 1, 1)
         for date_obs in _islamic_to_gre(year, 1, 1):
@@ -123,7 +121,9 @@ class Morocco(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 3, 12):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Aid al Mawlid Annabawi")
-                _add_holiday(hol_date + rd(days=+1), "Aid al Mawlid Annabawi")
+                _add_holiday(
+                    hol_date + timedelta(days=+1), "Aid al Mawlid Annabawi"
+                )
 
 
 class MA(Morocco):

--- a/holidays/countries/mozambique.py
+++ b/holidays/countries/mozambique.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -27,11 +28,11 @@ class Mozambique(HolidayBase):
 
         self[date(year, JAN, 1)] = "Ano novo"
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Sexta-feira Santa"
+        self[easter_date + td(days=-2)] = "Sexta-feira Santa"
 
         # carnival is the Tuesday before Ash Wednesday
         # which is 40 days before easter excluding sundays
-        self[easter_date + timedelta(days=-47)] = "Carnaval"
+        self[easter_date + td(days=-47)] = "Carnaval"
 
         self[date(year, FEB, 3)] = "Dia dos Heróis Moçambicanos"
         self[date(year, APR, 7)] = "Dia da Mulher Moçambicana"
@@ -47,7 +48,7 @@ class Mozambique(HolidayBase):
         if self.observed:
             for k, v in list(self.items()):
                 if k.weekday() == SUN and k.year == year:
-                    self[k + timedelta(days=+1)] = v + " (PONTE)"
+                    self[k + td(days=+1)] = v + " (PONTE)"
 
 
 class MZ(Mozambique):

--- a/holidays/countries/mozambique.py
+++ b/holidays/countries/mozambique.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, APR, MAY, JUN, SEP, OCT, DEC, SUN
 from holidays.holiday_base import HolidayBase
@@ -28,11 +27,11 @@ class Mozambique(HolidayBase):
 
         self[date(year, JAN, 1)] = "Ano novo"
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Sexta-feira Santa"
+        self[easter_date + timedelta(days=-2)] = "Sexta-feira Santa"
 
         # carnival is the Tuesday before Ash Wednesday
         # which is 40 days before easter excluding sundays
-        self[easter_date + rd(days=-47)] = "Carnaval"
+        self[easter_date + timedelta(days=-47)] = "Carnaval"
 
         self[date(year, FEB, 3)] = "Dia dos Heróis Moçambicanos"
         self[date(year, APR, 7)] = "Dia da Mulher Moçambicana"
@@ -48,7 +47,7 @@ class Mozambique(HolidayBase):
         if self.observed:
             for k, v in list(self.items()):
                 if k.weekday() == SUN and k.year == year:
-                    self[k + rd(days=+1)] = v + " (PONTE)"
+                    self[k + timedelta(days=+1)] = v + " (PONTE)"
 
 
 class MZ(Mozambique):

--- a/holidays/countries/namibia.py
+++ b/holidays/countries/namibia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, MAY, AUG, SEP, DEC, SUN
 from holidays.holiday_base import HolidayBase
@@ -42,9 +41,9 @@ class Namibia(HolidayBase):
 
         # Easter Calculation
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
-        self[easter_date + rd(days=+1)] = "Easter Monday"
-        self[easter_date + rd(days=+39)] = "Ascension Day"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=+39)] = "Ascension Day"
         # --------END OF EASTER------------#
 
         self[date(year, MAY, 1)] = "Workers' Day"
@@ -69,7 +68,7 @@ class Namibia(HolidayBase):
         if self.observed:
             for k, v in list(self.items()):
                 if k.weekday() == SUN and k.year == year:
-                    self[k + rd(days=+1)] = v + " (Observed)"
+                    self[k + timedelta(days=+1)] = v + " (Observed)"
 
 
 class NA(Namibia):

--- a/holidays/countries/namibia.py
+++ b/holidays/countries/namibia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -41,9 +42,9 @@ class Namibia(HolidayBase):
 
         # Easter Calculation
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
-        self[easter_date + timedelta(days=+39)] = "Ascension Day"
+        self[easter_date + td(days=-2)] = "Good Friday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=+39)] = "Ascension Day"
         # --------END OF EASTER------------#
 
         self[date(year, MAY, 1)] = "Workers' Day"
@@ -68,7 +69,7 @@ class Namibia(HolidayBase):
         if self.observed:
             for k, v in list(self.items()):
                 if k.weekday() == SUN and k.year == year:
-                    self[k + timedelta(days=+1)] = v + " (Observed)"
+                    self[k + td(days=+1)] = v + " (Observed)"
 
 
 class NA(Namibia):

--- a/holidays/countries/netherlands.py
+++ b/holidays/countries/netherlands.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, APR, MAY, AUG, DEC, SUN
 from holidays.holiday_base import HolidayBase
@@ -37,19 +36,19 @@ class Netherlands(HolidayBase):
         self[easter_date] = "Eerste paasdag"
 
         # Good friday
-        self[easter_date + rd(days=-2)] = "Goede Vrijdag"
+        self[easter_date + timedelta(days=-2)] = "Goede Vrijdag"
 
         # Second easter day
-        self[easter_date + rd(days=+1)] = "Tweede paasdag"
+        self[easter_date + timedelta(days=+1)] = "Tweede paasdag"
 
         # Ascension day
-        self[easter_date + rd(days=+39)] = "Hemelvaart"
+        self[easter_date + timedelta(days=+39)] = "Hemelvaart"
 
         # Pentecost
-        self[easter_date + rd(days=+49)] = "Eerste Pinksterdag"
+        self[easter_date + timedelta(days=+49)] = "Eerste Pinksterdag"
 
         # Pentecost monday
-        self[easter_date + rd(days=+50)] = "Tweede Pinksterdag"
+        self[easter_date + timedelta(days=+50)] = "Tweede Pinksterdag"
 
         # First christmas
         self[date(year, DEC, 25)] = "Eerste Kerstdag"
@@ -65,7 +64,7 @@ class Netherlands(HolidayBase):
         if year >= 2014:
             kings_day = date(year, APR, 27)
             if kings_day.weekday() == SUN:
-                kings_day += rd(days=-1)
+                kings_day += timedelta(days=-1)
 
             self[kings_day] = "Koningsdag"
 
@@ -76,7 +75,9 @@ class Netherlands(HolidayBase):
                 queens_day = date(year, AUG, 31)
 
             if queens_day.weekday() == SUN:
-                queens_day += rd(days=1) if year < 1980 else rd(days=-1)
+                queens_day += (
+                    timedelta(days=1) if year < 1980 else timedelta(days=-1)
+                )
 
             self[queens_day] = "Koninginnedag"
 

--- a/holidays/countries/netherlands.py
+++ b/holidays/countries/netherlands.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -36,19 +37,19 @@ class Netherlands(HolidayBase):
         self[easter_date] = "Eerste paasdag"
 
         # Good friday
-        self[easter_date + timedelta(days=-2)] = "Goede Vrijdag"
+        self[easter_date + td(days=-2)] = "Goede Vrijdag"
 
         # Second easter day
-        self[easter_date + timedelta(days=+1)] = "Tweede paasdag"
+        self[easter_date + td(days=+1)] = "Tweede paasdag"
 
         # Ascension day
-        self[easter_date + timedelta(days=+39)] = "Hemelvaart"
+        self[easter_date + td(days=+39)] = "Hemelvaart"
 
         # Pentecost
-        self[easter_date + timedelta(days=+49)] = "Eerste Pinksterdag"
+        self[easter_date + td(days=+49)] = "Eerste Pinksterdag"
 
         # Pentecost monday
-        self[easter_date + timedelta(days=+50)] = "Tweede Pinksterdag"
+        self[easter_date + td(days=+50)] = "Tweede Pinksterdag"
 
         # First christmas
         self[date(year, DEC, 25)] = "Eerste Kerstdag"
@@ -64,7 +65,7 @@ class Netherlands(HolidayBase):
         if year >= 2014:
             kings_day = date(year, APR, 27)
             if kings_day.weekday() == SUN:
-                kings_day += timedelta(days=-1)
+                kings_day += td(days=-1)
 
             self[kings_day] = "Koningsdag"
 
@@ -75,9 +76,7 @@ class Netherlands(HolidayBase):
                 queens_day = date(year, AUG, 31)
 
             if queens_day.weekday() == SUN:
-                queens_day += (
-                    timedelta(days=1) if year < 1980 else timedelta(days=-1)
-                )
+                queens_day += td(days=1) if year < 1980 else td(days=-1)
 
             self[queens_day] = "Koninginnedag"
 

--- a/holidays/countries/new_zealand.py
+++ b/holidays/countries/new_zealand.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, TU, WE
@@ -75,7 +76,7 @@ class NewZealand(HolidayBase):
         if self.observed and self._is_weekend(dt):
             obs_date = dt + rd(weekday=MO)
             if self.get(obs_date):
-                obs_date += timedelta(days=+1)
+                obs_date += td(days=+1)
             self[obs_date] = f"{self[dt]} (Observed)"
 
     def _populate(self, year):
@@ -122,8 +123,8 @@ class NewZealand(HolidayBase):
 
         # Easter
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=-2)] = "Good Friday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
 
         # Sovereign's Birthday
         if year >= 1902:
@@ -215,7 +216,7 @@ class NewZealand(HolidayBase):
 
         elif self.subdiv in {"Hawke's Bay", "HKB"}:
             self[
-                (date(year, OCT, 1) + rd(weekday=MO(+4)) + timedelta(days=-3))
+                (date(year, OCT, 1) + rd(weekday=MO(+4)) + td(days=-3))
             ] = "Hawke's Bay Anniversary Day"
 
         elif self.subdiv in {"WGN", "Wellington"}:
@@ -225,7 +226,7 @@ class NewZealand(HolidayBase):
 
         elif self.subdiv in {"Marlborough", "MBH"}:
             self[
-                (date(year, OCT, 1) + rd(weekday=MO(+4)) + timedelta(days=+7))
+                (date(year, OCT, 1) + rd(weekday=MO(+4)) + td(days=+7))
             ] = "Marlborough Anniversary Day"
 
         elif self.subdiv in {"Nelson", "NSN"}:
@@ -235,7 +236,7 @@ class NewZealand(HolidayBase):
 
         elif self.subdiv in {"CAN", "Canterbury"}:
             self[
-                (date(year, NOV, 1) + rd(weekday=TU) + timedelta(days=+10))
+                (date(year, NOV, 1) + rd(weekday=TU) + td(days=+10))
             ] = "Canterbury Anniversary Day"
 
         elif self.subdiv in {"South Canterbury", "STC"}:
@@ -254,14 +255,14 @@ class NewZealand(HolidayBase):
         elif self.subdiv in {"OTA", "Otago"}:
             # there is no easily determined single day of local observance?!?!
             dt = self._get_nearest_monday(date(year, MAR, 23))
-            if dt == easter_date + timedelta(days=+1):  # Avoid Easter Monday
-                dt += timedelta(days=+1)
+            if dt == easter_date + td(days=+1):  # Avoid Easter Monday
+                dt += td(days=+1)
             self[dt] = "Otago Anniversary Day"
 
         elif self.subdiv in {"STL", "Southland"}:
             name = "Southland Anniversary Day"
             if year >= 2012:
-                self[easter_date + timedelta(days=+2)] = name
+                self[easter_date + td(days=+2)] = name
             else:
                 self[self._get_nearest_monday(date(year, JAN, 17))] = name
 

--- a/holidays/countries/new_zealand.py
+++ b/holidays/countries/new_zealand.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, TU, WE
@@ -75,7 +75,7 @@ class NewZealand(HolidayBase):
         if self.observed and self._is_weekend(dt):
             obs_date = dt + rd(weekday=MO)
             if self.get(obs_date):
-                obs_date += rd(days=+1)
+                obs_date += timedelta(days=+1)
             self[obs_date] = f"{self[dt]} (Observed)"
 
     def _populate(self, year):
@@ -122,8 +122,8 @@ class NewZealand(HolidayBase):
 
         # Easter
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
-        self[easter_date + rd(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
         # Sovereign's Birthday
         if year >= 1902:
@@ -215,7 +215,7 @@ class NewZealand(HolidayBase):
 
         elif self.subdiv in {"Hawke's Bay", "HKB"}:
             self[
-                (date(year, OCT, 1) + rd(weekday=MO(+4)) + rd(days=-3))
+                (date(year, OCT, 1) + rd(weekday=MO(+4)) + timedelta(days=-3))
             ] = "Hawke's Bay Anniversary Day"
 
         elif self.subdiv in {"WGN", "Wellington"}:
@@ -225,7 +225,7 @@ class NewZealand(HolidayBase):
 
         elif self.subdiv in {"Marlborough", "MBH"}:
             self[
-                (date(year, OCT, 1) + rd(weekday=MO(+4)) + rd(days=+7))
+                (date(year, OCT, 1) + rd(weekday=MO(+4)) + timedelta(days=+7))
             ] = "Marlborough Anniversary Day"
 
         elif self.subdiv in {"Nelson", "NSN"}:
@@ -235,7 +235,7 @@ class NewZealand(HolidayBase):
 
         elif self.subdiv in {"CAN", "Canterbury"}:
             self[
-                (date(year, NOV, 1) + rd(weekday=TU) + rd(days=+10))
+                (date(year, NOV, 1) + rd(weekday=TU) + timedelta(days=+10))
             ] = "Canterbury Anniversary Day"
 
         elif self.subdiv in {"South Canterbury", "STC"}:
@@ -254,14 +254,14 @@ class NewZealand(HolidayBase):
         elif self.subdiv in {"OTA", "Otago"}:
             # there is no easily determined single day of local observance?!?!
             dt = self._get_nearest_monday(date(year, MAR, 23))
-            if dt == easter_date + rd(days=+1):  # Avoid Easter Monday
-                dt += rd(days=+1)
+            if dt == easter_date + timedelta(days=+1):  # Avoid Easter Monday
+                dt += timedelta(days=+1)
             self[dt] = "Otago Anniversary Day"
 
         elif self.subdiv in {"STL", "Southland"}:
             name = "Southland Anniversary Day"
             if year >= 2012:
-                self[easter_date + rd(days=+2)] = name
+                self[easter_date + timedelta(days=+2)] = name
             else:
                 self[self._get_nearest_monday(date(year, JAN, 17))] = name
 

--- a/holidays/countries/nicaragua.py
+++ b/holidays/countries/nicaragua.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUL, AUG, SEP, DEC
 from holidays.holiday_base import HolidayBase
@@ -35,9 +34,11 @@ class Nicaragua(HolidayBase):
         self[date(year, JAN, 1)] = "Año Nuevo [New Year's Day]"
         # Maundy Thursday
         easter_date = easter(year)
-        self[easter_date + rd(days=-3)] = "Jueves Santo [Maundy Thursday]"
+        self[
+            easter_date + timedelta(days=-3)
+        ] = "Jueves Santo [Maundy Thursday]"
         # Good Friday
-        self[easter_date + rd(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
         # Labor Day
         self[date(year, MAY, 1)] = "Día del Trabajo [Labour Day]"
         # Revolution Day

--- a/holidays/countries/nicaragua.py
+++ b/holidays/countries/nicaragua.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -34,11 +35,9 @@ class Nicaragua(HolidayBase):
         self[date(year, JAN, 1)] = "Año Nuevo [New Year's Day]"
         # Maundy Thursday
         easter_date = easter(year)
-        self[
-            easter_date + timedelta(days=-3)
-        ] = "Jueves Santo [Maundy Thursday]"
+        self[easter_date + td(days=-3)] = "Jueves Santo [Maundy Thursday]"
         # Good Friday
-        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter_date + td(days=-2)] = "Viernes Santo [Good Friday]"
         # Labor Day
         self[date(year, MAY, 1)] = "Día del Trabajo [Labour Day]"
         # Revolution Day

--- a/holidays/countries/nigeria.py
+++ b/holidays/countries/nigeria.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUN, OCT, DEC
 from holidays.holiday_base import HolidayBase
@@ -45,8 +44,8 @@ class Nigeria(HolidayBase):
         # Calculate Easter for given year
         # followed by easter related holidays
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
-        self[easter_date + rd(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
         # Worker's day
         if year >= 1981:
@@ -58,7 +57,9 @@ class Nigeria(HolidayBase):
         for yr in (year - 1, year):
             for hol_date in _islamic_to_gre(yr, 10, 1):
                 _add_holiday(hol_date, "Eid al-Fitr")
-                _add_holiday(hol_date + rd(days=+1), "Eid al-Fitr Holiday")
+                _add_holiday(
+                    hol_date + timedelta(days=+1), "Eid al-Fitr Holiday"
+                )
 
         # Arafat Day & Eid al-Adha - Scarfice Festive
         # This is an estimate
@@ -66,7 +67,9 @@ class Nigeria(HolidayBase):
         for yr in (year - 1, year):
             for hol_date in _islamic_to_gre(yr, 12, 10):
                 _add_holiday(hol_date, "Eid al-Adha")
-                _add_holiday(hol_date + rd(days=+1), "Eid al-Adha Holiday")
+                _add_holiday(
+                    hol_date + timedelta(days=+1), "Eid al-Adha Holiday"
+                )
 
         # Birthday of Prophet Muhammad
         for hol_date in _islamic_to_gre(year, 3, 12):
@@ -94,11 +97,11 @@ class Nigeria(HolidayBase):
         if self.observed and year >= 2016:
             for k, v in list(self.items()):
                 if self._is_weekend(k) and k.year == year:
-                    next_workday = k + rd(days=+1)
+                    next_workday = k + timedelta(days=+1)
                     while self._is_weekend(next_workday) or self.get(
                         next_workday
                     ):
-                        next_workday += rd(days=+1)
+                        next_workday += timedelta(days=+1)
                     self[next_workday] = v + " (Observed)"
 
 

--- a/holidays/countries/nigeria.py
+++ b/holidays/countries/nigeria.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -44,8 +45,8 @@ class Nigeria(HolidayBase):
         # Calculate Easter for given year
         # followed by easter related holidays
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=-2)] = "Good Friday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
 
         # Worker's day
         if year >= 1981:
@@ -57,9 +58,7 @@ class Nigeria(HolidayBase):
         for yr in (year - 1, year):
             for hol_date in _islamic_to_gre(yr, 10, 1):
                 _add_holiday(hol_date, "Eid al-Fitr")
-                _add_holiday(
-                    hol_date + timedelta(days=+1), "Eid al-Fitr Holiday"
-                )
+                _add_holiday(hol_date + td(days=+1), "Eid al-Fitr Holiday")
 
         # Arafat Day & Eid al-Adha - Scarfice Festive
         # This is an estimate
@@ -67,9 +66,7 @@ class Nigeria(HolidayBase):
         for yr in (year - 1, year):
             for hol_date in _islamic_to_gre(yr, 12, 10):
                 _add_holiday(hol_date, "Eid al-Adha")
-                _add_holiday(
-                    hol_date + timedelta(days=+1), "Eid al-Adha Holiday"
-                )
+                _add_holiday(hol_date + td(days=+1), "Eid al-Adha Holiday")
 
         # Birthday of Prophet Muhammad
         for hol_date in _islamic_to_gre(year, 3, 12):
@@ -97,11 +94,11 @@ class Nigeria(HolidayBase):
         if self.observed and year >= 2016:
             for k, v in list(self.items()):
                 if self._is_weekend(k) and k.year == year:
-                    next_workday = k + timedelta(days=+1)
+                    next_workday = k + td(days=+1)
                     while self._is_weekend(next_workday) or self.get(
                         next_workday
                     ):
-                        next_workday += timedelta(days=+1)
+                        next_workday += td(days=+1)
                     self[next_workday] = v + " (Observed)"
 
 

--- a/holidays/countries/north_macedonia.py
+++ b/holidays/countries/north_macedonia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -32,7 +33,7 @@ class NorthMacedonia(HolidayBase):
 
         self[date(year, JAN, 7)] = "Christmas Day (Orthodox)"
         easter_date = easter(year, method=EASTER_ORTHODOX)
-        self[easter_date + timedelta(days=+1)] = "Easter Monday(Orthodox)"
+        self[easter_date + td(days=+1)] = "Easter Monday(Orthodox)"
         self[date(year, MAY, 1)] = "Labour Day"
         self[date(year, MAY, 24)] = "Saints Cyril and Methodius Day"
         self[date(year, AUG, 2)] = "Republic Day"

--- a/holidays/countries/north_macedonia.py
+++ b/holidays/countries/north_macedonia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, SEP, AUG, OCT, DEC
 from holidays.holiday_base import HolidayBase
@@ -33,7 +32,7 @@ class NorthMacedonia(HolidayBase):
 
         self[date(year, JAN, 7)] = "Christmas Day (Orthodox)"
         easter_date = easter(year, method=EASTER_ORTHODOX)
-        self[easter_date + rd(days=+1)] = "Easter Monday(Orthodox)"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday(Orthodox)"
         self[date(year, MAY, 1)] = "Labour Day"
         self[date(year, MAY, 24)] = "Saints Cyril and Methodius Day"
         self[date(year, AUG, 2)] = "Republic Day"

--- a/holidays/countries/norway.py
+++ b/holidays/countries/norway.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
+from datetime import timedelta as td
 
 from dateutil import rrule
 from dateutil.easter import easter
@@ -84,13 +85,13 @@ class Norway(HolidayBase):
         # "(...) has been celebrated for over 1000 years (...)" (in Norway)
 
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-3)] = "Skjærtorsdag"
-        self[easter_date + timedelta(days=-2)] = "Langfredag"
+        self[easter_date + td(days=-3)] = "Skjærtorsdag"
+        self[easter_date + td(days=-2)] = "Langfredag"
         self[easter_date] = "Første påskedag"
-        self[easter_date + timedelta(days=+1)] = "Andre påskedag"
-        self[easter_date + timedelta(days=+39)] = "Kristi himmelfartsdag"
-        self[easter_date + timedelta(days=+49)] = "Første pinsedag"
-        self[easter_date + timedelta(days=+50)] = "Andre pinsedag"
+        self[easter_date + td(days=+1)] = "Andre påskedag"
+        self[easter_date + td(days=+39)] = "Kristi himmelfartsdag"
+        self[easter_date + td(days=+49)] = "Første pinsedag"
+        self[easter_date + td(days=+50)] = "Andre pinsedag"
 
 
 class NO(Norway):

--- a/holidays/countries/norway.py
+++ b/holidays/countries/norway.py
@@ -9,12 +9,11 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from dateutil import rrule
 from dateutil.easter import easter
 from dateutil.relativedelta import SU
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, DEC
 from holidays.holiday_base import HolidayBase
@@ -85,13 +84,13 @@ class Norway(HolidayBase):
         # "(...) has been celebrated for over 1000 years (...)" (in Norway)
 
         easter_date = easter(year)
-        self[easter_date + rd(days=-3)] = "Skjærtorsdag"
-        self[easter_date + rd(days=-2)] = "Langfredag"
+        self[easter_date + timedelta(days=-3)] = "Skjærtorsdag"
+        self[easter_date + timedelta(days=-2)] = "Langfredag"
         self[easter_date] = "Første påskedag"
-        self[easter_date + rd(days=+1)] = "Andre påskedag"
-        self[easter_date + rd(days=+39)] = "Kristi himmelfartsdag"
-        self[easter_date + rd(days=+49)] = "Første pinsedag"
-        self[easter_date + rd(days=+50)] = "Andre pinsedag"
+        self[easter_date + timedelta(days=+1)] = "Andre påskedag"
+        self[easter_date + timedelta(days=+39)] = "Kristi himmelfartsdag"
+        self[easter_date + timedelta(days=+49)] = "Første pinsedag"
+        self[easter_date + timedelta(days=+50)] = "Andre pinsedag"
 
 
 class NO(Norway):

--- a/holidays/countries/pakistan.py
+++ b/holidays/countries/pakistan.py
@@ -9,10 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 from typing import Dict, Tuple, List
-
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP
 from holidays.constants import OCT, NOV, DEC
@@ -80,8 +78,8 @@ class Pakistan(HolidayBase):
         hol_dates = self._get_islamic_holiday(name, year, 10, 1, dates_obs)
         for hol_date, hol_name in hol_dates:
             _add_holiday(hol_date, hol_name)
-            _add_holiday(hol_date + rd(days=+1), hol_name)
-            _add_holiday(hol_date + rd(days=+2), hol_name)
+            _add_holiday(hol_date + timedelta(days=+1), hol_name)
+            _add_holiday(hol_date + timedelta(days=+2), hol_name)
 
         # Eid-ul-Adha
         # https://www.timeanddate.com/holidays/pakistan/eid-ul-azha
@@ -112,8 +110,8 @@ class Pakistan(HolidayBase):
         hol_dates = self._get_islamic_holiday(name, year, 12, 10, dates_obs)
         for hol_date, hol_name in hol_dates:
             _add_holiday(hol_date, hol_name)
-            _add_holiday(hol_date + rd(days=+1), hol_name)
-            _add_holiday(hol_date + rd(days=+2), hol_name)
+            _add_holiday(hol_date + timedelta(days=+1), hol_name)
+            _add_holiday(hol_date + timedelta(days=+2), hol_name)
 
         # Eid Milad-un-Nabi, Birth of the Prophet
         # https://www.timeanddate.com/holidays/pakistan/eid-milad-un-nabi
@@ -171,7 +169,7 @@ class Pakistan(HolidayBase):
         hol_dates = self._get_islamic_holiday(name, year, 1, 10, dates_obs)
         for hol_date, hol_name in hol_dates:
             _add_holiday(hol_date, hol_name)
-            _add_holiday(hol_date + rd(days=+1), hol_name)
+            _add_holiday(hol_date + timedelta(days=+1), hol_name)
 
     @staticmethod
     def _get_islamic_holiday(

--- a/holidays/countries/pakistan.py
+++ b/holidays/countries/pakistan.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 from typing import Dict, Tuple, List
 
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP
@@ -78,8 +79,8 @@ class Pakistan(HolidayBase):
         hol_dates = self._get_islamic_holiday(name, year, 10, 1, dates_obs)
         for hol_date, hol_name in hol_dates:
             _add_holiday(hol_date, hol_name)
-            _add_holiday(hol_date + timedelta(days=+1), hol_name)
-            _add_holiday(hol_date + timedelta(days=+2), hol_name)
+            _add_holiday(hol_date + td(days=+1), hol_name)
+            _add_holiday(hol_date + td(days=+2), hol_name)
 
         # Eid-ul-Adha
         # https://www.timeanddate.com/holidays/pakistan/eid-ul-azha
@@ -110,8 +111,8 @@ class Pakistan(HolidayBase):
         hol_dates = self._get_islamic_holiday(name, year, 12, 10, dates_obs)
         for hol_date, hol_name in hol_dates:
             _add_holiday(hol_date, hol_name)
-            _add_holiday(hol_date + timedelta(days=+1), hol_name)
-            _add_holiday(hol_date + timedelta(days=+2), hol_name)
+            _add_holiday(hol_date + td(days=+1), hol_name)
+            _add_holiday(hol_date + td(days=+2), hol_name)
 
         # Eid Milad-un-Nabi, Birth of the Prophet
         # https://www.timeanddate.com/holidays/pakistan/eid-milad-un-nabi
@@ -169,7 +170,7 @@ class Pakistan(HolidayBase):
         hol_dates = self._get_islamic_holiday(name, year, 1, 10, dates_obs)
         for hol_date, hol_name in hol_dates:
             _add_holiday(hol_date, hol_name)
-            _add_holiday(hol_date + timedelta(days=+1), hol_name)
+            _add_holiday(hol_date + td(days=+1), hol_name)
 
     @staticmethod
     def _get_islamic_holiday(

--- a/holidays/countries/paraguay.py
+++ b/holidays/countries/paraguay.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -159,10 +160,8 @@ class Paraguay(HolidayBase):
 
         # Holy Week
         easter_date = easter(year)
-        self[
-            easter_date + timedelta(days=-3)
-        ] = "Jueves Santo [Maundy Thursday]"
-        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter_date + td(days=-3)] = "Jueves Santo [Maundy Thursday]"
+        self[easter_date + td(days=-2)] = "Viernes Santo [Good Friday]"
         self._add_holiday(easter_date, "Día de Pascuas [Easter Day]")
 
         # Labor Day

--- a/holidays/countries/paraguay.py
+++ b/holidays/countries/paraguay.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP
 from holidays.constants import OCT, DEC
@@ -160,8 +159,10 @@ class Paraguay(HolidayBase):
 
         # Holy Week
         easter_date = easter(year)
-        self[easter_date + rd(days=-3)] = "Jueves Santo [Maundy Thursday]"
-        self[easter_date + rd(days=-2)] = "Viernes Santo [Good Friday]"
+        self[
+            easter_date + timedelta(days=-3)
+        ] = "Jueves Santo [Maundy Thursday]"
+        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
         self._add_holiday(easter_date, "Día de Pascuas [Easter Day]")
 
         # Labor Day

--- a/holidays/countries/peru.py
+++ b/holidays/countries/peru.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -52,17 +53,13 @@ class Peru(HolidayBase):
 
         easter_date = easter(year)
         # Holy Thursday
-        self[
-            easter_date + timedelta(days=-3)
-        ] = "Jueves Santo [Maundy Thursday]"
+        self[easter_date + td(days=-3)] = "Jueves Santo [Maundy Thursday]"
 
         # Good Friday
-        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter_date + td(days=-2)] = "Viernes Santo [Good Friday]"
 
         # Holy Saturday
-        self[
-            easter_date + timedelta(days=-1)
-        ] = "Sábado de Gloria [Holy Saturday]"
+        self[easter_date + td(days=-1)] = "Sábado de Gloria [Holy Saturday]"
 
         # Easter Sunday
         self[easter_date] = "Domingo de Resurrección [Easter Sunday]"

--- a/holidays/countries/peru.py
+++ b/holidays/countries/peru.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUN, JUL, AUG, OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -53,13 +52,17 @@ class Peru(HolidayBase):
 
         easter_date = easter(year)
         # Holy Thursday
-        self[easter_date + rd(days=-3)] = "Jueves Santo [Maundy Thursday]"
+        self[
+            easter_date + timedelta(days=-3)
+        ] = "Jueves Santo [Maundy Thursday]"
 
         # Good Friday
-        self[easter_date + rd(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
 
         # Holy Saturday
-        self[easter_date + rd(days=-1)] = "Sábado de Gloria [Holy Saturday]"
+        self[
+            easter_date + timedelta(days=-1)
+        ] = "Sábado de Gloria [Holy Saturday]"
 
         # Easter Sunday
         self[easter_date] = "Domingo de Resurrección [Easter Sunday]"

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -51,11 +51,11 @@ class Philippines(HolidayBase):
 
         easter_date = easter(year)
         # Maundy Thursday.
-        self[easter_date + rd(days=-3)] = "Maundy Thursday"
+        self[easter_date + timedelta(days=-3)] = "Maundy Thursday"
         # Good Friday.
-        self[easter_date + rd(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
         # Black Saturday.
-        self[easter_date + rd(days=-1)] = "Black Saturday"
+        self[easter_date + timedelta(days=-1)] = "Black Saturday"
 
         # Labour Day.
         self[date(year, MAY, 1)] = "Labour Day"

--- a/holidays/countries/philippines.py
+++ b/holidays/countries/philippines.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -51,11 +52,11 @@ class Philippines(HolidayBase):
 
         easter_date = easter(year)
         # Maundy Thursday.
-        self[easter_date + timedelta(days=-3)] = "Maundy Thursday"
+        self[easter_date + td(days=-3)] = "Maundy Thursday"
         # Good Friday.
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-2)] = "Good Friday"
         # Black Saturday.
-        self[easter_date + timedelta(days=-1)] = "Black Saturday"
+        self[easter_date + td(days=-1)] = "Black Saturday"
 
         # Labour Day.
         self[date(year, MAY, 1)] = "Labour Day"

--- a/holidays/countries/poland.py
+++ b/holidays/countries/poland.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -36,15 +37,15 @@ class Poland(HolidayBase):
 
         easter_date = easter(year)
         self[easter_date] = "Niedziela Wielkanocna"
-        self[easter_date + timedelta(days=+1)] = "Poniedziałek Wielkanocny"
+        self[easter_date + td(days=+1)] = "Poniedziałek Wielkanocny"
 
         if year >= 1950:
             self[date(year, MAY, 1)] = "Święto Państwowe"
         if year >= 1919:
             self[date(year, MAY, 3)] = "Święto Narodowe Trzeciego Maja"
 
-        self[easter_date + timedelta(days=+49)] = "Zielone Świątki"
-        self[easter_date + timedelta(days=+60)] = "Dzień Bożego Ciała"
+        self[easter_date + td(days=+49)] = "Zielone Świątki"
+        self[easter_date + td(days=+60)] = "Dzień Bożego Ciała"
 
         self[date(year, AUG, 15)] = "Wniebowzięcie Najświętszej Marii Panny"
 

--- a/holidays/countries/poland.py
+++ b/holidays/countries/poland.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, AUG, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -37,15 +36,15 @@ class Poland(HolidayBase):
 
         easter_date = easter(year)
         self[easter_date] = "Niedziela Wielkanocna"
-        self[easter_date + rd(days=+1)] = "Poniedziałek Wielkanocny"
+        self[easter_date + timedelta(days=+1)] = "Poniedziałek Wielkanocny"
 
         if year >= 1950:
             self[date(year, MAY, 1)] = "Święto Państwowe"
         if year >= 1919:
             self[date(year, MAY, 3)] = "Święto Narodowe Trzeciego Maja"
 
-        self[easter_date + rd(days=+49)] = "Zielone Świątki"
-        self[easter_date + rd(days=+60)] = "Dzień Bożego Ciała"
+        self[easter_date + timedelta(days=+49)] = "Zielone Świątki"
+        self[easter_date + timedelta(days=+60)] = "Dzień Bożego Ciała"
 
         self[date(year, AUG, 15)] = "Wniebowzięcie Najświętszej Marii Panny"
 

--- a/holidays/countries/portugal.py
+++ b/holidays/countries/portugal.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAR, APR, MAY, JUN, JUL, AUG, SEP, OCT
 from holidays.constants import NOV, DEC
@@ -59,13 +58,13 @@ class Portugal(HolidayBase):
 
         # carnival is no longer a holiday, but some companies let workers off.
         # @todo recollect the years in which it was a public holiday
-        # self[e + rd(days=-47)] = "Carnaval"
-        self[easter_date + rd(days=-2)] = "Sexta-feira Santa"
+        # self[e + timedelta(days=-47)] = "Carnaval"
+        self[easter_date + timedelta(days=-2)] = "Sexta-feira Santa"
         self[easter_date] = "Páscoa"
 
         # Revoked holidays in 2013–2015
         if year < 2013 or year > 2015:
-            self[easter_date + rd(days=+60)] = "Corpo de Deus"
+            self[easter_date + timedelta(days=+60)] = "Corpo de Deus"
             self[date(year, OCT, 5)] = "Implantação da República"
             self[date(year, NOV, 1)] = "Dia de Todos os Santos"
             self[date(year, DEC, 1)] = "Restauração da Independência"
@@ -88,7 +87,7 @@ class Portugal(HolidayBase):
             - Lisbon's city holiday
             """
 
-            self[easter_date + rd(days=-47)] = "Carnaval"
+            self[easter_date + timedelta(days=-47)] = "Carnaval"
             self[date(year, DEC, 24)] = "Véspera de Natal"
             self[date(year, DEC, 26)] = "26 de Dezembro"
             self[date(year, DEC, 31)] = "Véspera de Ano Novo"
@@ -102,14 +101,16 @@ class Portugal(HolidayBase):
         if self.subdiv == "01":
             self[date(year, MAY, 12)] = "Dia de Santa Joana"
         if self.subdiv == "02":
-            self[easter_date + rd(days=+39)] = "Quinta-feira da Ascensão"
+            self[
+                easter_date + timedelta(days=+39)
+            ] = "Quinta-feira da Ascensão"
         if self.subdiv in {"03", "13"}:
             self[date(year, JUN, 24)] = "Dia de São João"
         if self.subdiv == "04":
             self[date(year, AUG, 22)] = "Dia de Nossa Senhora das Graças"
         if self.subdiv == "05":
             self[
-                easter_date + rd(days=+16)
+                easter_date + timedelta(days=+16)
             ] = "Dia de Nossa Senhora de Mércoles"
         if self.subdiv == "06":
             self[date(year, JUL, 4)] = "Dia de Santa Isabel"

--- a/holidays/countries/portugal.py
+++ b/holidays/countries/portugal.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -58,13 +59,13 @@ class Portugal(HolidayBase):
 
         # carnival is no longer a holiday, but some companies let workers off.
         # @todo recollect the years in which it was a public holiday
-        # self[e + timedelta(days=-47)] = "Carnaval"
-        self[easter_date + timedelta(days=-2)] = "Sexta-feira Santa"
+        # self[e + td(days=-47)] = "Carnaval"
+        self[easter_date + td(days=-2)] = "Sexta-feira Santa"
         self[easter_date] = "Páscoa"
 
         # Revoked holidays in 2013–2015
         if year < 2013 or year > 2015:
-            self[easter_date + timedelta(days=+60)] = "Corpo de Deus"
+            self[easter_date + td(days=+60)] = "Corpo de Deus"
             self[date(year, OCT, 5)] = "Implantação da República"
             self[date(year, NOV, 1)] = "Dia de Todos os Santos"
             self[date(year, DEC, 1)] = "Restauração da Independência"
@@ -87,7 +88,7 @@ class Portugal(HolidayBase):
             - Lisbon's city holiday
             """
 
-            self[easter_date + timedelta(days=-47)] = "Carnaval"
+            self[easter_date + td(days=-47)] = "Carnaval"
             self[date(year, DEC, 24)] = "Véspera de Natal"
             self[date(year, DEC, 26)] = "26 de Dezembro"
             self[date(year, DEC, 31)] = "Véspera de Ano Novo"
@@ -101,16 +102,14 @@ class Portugal(HolidayBase):
         if self.subdiv == "01":
             self[date(year, MAY, 12)] = "Dia de Santa Joana"
         if self.subdiv == "02":
-            self[
-                easter_date + timedelta(days=+39)
-            ] = "Quinta-feira da Ascensão"
+            self[easter_date + td(days=+39)] = "Quinta-feira da Ascensão"
         if self.subdiv in {"03", "13"}:
             self[date(year, JUN, 24)] = "Dia de São João"
         if self.subdiv == "04":
             self[date(year, AUG, 22)] = "Dia de Nossa Senhora das Graças"
         if self.subdiv == "05":
             self[
-                easter_date + timedelta(days=+16)
+                easter_date + td(days=+16)
             ] = "Dia de Nossa Senhora de Mércoles"
         if self.subdiv == "06":
             self[date(year, JUL, 4)] = "Dia de Santa Isabel"

--- a/holidays/countries/romania.py
+++ b/holidays/countries/romania.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUN, AUG, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -39,7 +38,7 @@ class Romania(HolidayBase):
 
         # Easter (Friday, Sunday and Monday)
         for day_after_easter in (-2, 0, 1):
-            self[easter_date + rd(days=day_after_easter)] = "Paștele"
+            self[easter_date + timedelta(days=day_after_easter)] = "Paștele"
 
         # Labour Day
         self[date(year, MAY, 1)] = "Ziua Muncii"
@@ -50,7 +49,7 @@ class Romania(HolidayBase):
 
         # Whit Monday
         for day_after_easter in (49, 50):
-            self[easter_date + rd(days=day_after_easter)] = "Rusaliile"
+            self[easter_date + timedelta(days=day_after_easter)] = "Rusaliile"
 
         # Assumption of Mary
         self[date(year, AUG, 15)] = "Adormirea Maicii Domnului"

--- a/holidays/countries/romania.py
+++ b/holidays/countries/romania.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -38,7 +39,7 @@ class Romania(HolidayBase):
 
         # Easter (Friday, Sunday and Monday)
         for day_after_easter in (-2, 0, 1):
-            self[easter_date + timedelta(days=day_after_easter)] = "Paștele"
+            self[easter_date + td(days=day_after_easter)] = "Paștele"
 
         # Labour Day
         self[date(year, MAY, 1)] = "Ziua Muncii"
@@ -49,7 +50,7 @@ class Romania(HolidayBase):
 
         # Whit Monday
         for day_after_easter in (49, 50):
-            self[easter_date + timedelta(days=day_after_easter)] = "Rusaliile"
+            self[easter_date + td(days=day_after_easter)] = "Rusaliile"
 
         # Assumption of Mary
         self[date(year, AUG, 15)] = "Adormirea Maicii Domnului"

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import FEB, SEP, THU, FRI, SAT
 from holidays.holiday_base import HolidayBase
@@ -67,20 +68,17 @@ class SaudiArabia(HolidayBase):
         holiday_name = "Eid al-Fitr Holiday"
         for yr in (year - 1, year):
             for hijri_date in _islamic_to_gre(yr, 9, 29):
-                hijri_date += timedelta(days=+1)
+                hijri_date += td(days=+1)
                 for dys in range(4):
-                    _add_holiday(
-                        (hijri_date + timedelta(days=dys)), holiday_name
-                    )
+                    _add_holiday((hijri_date + td(days=dys)), holiday_name)
                 if self.observed:
                     weekend_days = sum(
-                        (hijri_date + timedelta(days=dys)).weekday()
-                        in self.weekend
+                        (hijri_date + td(days=dys)).weekday() in self.weekend
                         for dys in range(4)
                     )
                     for dys in range(weekend_days):
                         _add_holiday(
-                            hijri_date + timedelta(days=4 + dys),
+                            hijri_date + td(days=4 + dys),
                             holiday_name + observed_str,
                         )
 
@@ -96,18 +94,15 @@ class SaudiArabia(HolidayBase):
             for hijri_date in _islamic_to_gre(yr, 12, 9):
                 _add_holiday(hijri_date, "Arafat Day Holiday")
                 for dys in range(1, 4):
-                    _add_holiday(
-                        (hijri_date + timedelta(days=dys)), holiday_name
-                    )
+                    _add_holiday((hijri_date + td(days=dys)), holiday_name)
                 if self.observed:
                     weekend_days = sum(
-                        (hijri_date + timedelta(days=dys)).weekday()
-                        in self.weekend
+                        (hijri_date + td(days=dys)).weekday() in self.weekend
                         for dys in range(4)
                     )
                     for dys in range(weekend_days):
                         _add_holiday(
-                            hijri_date + timedelta(days=4 + dys),
+                            hijri_date + td(days=4 + dys),
                             holiday_name + observed_str,
                         )
 
@@ -121,13 +116,13 @@ class SaudiArabia(HolidayBase):
                 self[national_day] = holiday_name
                 # First weekend day(Thursaday before 2013 and Friday otherwise)
                 if self.observed and national_day.weekday() == self.weekend[0]:
-                    national_day += timedelta(days=-1)
+                    national_day += td(days=-1)
                     self[national_day] = holiday_name + observed_str
                 # Second weekend day(Friday before 2013 and Saturday otherwise)
                 elif (
                     self.observed and national_day.weekday() == self.weekend[1]
                 ):
-                    national_day += timedelta(days=+1)
+                    national_day += td(days=+1)
                     self[national_day] = holiday_name + observed_str
 
         # Founding Day holiday (started 2022).
@@ -140,13 +135,13 @@ class SaudiArabia(HolidayBase):
                 self[founding_day] = holiday_name
                 # First weekend day(Thursaday before 2013 and Friday otherwise)
                 if self.observed and founding_day.weekday() == self.weekend[0]:
-                    founding_day += timedelta(days=-1)
+                    founding_day += td(days=-1)
                     self[founding_day] = holiday_name + observed_str
                 # Second weekend day(Friday before 2013 and Saturday otherwise)
                 elif (
                     self.observed and founding_day.weekday() == self.weekend[1]
                 ):
-                    founding_day += timedelta(days=+1)
+                    founding_day += td(days=+1)
                     self[founding_day] = holiday_name + observed_str
 
 

--- a/holidays/countries/saudi_arabia.py
+++ b/holidays/countries/saudi_arabia.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import FEB, SEP, THU, FRI, SAT
 from holidays.holiday_base import HolidayBase
@@ -69,17 +67,20 @@ class SaudiArabia(HolidayBase):
         holiday_name = "Eid al-Fitr Holiday"
         for yr in (year - 1, year):
             for hijri_date in _islamic_to_gre(yr, 9, 29):
-                hijri_date += rd(days=+1)
+                hijri_date += timedelta(days=+1)
                 for dys in range(4):
-                    _add_holiday((hijri_date + rd(days=dys)), holiday_name)
+                    _add_holiday(
+                        (hijri_date + timedelta(days=dys)), holiday_name
+                    )
                 if self.observed:
                     weekend_days = sum(
-                        (hijri_date + rd(days=dys)).weekday() in self.weekend
+                        (hijri_date + timedelta(days=dys)).weekday()
+                        in self.weekend
                         for dys in range(4)
                     )
                     for dys in range(weekend_days):
                         _add_holiday(
-                            hijri_date + rd(days=4 + dys),
+                            hijri_date + timedelta(days=4 + dys),
                             holiday_name + observed_str,
                         )
 
@@ -95,15 +96,18 @@ class SaudiArabia(HolidayBase):
             for hijri_date in _islamic_to_gre(yr, 12, 9):
                 _add_holiday(hijri_date, "Arafat Day Holiday")
                 for dys in range(1, 4):
-                    _add_holiday((hijri_date + rd(days=dys)), holiday_name)
+                    _add_holiday(
+                        (hijri_date + timedelta(days=dys)), holiday_name
+                    )
                 if self.observed:
                     weekend_days = sum(
-                        (hijri_date + rd(days=dys)).weekday() in self.weekend
+                        (hijri_date + timedelta(days=dys)).weekday()
+                        in self.weekend
                         for dys in range(4)
                     )
                     for dys in range(weekend_days):
                         _add_holiday(
-                            hijri_date + rd(days=4 + dys),
+                            hijri_date + timedelta(days=4 + dys),
                             holiday_name + observed_str,
                         )
 
@@ -117,13 +121,13 @@ class SaudiArabia(HolidayBase):
                 self[national_day] = holiday_name
                 # First weekend day(Thursaday before 2013 and Friday otherwise)
                 if self.observed and national_day.weekday() == self.weekend[0]:
-                    national_day += rd(days=-1)
+                    national_day += timedelta(days=-1)
                     self[national_day] = holiday_name + observed_str
                 # Second weekend day(Friday before 2013 and Saturday otherwise)
                 elif (
                     self.observed and national_day.weekday() == self.weekend[1]
                 ):
-                    national_day += rd(days=+1)
+                    national_day += timedelta(days=+1)
                     self[national_day] = holiday_name + observed_str
 
         # Founding Day holiday (started 2022).
@@ -136,13 +140,13 @@ class SaudiArabia(HolidayBase):
                 self[founding_day] = holiday_name
                 # First weekend day(Thursaday before 2013 and Friday otherwise)
                 if self.observed and founding_day.weekday() == self.weekend[0]:
-                    founding_day += rd(days=-1)
+                    founding_day += timedelta(days=-1)
                     self[founding_day] = holiday_name + observed_str
                 # Second weekend day(Friday before 2013 and Saturday otherwise)
                 elif (
                     self.observed and founding_day.weekday() == self.weekend[1]
                 ):
-                    founding_day += rd(days=+1)
+                    founding_day += timedelta(days=+1)
                     self[founding_day] = holiday_name + observed_str
 
 

--- a/holidays/countries/serbia.py
+++ b/holidays/countries/serbia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, MAY, NOV, SUN
 from holidays.holiday_base import HolidayBase
@@ -59,10 +58,10 @@ class Serbia(HolidayBase):
         if self.observed and date(year, NOV, 11).weekday() == SUN:
             self[date(year, NOV, 12)] = name + " (Observed)"
         # Easter
-        self[easter_date + rd(days=-2)] = "Велики петак"
-        self[easter_date + rd(days=-1)] = "Велика субота"
+        self[easter_date + timedelta(days=-2)] = "Велики петак"
+        self[easter_date + timedelta(days=-1)] = "Велика субота"
         self[easter_date] = "Васкрс"
-        self[easter_date + rd(days=+1)] = "Други дан Васкрса"
+        self[easter_date + timedelta(days=+1)] = "Други дан Васкрса"
 
 
 class RS(Serbia):

--- a/holidays/countries/serbia.py
+++ b/holidays/countries/serbia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -58,10 +59,10 @@ class Serbia(HolidayBase):
         if self.observed and date(year, NOV, 11).weekday() == SUN:
             self[date(year, NOV, 12)] = name + " (Observed)"
         # Easter
-        self[easter_date + timedelta(days=-2)] = "Велики петак"
-        self[easter_date + timedelta(days=-1)] = "Велика субота"
+        self[easter_date + td(days=-2)] = "Велики петак"
+        self[easter_date + td(days=-1)] = "Велика субота"
         self[easter_date] = "Васкрс"
-        self[easter_date + timedelta(days=+1)] = "Други дан Васкрса"
+        self[easter_date + td(days=+1)] = "Други дан Васкрса"
 
 
 class RS(Serbia):

--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 from typing import Dict, Iterable, Optional, Tuple, Union
 
 from dateutil.easter import easter
@@ -95,7 +96,7 @@ class Singapore(HolidayBase):
         # Chinese New Year (two days)
         hol_date = self.cnls.lunar_n_y_date(year)
         self[hol_date] = "Chinese New Year"
-        self[hol_date + timedelta(days=+1)] = "Chinese New Year"
+        self[hol_date + td(days=+1)] = "Chinese New Year"
 
         # Hari Raya Puasa
         # aka Eid al-Fitr
@@ -139,7 +140,7 @@ class Singapore(HolidayBase):
                 # Second day of Hari Raya Puasa (up to and including 1968)
                 if year <= 1968:
                     _add_holiday(
-                        hol_date + timedelta(days=+1),
+                        hol_date + td(days=+1),
                         "Second day of Hari Raya Puasa* (*estimated)",
                     )
 
@@ -182,14 +183,14 @@ class Singapore(HolidayBase):
 
         easter_date = easter(year)
         # Good Friday
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-2)] = "Good Friday"
 
         if year <= 1968:
             # Holy Saturday
-            self[easter_date + timedelta(days=-1)] = "Holy Saturday"
+            self[easter_date + td(days=-1)] = "Holy Saturday"
 
             # Easter Monday
-            self[easter_date + timedelta(days=+1)] = "Easter Monday"
+            self[easter_date + td(days=+1)] = "Easter Monday"
 
         # Labour Day
         self[date(year, MAY, 1)] = "Labour Day"
@@ -283,9 +284,9 @@ class Singapore(HolidayBase):
         if self.observed and year >= 1998:
             for (hol_date, hol_name) in list(self.items()):
                 if hol_date.year == year and hol_date.weekday() == SUN:
-                    in_lieu_date = hol_date + timedelta(days=+1)
+                    in_lieu_date = hol_date + td(days=+1)
                     while in_lieu_date.year == year and in_lieu_date in self:
-                        in_lieu_date += timedelta(days=+1)
+                        in_lieu_date += td(days=+1)
                     _add_holiday(in_lieu_date, f"{hol_name} (Observed)")
 
         # special case (observed from previuos year)

--- a/holidays/countries/singapore.py
+++ b/holidays/countries/singapore.py
@@ -9,11 +9,10 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 from typing import Dict, Iterable, Optional, Tuple, Union
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, SEP, AUG
 from holidays.constants import OCT, NOV, DEC, SUN
@@ -96,7 +95,7 @@ class Singapore(HolidayBase):
         # Chinese New Year (two days)
         hol_date = self.cnls.lunar_n_y_date(year)
         self[hol_date] = "Chinese New Year"
-        self[hol_date + rd(days=+1)] = "Chinese New Year"
+        self[hol_date + timedelta(days=+1)] = "Chinese New Year"
 
         # Hari Raya Puasa
         # aka Eid al-Fitr
@@ -140,7 +139,7 @@ class Singapore(HolidayBase):
                 # Second day of Hari Raya Puasa (up to and including 1968)
                 if year <= 1968:
                     _add_holiday(
-                        hol_date + rd(days=+1),
+                        hol_date + timedelta(days=+1),
                         "Second day of Hari Raya Puasa* (*estimated)",
                     )
 
@@ -183,14 +182,14 @@ class Singapore(HolidayBase):
 
         easter_date = easter(year)
         # Good Friday
-        self[easter_date + rd(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
 
         if year <= 1968:
             # Holy Saturday
-            self[easter_date + rd(days=-1)] = "Holy Saturday"
+            self[easter_date + timedelta(days=-1)] = "Holy Saturday"
 
             # Easter Monday
-            self[easter_date + rd(days=+1)] = "Easter Monday"
+            self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
         # Labour Day
         self[date(year, MAY, 1)] = "Labour Day"
@@ -284,9 +283,9 @@ class Singapore(HolidayBase):
         if self.observed and year >= 1998:
             for (hol_date, hol_name) in list(self.items()):
                 if hol_date.year == year and hol_date.weekday() == SUN:
-                    in_lieu_date = hol_date + rd(days=+1)
+                    in_lieu_date = hol_date + timedelta(days=+1)
                     while in_lieu_date.year == year and in_lieu_date in self:
-                        in_lieu_date += rd(days=+1)
+                        in_lieu_date += timedelta(days=+1)
                     _add_holiday(in_lieu_date, f"{hol_name} (Observed)")
 
         # special case (observed from previuos year)

--- a/holidays/countries/slovakia.py
+++ b/holidays/countries/slovakia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, MAY, JUL, AUG, SEP, OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -42,8 +41,8 @@ class Slovakia(HolidayBase):
         )
 
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Veľký piatok"
-        self[easter_date + rd(days=+1)] = "Veľkonočný pondelok"
+        self[easter_date + timedelta(days=-2)] = "Veľký piatok"
+        self[easter_date + timedelta(days=+1)] = "Veľkonočný pondelok"
 
         self[date(year, MAY, 1)] = "Sviatok práce"
 

--- a/holidays/countries/slovakia.py
+++ b/holidays/countries/slovakia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -41,8 +42,8 @@ class Slovakia(HolidayBase):
         )
 
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Veľký piatok"
-        self[easter_date + timedelta(days=+1)] = "Veľkonočný pondelok"
+        self[easter_date + td(days=-2)] = "Veľký piatok"
+        self[easter_date + td(days=+1)] = "Veľkonočný pondelok"
 
         self[date(year, MAY, 1)] = "Sviatok práce"
 

--- a/holidays/countries/slovenia.py
+++ b/holidays/countries/slovenia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -47,7 +48,7 @@ class Slovenia(HolidayBase):
         self[date(year, FEB, 8)] = "Prešernov dan"
 
         # Easter monday is the only easter related work-free day
-        self[easter(year) + timedelta(days=+1)] = "Velikonočni ponedeljek"
+        self[easter(year) + td(days=+1)] = "Velikonočni ponedeljek"
 
         # Day of uprising against occupation
         self[date(year, APR, 27)] = "dan upora proti okupatorju"

--- a/holidays/countries/slovenia.py
+++ b/holidays/countries/slovenia.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, APR, MAY, JUN, AUG, OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
@@ -48,7 +47,7 @@ class Slovenia(HolidayBase):
         self[date(year, FEB, 8)] = "Prešernov dan"
 
         # Easter monday is the only easter related work-free day
-        self[easter(year) + rd(days=+1)] = "Velikonočni ponedeljek"
+        self[easter(year) + timedelta(days=+1)] = "Velikonočni ponedeljek"
 
         # Day of uprising against occupation
         self[date(year, APR, 27)] = "dan upora proti okupatorju"

--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, FR
@@ -60,12 +61,12 @@ class SouthAfrica(HolidayBase):
         self[date(year, JAN, 1)] = "New Year's Day"
 
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-2)] = "Good Friday"
         if year >= 1980:
             name = "Family Day"
         else:
             name = "Easter Monday"
-        self[easter_date + timedelta(days=+1)] = name
+        self[easter_date + td(days=+1)] = name
 
         if year <= 1951:
             name = "Dingaan's Day"
@@ -100,7 +101,7 @@ class SouthAfrica(HolidayBase):
             for k, v in list(self.items()):
                 if k.weekday() != SUN or k.year != year:
                     continue
-                dt = k + timedelta(days=+1)
+                dt = k + td(days=+1)
                 if dt in self:
                     continue
                 self[dt] = v + " (Observed)"
@@ -116,7 +117,7 @@ class SouthAfrica(HolidayBase):
             self[(date(year, MAY, 1) + rd(weekday=FR))] = "Workers' Day"
 
         if year <= 1993:
-            self[easter_date + timedelta(days=+40)] = "Ascension Day"
+            self[easter_date + td(days=+40)] = "Ascension Day"
 
         if year <= 1951:
             self[date(year, MAY, 24)] = "Empire Day"

--- a/holidays/countries/south_africa.py
+++ b/holidays/countries/south_africa.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, FR
@@ -60,12 +60,12 @@ class SouthAfrica(HolidayBase):
         self[date(year, JAN, 1)] = "New Year's Day"
 
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
         if year >= 1980:
             name = "Family Day"
         else:
             name = "Easter Monday"
-        self[easter_date + rd(days=+1)] = name
+        self[easter_date + timedelta(days=+1)] = name
 
         if year <= 1951:
             name = "Dingaan's Day"
@@ -100,7 +100,7 @@ class SouthAfrica(HolidayBase):
             for k, v in list(self.items()):
                 if k.weekday() != SUN or k.year != year:
                     continue
-                dt = k + rd(days=+1)
+                dt = k + timedelta(days=+1)
                 if dt in self:
                     continue
                 self[dt] = v + " (Observed)"
@@ -116,7 +116,7 @@ class SouthAfrica(HolidayBase):
             self[(date(year, MAY, 1) + rd(weekday=FR))] = "Workers' Day"
 
         if year <= 1993:
-            self[easter_date + rd(days=+40)] = "Ascension Day"
+            self[easter_date + timedelta(days=+40)] = "Ascension Day"
 
         if year <= 1951:
             self[date(year, MAY, 24)] = "Empire Day"

--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -11,10 +11,8 @@
 
 
 import warnings
-from datetime import date
+from datetime import date, timedelta
 from typing import Tuple
-
-from dateutil.relativedelta import relativedelta as rd
 
 # Installation: pip install korean_lunar_calendar
 # URL: https://github.com/usingsky/korean_lunar_calendar_py/
@@ -68,9 +66,9 @@ class SouthKorea(HolidayBase):
         dt = self.get_solar_date(year, 1, 1)
         new_year_date = date(dt.year, dt.month, dt.day)
 
-        self[new_year_date + rd(days=-1)] = preceding_day_lunar
+        self[new_year_date + timedelta(days=-1)] = preceding_day_lunar
         self[new_year_date] = name
-        self[new_year_date + rd(days=+1)] = second_day_lunar
+        self[new_year_date + timedelta(days=+1)] = second_day_lunar
 
         if self.observed and year >= 2015:
             for cur_rd, cur_name in [
@@ -78,7 +76,7 @@ class SouthKorea(HolidayBase):
                 (0, name),
                 (+1, second_day_lunar),
             ]:
-                target_date = new_year_date + rd(days=cur_rd)
+                target_date = new_year_date + timedelta(days=cur_rd)
                 is_alt, alt_date = self.get_next_first_non_holiday(
                     cur_name, target_date
                 )
@@ -168,9 +166,9 @@ class SouthKorea(HolidayBase):
         dt = self.get_solar_date(year, 8, 15)
         chuseok_date = date(dt.year, dt.month, dt.day)
 
-        self[chuseok_date + rd(days=-1)] = preceding_day_chuseok
+        self[chuseok_date + timedelta(days=-1)] = preceding_day_chuseok
         self[chuseok_date] = name
-        self[chuseok_date + rd(days=+1)] = second_day_chuseok
+        self[chuseok_date + timedelta(days=+1)] = second_day_chuseok
 
         if self.observed and year >= 2014:
             for cur_rd, cur_name in [
@@ -178,7 +176,7 @@ class SouthKorea(HolidayBase):
                 (0, name),
                 (+1, second_day_chuseok),
             ]:
-                target_date = chuseok_date + rd(days=cur_rd)
+                target_date = chuseok_date + timedelta(days=cur_rd)
                 is_alt, alt_date = self.get_next_first_non_holiday(
                     cur_name, target_date
                 )
@@ -269,7 +267,7 @@ class SouthKorea(HolidayBase):
             cur in self and name != self[cur]
         )  # Exclude if already a holiday
         while check_1 or check_2:
-            cur += rd(days=+1)
+            cur += timedelta(days=+1)
             check_1 = cur.weekday() in target_weekday
             check_2 = cur in self and name != self[cur]
 

--- a/holidays/countries/south_korea.py
+++ b/holidays/countries/south_korea.py
@@ -11,7 +11,8 @@
 
 
 import warnings
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 from typing import Tuple
 
 # Installation: pip install korean_lunar_calendar
@@ -66,9 +67,9 @@ class SouthKorea(HolidayBase):
         dt = self.get_solar_date(year, 1, 1)
         new_year_date = date(dt.year, dt.month, dt.day)
 
-        self[new_year_date + timedelta(days=-1)] = preceding_day_lunar
+        self[new_year_date + td(days=-1)] = preceding_day_lunar
         self[new_year_date] = name
-        self[new_year_date + timedelta(days=+1)] = second_day_lunar
+        self[new_year_date + td(days=+1)] = second_day_lunar
 
         if self.observed and year >= 2015:
             for cur_rd, cur_name in [
@@ -76,7 +77,7 @@ class SouthKorea(HolidayBase):
                 (0, name),
                 (+1, second_day_lunar),
             ]:
-                target_date = new_year_date + timedelta(days=cur_rd)
+                target_date = new_year_date + td(days=cur_rd)
                 is_alt, alt_date = self.get_next_first_non_holiday(
                     cur_name, target_date
                 )
@@ -166,9 +167,9 @@ class SouthKorea(HolidayBase):
         dt = self.get_solar_date(year, 8, 15)
         chuseok_date = date(dt.year, dt.month, dt.day)
 
-        self[chuseok_date + timedelta(days=-1)] = preceding_day_chuseok
+        self[chuseok_date + td(days=-1)] = preceding_day_chuseok
         self[chuseok_date] = name
-        self[chuseok_date + timedelta(days=+1)] = second_day_chuseok
+        self[chuseok_date + td(days=+1)] = second_day_chuseok
 
         if self.observed and year >= 2014:
             for cur_rd, cur_name in [
@@ -176,7 +177,7 @@ class SouthKorea(HolidayBase):
                 (0, name),
                 (+1, second_day_chuseok),
             ]:
-                target_date = chuseok_date + timedelta(days=cur_rd)
+                target_date = chuseok_date + td(days=cur_rd)
                 is_alt, alt_date = self.get_next_first_non_holiday(
                     cur_name, target_date
                 )
@@ -267,7 +268,7 @@ class SouthKorea(HolidayBase):
             cur in self and name != self[cur]
         )  # Exclude if already a holiday
         while check_1 or check_2:
-            cur += timedelta(days=+1)
+            cur += td(days=+1)
             check_1 = cur.weekday() in target_weekday
             check_2 = cur in self and name != self[cur]
 

--- a/holidays/countries/spain.py
+++ b/holidays/countries/spain.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -45,9 +46,7 @@ class Spain(HolidayBase):
 
     def _is_observed(self, date_holiday, name_holiday):
         if self.observed and date_holiday.weekday() == SUN:
-            self[date_holiday + timedelta(days=+1)] = (
-                name_holiday + " (Trasladado)"
-            )
+            self[date_holiday + td(days=+1)] = name_holiday + " (Trasladado)"
         else:
             self[date_holiday] = name_holiday
 
@@ -107,16 +106,16 @@ class Spain(HolidayBase):
         elif year >= 2022 and self.subdiv and self.subdiv == "VC":
             self._is_observed(date(year, MAR, 19), "San José")
         if year != 2022 and self.subdiv not in {"CT", "VC"}:
-            self[easter_date + timedelta(days=-3)] = "Jueves Santo"
+            self[easter_date + td(days=-3)] = "Jueves Santo"
         elif year == 2022 and self.subdiv and self.subdiv not in {"CT"}:
-            self[easter_date + timedelta(days=-3)] = "Jueves Santo"
-        self[easter_date + timedelta(days=-2)] = "Viernes Santo"
+            self[easter_date + td(days=-3)] = "Jueves Santo"
+        self[easter_date + td(days=-2)] = "Viernes Santo"
         if (
             2022 == year
             and self.subdiv
             and self.subdiv in {"CT", "IB", "NC", "PV", "RI", "VC"}
         ):
-            self[easter_date + timedelta(days=+1)] = "Lunes de Pascua"
+            self[easter_date + td(days=+1)] = "Lunes de Pascua"
         elif 2022 > year and self.subdiv in {
             "CM",
             "CT",
@@ -125,7 +124,7 @@ class Spain(HolidayBase):
             "PV",
             "VC",
         }:
-            self[easter(year) + timedelta(days=+1)] = "Lunes de Pascua"
+            self[easter(year) + td(days=+1)] = "Lunes de Pascua"
 
         if 2022 != year:
             self._is_observed(date(year, MAY, 1), "Día del Trabajador")
@@ -211,11 +210,11 @@ class Spain(HolidayBase):
             self._is_observed(date(year, SEP, 17), "Día de Melilla")
             if year == 2022:
                 self._is_observed(
-                    _islamic_to_gre(year, 10, 1)[0] + timedelta(days=+1),
+                    _islamic_to_gre(year, 10, 1)[0] + td(days=+1),
                     "Aid Al-Fitr",
                 )
                 self._is_observed(
-                    _islamic_to_gre(year, 12, 10)[0] + timedelta(days=+2),
+                    _islamic_to_gre(year, 12, 10)[0] + td(days=+2),
                     "Aid Al-Adha",
                 )
             else:

--- a/holidays/countries/spain.py
+++ b/holidays/countries/spain.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP
 from holidays.constants import OCT, NOV, DEC, SUN
@@ -46,7 +45,9 @@ class Spain(HolidayBase):
 
     def _is_observed(self, date_holiday, name_holiday):
         if self.observed and date_holiday.weekday() == SUN:
-            self[date_holiday + rd(days=+1)] = name_holiday + " (Trasladado)"
+            self[date_holiday + timedelta(days=+1)] = (
+                name_holiday + " (Trasladado)"
+            )
         else:
             self[date_holiday] = name_holiday
 
@@ -106,16 +107,16 @@ class Spain(HolidayBase):
         elif year >= 2022 and self.subdiv and self.subdiv == "VC":
             self._is_observed(date(year, MAR, 19), "San José")
         if year != 2022 and self.subdiv not in {"CT", "VC"}:
-            self[easter_date + rd(days=-3)] = "Jueves Santo"
+            self[easter_date + timedelta(days=-3)] = "Jueves Santo"
         elif year == 2022 and self.subdiv and self.subdiv not in {"CT"}:
-            self[easter_date + rd(days=-3)] = "Jueves Santo"
-        self[easter_date + rd(days=-2)] = "Viernes Santo"
+            self[easter_date + timedelta(days=-3)] = "Jueves Santo"
+        self[easter_date + timedelta(days=-2)] = "Viernes Santo"
         if (
             2022 == year
             and self.subdiv
             and self.subdiv in {"CT", "IB", "NC", "PV", "RI", "VC"}
         ):
-            self[easter_date + rd(days=+1)] = "Lunes de Pascua"
+            self[easter_date + timedelta(days=+1)] = "Lunes de Pascua"
         elif 2022 > year and self.subdiv in {
             "CM",
             "CT",
@@ -124,7 +125,7 @@ class Spain(HolidayBase):
             "PV",
             "VC",
         }:
-            self[easter(year) + rd(days=+1)] = "Lunes de Pascua"
+            self[easter(year) + timedelta(days=+1)] = "Lunes de Pascua"
 
         if 2022 != year:
             self._is_observed(date(year, MAY, 1), "Día del Trabajador")
@@ -210,11 +211,11 @@ class Spain(HolidayBase):
             self._is_observed(date(year, SEP, 17), "Día de Melilla")
             if year == 2022:
                 self._is_observed(
-                    _islamic_to_gre(year, 10, 1)[0] + rd(days=+1),
+                    _islamic_to_gre(year, 10, 1)[0] + timedelta(days=+1),
                     "Aid Al-Fitr",
                 )
                 self._is_observed(
-                    _islamic_to_gre(year, 12, 10)[0] + rd(days=+2),
+                    _islamic_to_gre(year, 12, 10)[0] + timedelta(days=+2),
                     "Aid Al-Adha",
                 )
             else:

--- a/holidays/countries/sweden.py
+++ b/holidays/countries/sweden.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from dateutil import rrule
 from dateutil.easter import easter
@@ -79,13 +79,13 @@ class Sweden(HolidayBase):
 
         # ========= Moving holidays =========
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Långfredagen"
+        self[easter_date + timedelta(days=-2)] = "Långfredagen"
         self[easter_date] = "Påskdagen"
-        self[easter_date + rd(days=+1)] = "Annandag påsk"
-        self[easter_date + rd(days=+39)] = "Kristi himmelsfärdsdag"
-        self[easter_date + rd(days=+49)] = "Pingstdagen"
+        self[easter_date + timedelta(days=+1)] = "Annandag påsk"
+        self[easter_date + timedelta(days=+39)] = "Kristi himmelsfärdsdag"
+        self[easter_date + timedelta(days=+49)] = "Pingstdagen"
         if year <= 2004:
-            self[easter_date + rd(days=+50)] = "Annandag pingst"
+            self[easter_date + timedelta(days=+50)] = "Annandag pingst"
 
         # Source:
         # https://sv.wikipedia.org/wiki/Midsommarafton

--- a/holidays/countries/sweden.py
+++ b/holidays/countries/sweden.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
+from datetime import timedelta as td
 
 from dateutil import rrule
 from dateutil.easter import easter
@@ -79,13 +80,13 @@ class Sweden(HolidayBase):
 
         # ========= Moving holidays =========
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Långfredagen"
+        self[easter_date + td(days=-2)] = "Långfredagen"
         self[easter_date] = "Påskdagen"
-        self[easter_date + timedelta(days=+1)] = "Annandag påsk"
-        self[easter_date + timedelta(days=+39)] = "Kristi himmelsfärdsdag"
-        self[easter_date + timedelta(days=+49)] = "Pingstdagen"
+        self[easter_date + td(days=+1)] = "Annandag påsk"
+        self[easter_date + td(days=+39)] = "Kristi himmelsfärdsdag"
+        self[easter_date + td(days=+49)] = "Pingstdagen"
         if year <= 2004:
-            self[easter_date + timedelta(days=+50)] = "Annandag pingst"
+            self[easter_date + td(days=+50)] = "Annandag pingst"
 
         # Source:
         # https://sv.wikipedia.org/wiki/Midsommarafton

--- a/holidays/countries/switzerland.py
+++ b/holidays/countries/switzerland.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import TH, SU
@@ -88,8 +89,8 @@ class Switzerland(HolidayBase):
         # Näfelser Fahrt (first Thursday in April but not in Holy Week)
         if self.subdiv == "GL" and year >= 1835:
             dt = date(year, APR, 1) + rd(weekday=TH)
-            if dt == easter_date + timedelta(days=-3):
-                dt += timedelta(days=+7)
+            if dt == easter_date + td(days=-3):
+                dt += td(days=+7)
             self[dt] = "Näfelser Fahrt"
 
         # it's a Holiday on a Sunday
@@ -97,8 +98,8 @@ class Switzerland(HolidayBase):
 
         # VS don't have easter
         if self.subdiv != "VS":
-            self[easter_date + timedelta(days=-2)] = "Karfreitag"
-            self[easter_date + timedelta(days=+1)] = "Ostermontag"
+            self[easter_date + td(days=-2)] = "Karfreitag"
+            self[easter_date + td(days=+1)] = "Ostermontag"
 
         if self.subdiv in {
             "BL",
@@ -113,12 +114,12 @@ class Switzerland(HolidayBase):
         }:
             self[date(year, MAY, 1)] = "Tag der Arbeit"
 
-        self[easter_date + timedelta(days=+39)] = "Auffahrt"
+        self[easter_date + td(days=+39)] = "Auffahrt"
 
         # it's a Holiday on a Sunday
-        self[easter_date + timedelta(days=+49)] = "Pfingsten"
+        self[easter_date + td(days=+49)] = "Pfingsten"
 
-        self[easter_date + timedelta(days=+50)] = "Pfingstmontag"
+        self[easter_date + td(days=+50)] = "Pfingstmontag"
 
         if self.subdiv in {
             "AI",
@@ -132,7 +133,7 @@ class Switzerland(HolidayBase):
             "VS",
             "ZG",
         }:
-            self[easter_date + timedelta(days=+60)] = "Fronleichnam"
+            self[easter_date + td(days=+60)] = "Fronleichnam"
 
         if self.subdiv == "JU":
             self[date(year, JUN, 23)] = "Fest der Unabhängigkeit"
@@ -159,12 +160,12 @@ class Switzerland(HolidayBase):
 
         if self.subdiv == "VD":
             # Monday after the third Sunday of September
-            dt = date(year, SEP, 1) + rd(weekday=SU(+3)) + timedelta(days=+1)
+            dt = date(year, SEP, 1) + rd(weekday=SU(+3)) + td(days=+1)
             self[dt] = "Lundi du Jeûne"
 
         if self.subdiv == "GE":
             # Thursday after the first Sunday of September
-            dt = date(year, SEP, 1) + rd(weekday=SU) + timedelta(days=+4)
+            dt = date(year, SEP, 1) + rd(weekday=SU) + td(days=+4)
             self[dt] = "Jeûne genevois"
 
         if self.subdiv == "OW":

--- a/holidays/countries/switzerland.py
+++ b/holidays/countries/switzerland.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import TH, SU
@@ -88,8 +88,8 @@ class Switzerland(HolidayBase):
         # Näfelser Fahrt (first Thursday in April but not in Holy Week)
         if self.subdiv == "GL" and year >= 1835:
             dt = date(year, APR, 1) + rd(weekday=TH)
-            if dt == easter_date + rd(days=-3):
-                dt += rd(days=+7)
+            if dt == easter_date + timedelta(days=-3):
+                dt += timedelta(days=+7)
             self[dt] = "Näfelser Fahrt"
 
         # it's a Holiday on a Sunday
@@ -97,8 +97,8 @@ class Switzerland(HolidayBase):
 
         # VS don't have easter
         if self.subdiv != "VS":
-            self[easter_date + rd(days=-2)] = "Karfreitag"
-            self[easter_date + rd(days=+1)] = "Ostermontag"
+            self[easter_date + timedelta(days=-2)] = "Karfreitag"
+            self[easter_date + timedelta(days=+1)] = "Ostermontag"
 
         if self.subdiv in {
             "BL",
@@ -113,12 +113,12 @@ class Switzerland(HolidayBase):
         }:
             self[date(year, MAY, 1)] = "Tag der Arbeit"
 
-        self[easter_date + rd(days=+39)] = "Auffahrt"
+        self[easter_date + timedelta(days=+39)] = "Auffahrt"
 
         # it's a Holiday on a Sunday
-        self[easter_date + rd(days=+49)] = "Pfingsten"
+        self[easter_date + timedelta(days=+49)] = "Pfingsten"
 
-        self[easter_date + rd(days=+50)] = "Pfingstmontag"
+        self[easter_date + timedelta(days=+50)] = "Pfingstmontag"
 
         if self.subdiv in {
             "AI",
@@ -132,7 +132,7 @@ class Switzerland(HolidayBase):
             "VS",
             "ZG",
         }:
-            self[easter_date + rd(days=+60)] = "Fronleichnam"
+            self[easter_date + timedelta(days=+60)] = "Fronleichnam"
 
         if self.subdiv == "JU":
             self[date(year, JUN, 23)] = "Fest der Unabhängigkeit"
@@ -159,12 +159,12 @@ class Switzerland(HolidayBase):
 
         if self.subdiv == "VD":
             # Monday after the third Sunday of September
-            dt = date(year, SEP, 1) + rd(weekday=SU(+3)) + rd(days=+1)
+            dt = date(year, SEP, 1) + rd(weekday=SU(+3)) + timedelta(days=+1)
             self[dt] = "Lundi du Jeûne"
 
         if self.subdiv == "GE":
             # Thursday after the first Sunday of September
-            dt = date(year, SEP, 1) + rd(weekday=SU) + rd(days=+4)
+            dt = date(year, SEP, 1) + rd(weekday=SU) + timedelta(days=+4)
             self[dt] = "Jeûne genevois"
 
         if self.subdiv == "OW":

--- a/holidays/countries/taiwan.py
+++ b/holidays/countries/taiwan.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import JAN, FEB, APR, OCT
 from holidays.holiday_base import HolidayBase
@@ -36,10 +37,10 @@ class Taiwan(HolidayBase):
                 date(year, JAN, 1)
             ] = "Founding of the Republic of China (New Year's Day)"
             hol_date = self.cnls.lunar_n_y_date(year)
-            self[hol_date + timedelta(days=-1)] = "Chinese New Year's Eve"
+            self[hol_date + td(days=-1)] = "Chinese New Year's Eve"
             self[hol_date] = "Spring Festival"
-            self[hol_date + timedelta(days=+1)] = "Spring Festival"
-            self[hol_date + timedelta(days=+2)] = "Spring Festival"
+            self[hol_date + td(days=+1)] = "Spring Festival"
+            self[hol_date + td(days=+2)] = "Spring Festival"
             self[date(year, APR, 4)] = "Children's Day"
             self[self.cnls.lunar_to_gre(year, 5, 5)] = "Dragon Boat Festival"
             self[self.cnls.lunar_to_gre(year, 8, 15)] = "Mid-Autumn Festival"
@@ -49,8 +50,8 @@ class Taiwan(HolidayBase):
             self[date(year, FEB, 28)] = "Peace Memorial Day"
         if year == 2021:
             hol_date = self.cnls.lunar_n_y_date(year)
-            self[hol_date + timedelta(days=+3)] = "Spring Festival"
-            self[hol_date + timedelta(days=+4)] = "Spring Festival"
+            self[hol_date + td(days=+3)] = "Spring Festival"
+            self[hol_date + td(days=+4)] = "Spring Festival"
 
 
 class TW(Taiwan):

--- a/holidays/countries/taiwan.py
+++ b/holidays/countries/taiwan.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import JAN, FEB, APR, OCT
 from holidays.holiday_base import HolidayBase
@@ -38,10 +36,10 @@ class Taiwan(HolidayBase):
                 date(year, JAN, 1)
             ] = "Founding of the Republic of China (New Year's Day)"
             hol_date = self.cnls.lunar_n_y_date(year)
-            self[hol_date + rd(days=-1)] = "Chinese New Year's Eve"
+            self[hol_date + timedelta(days=-1)] = "Chinese New Year's Eve"
             self[hol_date] = "Spring Festival"
-            self[hol_date + rd(days=+1)] = "Spring Festival"
-            self[hol_date + rd(days=+2)] = "Spring Festival"
+            self[hol_date + timedelta(days=+1)] = "Spring Festival"
+            self[hol_date + timedelta(days=+2)] = "Spring Festival"
             self[date(year, APR, 4)] = "Children's Day"
             self[self.cnls.lunar_to_gre(year, 5, 5)] = "Dragon Boat Festival"
             self[self.cnls.lunar_to_gre(year, 8, 15)] = "Mid-Autumn Festival"
@@ -51,8 +49,8 @@ class Taiwan(HolidayBase):
             self[date(year, FEB, 28)] = "Peace Memorial Day"
         if year == 2021:
             hol_date = self.cnls.lunar_n_y_date(year)
-            self[hol_date + rd(days=+3)] = "Spring Festival"
-            self[hol_date + rd(days=+4)] = "Spring Festival"
+            self[hol_date + timedelta(days=+3)] = "Spring Festival"
+            self[hol_date + timedelta(days=+4)] = "Spring Festival"
 
 
 class TW(Taiwan):

--- a/holidays/countries/thailand.py
+++ b/holidays/countries/thailand.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import FEB, MAR, APR, MAY, JUN, JUL, AUG, OCT, DEC, SAT
 from holidays.holiday_base import HolidayBase
@@ -39,9 +37,9 @@ class Thailand(HolidayBase):
 
             self[dt] = holiday_name
             if self.observed and self._is_weekend(dt):
-                in_lieu = dt + rd(days=2 if dt.weekday() == SAT else 1)
+                in_lieu = dt + timedelta(days=2 if dt.weekday() == SAT else 1)
                 while in_lieu.year == year and in_lieu in self:
-                    in_lieu += rd(days=+1)
+                    in_lieu += timedelta(days=+1)
 
                 add_holiday(in_lieu, f"{holiday_name} (in lieu)")
 

--- a/holidays/countries/thailand.py
+++ b/holidays/countries/thailand.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import FEB, MAR, APR, MAY, JUN, JUL, AUG, OCT, DEC, SAT
 from holidays.holiday_base import HolidayBase
@@ -37,9 +38,9 @@ class Thailand(HolidayBase):
 
             self[dt] = holiday_name
             if self.observed and self._is_weekend(dt):
-                in_lieu = dt + timedelta(days=2 if dt.weekday() == SAT else 1)
+                in_lieu = dt + td(days=2 if dt.weekday() == SAT else 1)
                 while in_lieu.year == year and in_lieu in self:
-                    in_lieu += timedelta(days=+1)
+                    in_lieu += td(days=+1)
 
                 add_holiday(in_lieu, f"{holiday_name} (in lieu)")
 

--- a/holidays/countries/tunisia.py
+++ b/holidays/countries/tunisia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import JAN, MAR, APR, MAY, JUL, AUG, OCT
 from holidays.holiday_base import HolidayBase
@@ -76,12 +77,8 @@ class Tunisia(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 10, 1):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid al-Fitr")
-                _add_holiday(
-                    hol_date + timedelta(days=+1), "Eid al-Fitr Holiday"
-                )
-                _add_holiday(
-                    hol_date + timedelta(days=+2), "Eid al-Fitr Holiday"
-                )
+                _add_holiday(hol_date + td(days=+1), "Eid al-Fitr Holiday")
+                _add_holiday(hol_date + td(days=+2), "Eid al-Fitr Holiday")
 
         # Arafat Day & Eid al-Adha - Scarfice Festive
         # date of observance is announced yearly
@@ -89,13 +86,9 @@ class Tunisia(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 9):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Arafat Day")
-                _add_holiday(hol_date + timedelta(days=+1), "Eid al-Adha")
-                _add_holiday(
-                    hol_date + timedelta(days=+2), "Eid al-Adha Holiday"
-                )
-                _add_holiday(
-                    hol_date + timedelta(days=+3), "Eid al-Adha Holiday"
-                )
+                _add_holiday(hol_date + td(days=+1), "Eid al-Adha")
+                _add_holiday(hol_date + td(days=+2), "Eid al-Adha Holiday")
+                _add_holiday(hol_date + td(days=+3), "Eid al-Adha Holiday")
 
         # Islamic New Year - (hijari_year, 1, 1)
         for date_obs in _islamic_to_gre(year, 1, 1):

--- a/holidays/countries/tunisia.py
+++ b/holidays/countries/tunisia.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import JAN, MAR, APR, MAY, JUL, AUG, OCT
 from holidays.holiday_base import HolidayBase
@@ -78,8 +76,12 @@ class Tunisia(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 10, 1):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Eid al-Fitr")
-                _add_holiday(hol_date + rd(days=+1), "Eid al-Fitr Holiday")
-                _add_holiday(hol_date + rd(days=+2), "Eid al-Fitr Holiday")
+                _add_holiday(
+                    hol_date + timedelta(days=+1), "Eid al-Fitr Holiday"
+                )
+                _add_holiday(
+                    hol_date + timedelta(days=+2), "Eid al-Fitr Holiday"
+                )
 
         # Arafat Day & Eid al-Adha - Scarfice Festive
         # date of observance is announced yearly
@@ -87,9 +89,13 @@ class Tunisia(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 9):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Arafat Day")
-                _add_holiday(hol_date + rd(days=+1), "Eid al-Adha")
-                _add_holiday(hol_date + rd(days=+2), "Eid al-Adha Holiday")
-                _add_holiday(hol_date + rd(days=+3), "Eid al-Adha Holiday")
+                _add_holiday(hol_date + timedelta(days=+1), "Eid al-Adha")
+                _add_holiday(
+                    hol_date + timedelta(days=+2), "Eid al-Adha Holiday"
+                )
+                _add_holiday(
+                    hol_date + timedelta(days=+3), "Eid al-Adha Holiday"
+                )
 
         # Islamic New Year - (hijari_year, 1, 1)
         for date_obs in _islamic_to_gre(year, 1, 1):

--- a/holidays/countries/turkey.py
+++ b/holidays/countries/turkey.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import JAN, APR, MAY, JUL, AUG, OCT
 from holidays.holiday_base import HolidayBase
@@ -65,12 +66,8 @@ class Turkey(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 10, 1):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Ramadan Feast")
-                _add_holiday(
-                    hol_date + timedelta(days=+1), "Ramadan Feast Holiday"
-                )
-                _add_holiday(
-                    hol_date + timedelta(days=+2), "Ramadan Feast Holiday"
-                )
+                _add_holiday(hol_date + td(days=+1), "Ramadan Feast Holiday")
+                _add_holiday(hol_date + td(days=+2), "Ramadan Feast Holiday")
 
         # Sacrifice Feast
         # Date of observance is announced yearly, This is an estimate.
@@ -78,15 +75,9 @@ class Turkey(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 10):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Sacrifice Feast")
-                _add_holiday(
-                    hol_date + timedelta(days=+1), "Sacrifice Feast Holiday"
-                )
-                _add_holiday(
-                    hol_date + timedelta(days=+2), "Sacrifice Feast Holiday"
-                )
-                _add_holiday(
-                    hol_date + timedelta(days=+3), "Sacrifice Feast Holiday"
-                )
+                _add_holiday(hol_date + td(days=+1), "Sacrifice Feast Holiday")
+                _add_holiday(hol_date + td(days=+2), "Sacrifice Feast Holiday")
+                _add_holiday(hol_date + td(days=+3), "Sacrifice Feast Holiday")
 
 
 class TR(Turkey):

--- a/holidays/countries/turkey.py
+++ b/holidays/countries/turkey.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import JAN, APR, MAY, JUL, AUG, OCT
 from holidays.holiday_base import HolidayBase
@@ -67,8 +65,12 @@ class Turkey(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 10, 1):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Ramadan Feast")
-                _add_holiday(hol_date + rd(days=+1), "Ramadan Feast Holiday")
-                _add_holiday(hol_date + rd(days=+2), "Ramadan Feast Holiday")
+                _add_holiday(
+                    hol_date + timedelta(days=+1), "Ramadan Feast Holiday"
+                )
+                _add_holiday(
+                    hol_date + timedelta(days=+2), "Ramadan Feast Holiday"
+                )
 
         # Sacrifice Feast
         # Date of observance is announced yearly, This is an estimate.
@@ -76,9 +78,15 @@ class Turkey(HolidayBase):
             for date_obs in _islamic_to_gre(yr, 12, 10):
                 hol_date = date_obs
                 _add_holiday(hol_date, "Sacrifice Feast")
-                _add_holiday(hol_date + rd(days=+1), "Sacrifice Feast Holiday")
-                _add_holiday(hol_date + rd(days=+2), "Sacrifice Feast Holiday")
-                _add_holiday(hol_date + rd(days=+3), "Sacrifice Feast Holiday")
+                _add_holiday(
+                    hol_date + timedelta(days=+1), "Sacrifice Feast Holiday"
+                )
+                _add_holiday(
+                    hol_date + timedelta(days=+2), "Sacrifice Feast Holiday"
+                )
+                _add_holiday(
+                    hol_date + timedelta(days=+3), "Sacrifice Feast Holiday"
+                )
 
 
 class TR(Turkey):

--- a/holidays/countries/ukraine.py
+++ b/holidays/countries/ukraine.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import EASTER_ORTHODOX, easter
 
@@ -53,7 +54,7 @@ class Ukraine(HolidayBase):
             self[easter_date] = "Великдень (Пасха)"
 
             # Holy trinity
-            self[easter_date + timedelta(days=+49)] = "Трійця"
+            self[easter_date + td(days=+49)] = "Трійця"
 
         # Labour Day
         name = "День міжнародної солідарності трудящих"
@@ -129,11 +130,11 @@ class Ukraine(HolidayBase):
                         or k >= date(1999, APR, 23)
                     )
                 ):
-                    next_workday = k + timedelta(days=+1)
+                    next_workday = k + td(days=+1)
                     while self._is_weekend(next_workday) or self.get(
                         next_workday
                     ):
-                        next_workday += timedelta(days=+1)
+                        next_workday += td(days=+1)
                     self[next_workday] = "Вихідний за " + v
 
         # USSR holidays

--- a/holidays/countries/ukraine.py
+++ b/holidays/countries/ukraine.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import EASTER_ORTHODOX, easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, APR, MAR, MAY, JUN, JUL, AUG, SEP, OCT
 from holidays.constants import NOV, DEC
@@ -54,7 +53,7 @@ class Ukraine(HolidayBase):
             self[easter_date] = "Великдень (Пасха)"
 
             # Holy trinity
-            self[easter_date + rd(days=+49)] = "Трійця"
+            self[easter_date + timedelta(days=+49)] = "Трійця"
 
         # Labour Day
         name = "День міжнародної солідарності трудящих"
@@ -130,11 +129,11 @@ class Ukraine(HolidayBase):
                         or k >= date(1999, APR, 23)
                     )
                 ):
-                    next_workday = k + rd(days=+1)
+                    next_workday = k + timedelta(days=+1)
                     while self._is_weekend(next_workday) or self.get(
                         next_workday
                     ):
-                        next_workday += rd(days=+1)
+                        next_workday += timedelta(days=+1)
                     self[next_workday] = "Вихідний за " + v
 
         # USSR holidays

--- a/holidays/countries/united_arab_emirates.py
+++ b/holidays/countries/united_arab_emirates.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import JAN, APR, MAY, JUN, JUL, AUG, SEP, NOV, DEC
 from holidays.constants import FRI, SAT
@@ -85,19 +86,19 @@ class UnitedArabEmirates(HolidayBase):
             for date_obs in dates_obs[year]:
                 hol_date = date(year, *date_obs)
                 self[hol_date] = fitr
-                self[hol_date + timedelta(days=+1)] = f"{fitr} Holiday"
-                self[hol_date + timedelta(days=+2)] = f"{fitr} Holiday"
+                self[hol_date + td(days=+1)] = f"{fitr} Holiday"
+                self[hol_date + td(days=+2)] = f"{fitr} Holiday"
         else:
             for yr in (year - 1, year):
                 for date_obs in _islamic_to_gre(yr, 10, 1):
                     hol_date = date_obs
                     _add_holiday(hol_date, f"{fitr}* (*estimated)")
                     _add_holiday(
-                        hol_date + timedelta(days=+1),
+                        hol_date + td(days=+1),
                         f"{fitr} Holiday* (*estimated)",
                     )
                     _add_holiday(
-                        hol_date + timedelta(days=+2),
+                        hol_date + td(days=+2),
                         f"{fitr} Holiday* (*estimated)",
                     )
 
@@ -114,23 +115,23 @@ class UnitedArabEmirates(HolidayBase):
             for date_obs in dates_obs[year]:
                 hol_date = date(year, *date_obs)
                 self[hol_date] = hajj
-                self[hol_date + timedelta(days=+1)] = adha
-                self[hol_date + timedelta(days=+2)] = f"{adha} Holiday"
-                self[hol_date + timedelta(days=+3)] = f"{adha} Holiday"
+                self[hol_date + td(days=+1)] = adha
+                self[hol_date + td(days=+2)] = f"{adha} Holiday"
+                self[hol_date + td(days=+3)] = f"{adha} Holiday"
         else:
             for yr in (year - 1, year):
                 for date_obs in _islamic_to_gre(yr, 12, 9):
                     hol_date = date_obs
                     _add_holiday(hol_date, f"{hajj}* (*estimated)")
                     _add_holiday(
-                        hol_date + timedelta(days=+1), f"{adha}* (*estimated)"
+                        hol_date + td(days=+1), f"{adha}* (*estimated)"
                     )
                     _add_holiday(
-                        hol_date + timedelta(days=+2),
+                        hol_date + td(days=+2),
                         f"{adha}* Holiday* (*estimated)",
                     )
                     _add_holiday(
-                        hol_date + timedelta(days=+3),
+                        hol_date + td(days=+3),
                         f"{adha} Holiday* (*estimated)",
                     )
 

--- a/holidays/countries/united_arab_emirates.py
+++ b/holidays/countries/united_arab_emirates.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import JAN, APR, MAY, JUN, JUL, AUG, SEP, NOV, DEC
 from holidays.constants import FRI, SAT
@@ -87,19 +85,19 @@ class UnitedArabEmirates(HolidayBase):
             for date_obs in dates_obs[year]:
                 hol_date = date(year, *date_obs)
                 self[hol_date] = fitr
-                self[hol_date + rd(days=+1)] = f"{fitr} Holiday"
-                self[hol_date + rd(days=+2)] = f"{fitr} Holiday"
+                self[hol_date + timedelta(days=+1)] = f"{fitr} Holiday"
+                self[hol_date + timedelta(days=+2)] = f"{fitr} Holiday"
         else:
             for yr in (year - 1, year):
                 for date_obs in _islamic_to_gre(yr, 10, 1):
                     hol_date = date_obs
                     _add_holiday(hol_date, f"{fitr}* (*estimated)")
                     _add_holiday(
-                        hol_date + rd(days=+1),
+                        hol_date + timedelta(days=+1),
                         f"{fitr} Holiday* (*estimated)",
                     )
                     _add_holiday(
-                        hol_date + rd(days=+2),
+                        hol_date + timedelta(days=+2),
                         f"{fitr} Holiday* (*estimated)",
                     )
 
@@ -116,23 +114,23 @@ class UnitedArabEmirates(HolidayBase):
             for date_obs in dates_obs[year]:
                 hol_date = date(year, *date_obs)
                 self[hol_date] = hajj
-                self[hol_date + rd(days=+1)] = adha
-                self[hol_date + rd(days=+2)] = f"{adha} Holiday"
-                self[hol_date + rd(days=+3)] = f"{adha} Holiday"
+                self[hol_date + timedelta(days=+1)] = adha
+                self[hol_date + timedelta(days=+2)] = f"{adha} Holiday"
+                self[hol_date + timedelta(days=+3)] = f"{adha} Holiday"
         else:
             for yr in (year - 1, year):
                 for date_obs in _islamic_to_gre(yr, 12, 9):
                     hol_date = date_obs
                     _add_holiday(hol_date, f"{hajj}* (*estimated)")
                     _add_holiday(
-                        hol_date + rd(days=+1), f"{adha}* (*estimated)"
+                        hol_date + timedelta(days=+1), f"{adha}* (*estimated)"
                     )
                     _add_holiday(
-                        hol_date + rd(days=+2),
+                        hol_date + timedelta(days=+2),
                         f"{adha}* Holiday* (*estimated)",
                     )
                     _add_holiday(
-                        hol_date + rd(days=+3),
+                        hol_date + timedelta(days=+3),
                         f"{adha} Holiday* (*estimated)",
                     )
 

--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 from typing import Any
 
 from dateutil.easter import easter
@@ -70,9 +71,9 @@ class UnitedKingdom(HolidayBase):
                 name += " [Scotland]"
             self[dt] = name
             if self.observed and self._is_weekend(dt):
-                self[dt + timedelta(days=+2)] = name + " (Observed)"
+                self[dt + td(days=+2)] = name + " (Observed)"
             elif self.observed and dt.weekday() == MON:
-                self[dt + timedelta(days=+1)] = name + " (Observed)"
+                self[dt + td(days=+1)] = name + " (Observed)"
 
         # St. Patrick's Day
         if self.subdiv in {"Northern Ireland", "UK"}:
@@ -110,7 +111,7 @@ class UnitedKingdom(HolidayBase):
         dt = date(year, DEC, 25)
         self[dt] = name
         if self.observed and self._is_weekend(dt):
-            self[dt + timedelta(days=+2)] = name + " (Observed)"
+            self[dt + td(days=+2)] = name + " (Observed)"
 
         # Overwrite to modify country specific holidays
         self._country_specific(year)
@@ -122,14 +123,14 @@ class UnitedKingdom(HolidayBase):
 
         easter_date = easter(year)
         # Good Friday
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-2)] = "Good Friday"
 
         # Easter Monday
         if self.subdiv != "Scotland":
             name = "Easter Monday"
             if self.subdiv == "UK":
                 name += " [England/Wales/Northern Ireland]"
-            self[easter_date + timedelta(days=+1)] = name
+            self[easter_date + td(days=+1)] = name
 
         # May Day bank holiday (first Monday in May)
         if year >= 1978:
@@ -162,7 +163,7 @@ class UnitedKingdom(HolidayBase):
         dt = date(year, DEC, 26)
         self[dt] = name
         if self.observed and self._is_weekend(dt):
-            self[dt + timedelta(days=+2)] = name + " (Observed)"
+            self[dt + td(days=+2)] = name + " (Observed)"
 
 
 class UK(UnitedKingdom):

--- a/holidays/countries/united_kingdom.py
+++ b/holidays/countries/united_kingdom.py
@@ -8,7 +8,8 @@
 #           ryanss <ryanssdev@icloud.com> (c) 2014-2017
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
-from datetime import date
+
+from datetime import date, timedelta
 from typing import Any
 
 from dateutil.easter import easter
@@ -69,9 +70,9 @@ class UnitedKingdom(HolidayBase):
                 name += " [Scotland]"
             self[dt] = name
             if self.observed and self._is_weekend(dt):
-                self[dt + rd(days=+2)] = name + " (Observed)"
+                self[dt + timedelta(days=+2)] = name + " (Observed)"
             elif self.observed and dt.weekday() == MON:
-                self[dt + rd(days=+1)] = name + " (Observed)"
+                self[dt + timedelta(days=+1)] = name + " (Observed)"
 
         # St. Patrick's Day
         if self.subdiv in {"Northern Ireland", "UK"}:
@@ -109,7 +110,7 @@ class UnitedKingdom(HolidayBase):
         dt = date(year, DEC, 25)
         self[dt] = name
         if self.observed and self._is_weekend(dt):
-            self[dt + rd(days=+2)] = name + " (Observed)"
+            self[dt + timedelta(days=+2)] = name + " (Observed)"
 
         # Overwrite to modify country specific holidays
         self._country_specific(year)
@@ -121,14 +122,14 @@ class UnitedKingdom(HolidayBase):
 
         easter_date = easter(year)
         # Good Friday
-        self[easter_date + rd(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
 
         # Easter Monday
         if self.subdiv != "Scotland":
             name = "Easter Monday"
             if self.subdiv == "UK":
                 name += " [England/Wales/Northern Ireland]"
-            self[easter_date + rd(days=+1)] = name
+            self[easter_date + timedelta(days=+1)] = name
 
         # May Day bank holiday (first Monday in May)
         if year >= 1978:
@@ -161,7 +162,7 @@ class UnitedKingdom(HolidayBase):
         dt = date(year, DEC, 26)
         self[dt] = name
         if self.observed and self._is_weekend(dt):
-            self[dt + rd(days=+2)] = name + " (Observed)"
+            self[dt + timedelta(days=+2)] = name + " (Observed)"
 
 
 class UK(UnitedKingdom):

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, TU, TH, FR
@@ -95,9 +95,9 @@ class UnitedStates(HolidayBase):
         if not self.observed:
             return
         if dt.weekday() == SAT and before:
-            self[dt + rd(days=-1)] = f"{name} (Observed)"
+            self[dt + timedelta(days=-1)] = f"{name} (Observed)"
         elif dt.weekday() == SUN and after:
-            self[dt + rd(days=+1)] = f"{name} (Observed)"
+            self[dt + timedelta(days=+1)] = f"{name} (Observed)"
 
     def _populate(self, year):
         super()._populate(year)
@@ -123,7 +123,11 @@ class UnitedStates(HolidayBase):
         if self.subdiv == "VA" and year <= 2020:
             name = "Lee Jackson Day"
             if year >= 2000:
-                dt = date(year, JAN, 1) + rd(weekday=MO(+3)) + rd(days=-3)
+                dt = (
+                    date(year, JAN, 1)
+                    + rd(weekday=MO(+3))
+                    + timedelta(days=-3)
+                )
                 self[dt] = name
             elif year >= 1983:
                 self[date(year, JAN, 1) + rd(weekday=MO(+3))] = name
@@ -201,7 +205,7 @@ class UnitedStates(HolidayBase):
         easter_date = easter(year)
         # Mardi Gras
         if self.subdiv == "LA" and year >= 1857:
-            self[easter_date + rd(days=-47)] = "Mardi Gras"
+            self[easter_date + timedelta(days=-47)] = "Mardi Gras"
 
         # Guam Discovery Day
         if self.subdiv == "GU" and year >= 1970:
@@ -273,7 +277,7 @@ class UnitedStates(HolidayBase):
 
         # Holy Thursday
         if self.subdiv == "VI":
-            self[easter_date + rd(days=-3)] = "Holy Thursday"
+            self[easter_date + timedelta(days=-3)] = "Holy Thursday"
 
         # Good Friday
         if self.subdiv in {
@@ -290,11 +294,11 @@ class UnitedStates(HolidayBase):
             "TX",
             "VI",
         }:
-            self[easter_date + rd(days=-2)] = "Good Friday"
+            self[easter_date + timedelta(days=-2)] = "Good Friday"
 
         # Easter Monday
         if self.subdiv == "VI":
-            self[easter_date + rd(days=+1)] = "Easter Monday"
+            self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
         # Confederate Memorial Day
         name = "Confederate Memorial Day"
@@ -325,7 +329,7 @@ class UnitedStates(HolidayBase):
             (year >= 2006 and year % 2 == 0) or year >= 2015
         ):
             self[
-                (date(year, MAY, 1) + rd(weekday=MO) + rd(days=+1))
+                (date(year, MAY, 1) + rd(weekday=MO) + timedelta(days=+1))
             ] = "Primary Election Day"
 
         # Truman Day
@@ -446,7 +450,7 @@ class UnitedStates(HolidayBase):
             and year % 2 == 0
         ) or (self.subdiv in {"IN", "NY"} and year >= 2015):
             self[
-                date(year, NOV, 1) + rd(weekday=MO) + rd(days=+1)
+                date(year, NOV, 1) + rd(weekday=MO) + timedelta(days=+1)
             ] = "Election Day"
 
         # All Souls' Day
@@ -500,7 +504,9 @@ class UnitedStates(HolidayBase):
                 name = "Family Day"
             if self.subdiv == "NM":
                 name = "Presidents' Day"
-            self[date(year, NOV, 1) + rd(weekday=TH(+4)) + rd(days=+1)] = name
+            self[
+                date(year, NOV, 1) + rd(weekday=TH(+4)) + timedelta(days=+1)
+            ] = name
 
         # Robert E. Lee's Birthday
         if self.subdiv == "GA" and year >= 1986:
@@ -526,7 +532,7 @@ class UnitedStates(HolidayBase):
             self[dt] = name
             # If on Friday, observed on Thursday
             if self.observed and dt.weekday() == FRI:
-                self[dt + rd(days=-1)] = f"{name} (Observed)"
+                self[dt + timedelta(days=-1)] = f"{name} (Observed)"
             # If on Saturday or Sunday, observed on Friday
             elif self.observed and self._is_weekend(dt):
                 self[dt + rd(weekday=FR(-1))] = f"{name} (Observed)"
@@ -545,7 +551,7 @@ class UnitedStates(HolidayBase):
                 self[dt + rd(weekday=MO)] = f"{name} (Observed)"
             # If on Monday, observed on Tuesday
             elif self.observed and dt.weekday() == MON:
-                self[dt + rd(days=+1)] = f"{name} (Observed)"
+                self[dt + timedelta(days=+1)] = f"{name} (Observed)"
         elif self.subdiv == "TX" and year >= 1981:
             self[dt] = "Day After Christmas"
         elif self.subdiv == "VI":

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, TU, TH, FR
@@ -95,9 +96,9 @@ class UnitedStates(HolidayBase):
         if not self.observed:
             return
         if dt.weekday() == SAT and before:
-            self[dt + timedelta(days=-1)] = f"{name} (Observed)"
+            self[dt + td(days=-1)] = f"{name} (Observed)"
         elif dt.weekday() == SUN and after:
-            self[dt + timedelta(days=+1)] = f"{name} (Observed)"
+            self[dt + td(days=+1)] = f"{name} (Observed)"
 
     def _populate(self, year):
         super()._populate(year)
@@ -123,11 +124,7 @@ class UnitedStates(HolidayBase):
         if self.subdiv == "VA" and year <= 2020:
             name = "Lee Jackson Day"
             if year >= 2000:
-                dt = (
-                    date(year, JAN, 1)
-                    + rd(weekday=MO(+3))
-                    + timedelta(days=-3)
-                )
+                dt = date(year, JAN, 1) + rd(weekday=MO(+3)) + td(days=-3)
                 self[dt] = name
             elif year >= 1983:
                 self[date(year, JAN, 1) + rd(weekday=MO(+3))] = name
@@ -205,7 +202,7 @@ class UnitedStates(HolidayBase):
         easter_date = easter(year)
         # Mardi Gras
         if self.subdiv == "LA" and year >= 1857:
-            self[easter_date + timedelta(days=-47)] = "Mardi Gras"
+            self[easter_date + td(days=-47)] = "Mardi Gras"
 
         # Guam Discovery Day
         if self.subdiv == "GU" and year >= 1970:
@@ -277,7 +274,7 @@ class UnitedStates(HolidayBase):
 
         # Holy Thursday
         if self.subdiv == "VI":
-            self[easter_date + timedelta(days=-3)] = "Holy Thursday"
+            self[easter_date + td(days=-3)] = "Holy Thursday"
 
         # Good Friday
         if self.subdiv in {
@@ -294,11 +291,11 @@ class UnitedStates(HolidayBase):
             "TX",
             "VI",
         }:
-            self[easter_date + timedelta(days=-2)] = "Good Friday"
+            self[easter_date + td(days=-2)] = "Good Friday"
 
         # Easter Monday
         if self.subdiv == "VI":
-            self[easter_date + timedelta(days=+1)] = "Easter Monday"
+            self[easter_date + td(days=+1)] = "Easter Monday"
 
         # Confederate Memorial Day
         name = "Confederate Memorial Day"
@@ -329,7 +326,7 @@ class UnitedStates(HolidayBase):
             (year >= 2006 and year % 2 == 0) or year >= 2015
         ):
             self[
-                (date(year, MAY, 1) + rd(weekday=MO) + timedelta(days=+1))
+                (date(year, MAY, 1) + rd(weekday=MO) + td(days=+1))
             ] = "Primary Election Day"
 
         # Truman Day
@@ -450,7 +447,7 @@ class UnitedStates(HolidayBase):
             and year % 2 == 0
         ) or (self.subdiv in {"IN", "NY"} and year >= 2015):
             self[
-                date(year, NOV, 1) + rd(weekday=MO) + timedelta(days=+1)
+                date(year, NOV, 1) + rd(weekday=MO) + td(days=+1)
             ] = "Election Day"
 
         # All Souls' Day
@@ -504,9 +501,7 @@ class UnitedStates(HolidayBase):
                 name = "Family Day"
             if self.subdiv == "NM":
                 name = "Presidents' Day"
-            self[
-                date(year, NOV, 1) + rd(weekday=TH(+4)) + timedelta(days=+1)
-            ] = name
+            self[date(year, NOV, 1) + rd(weekday=TH(+4)) + td(days=+1)] = name
 
         # Robert E. Lee's Birthday
         if self.subdiv == "GA" and year >= 1986:
@@ -532,7 +527,7 @@ class UnitedStates(HolidayBase):
             self[dt] = name
             # If on Friday, observed on Thursday
             if self.observed and dt.weekday() == FRI:
-                self[dt + timedelta(days=-1)] = f"{name} (Observed)"
+                self[dt + td(days=-1)] = f"{name} (Observed)"
             # If on Saturday or Sunday, observed on Friday
             elif self.observed and self._is_weekend(dt):
                 self[dt + rd(weekday=FR(-1))] = f"{name} (Observed)"
@@ -551,7 +546,7 @@ class UnitedStates(HolidayBase):
                 self[dt + rd(weekday=MO)] = f"{name} (Observed)"
             # If on Monday, observed on Tuesday
             elif self.observed and dt.weekday() == MON:
-                self[dt + timedelta(days=+1)] = f"{name} (Observed)"
+                self[dt + td(days=+1)] = f"{name} (Observed)"
         elif self.subdiv == "TX" and year >= 1981:
             self[dt] = "Day After Christmas"
         elif self.subdiv == "VI":

--- a/holidays/countries/uruguay.py
+++ b/holidays/countries/uruguay.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -74,12 +75,12 @@ class Uruguay(HolidayBase):
         # Carnival days
         # revisar este día para futuros casos
         name = "Día de Carnaval [Carnival's Day]"
-        self[easter_date + timedelta(days=-48)] = name
-        self[easter_date + timedelta(days=-47)] = name
+        self[easter_date + td(days=-48)] = name
+        self[easter_date + td(days=-47)] = name
 
         # Holy Week.
-        self[easter_date + timedelta(days=-3)] = "Jueves Santo [Holy Thursday]"
-        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Holy Friday]"
+        self[easter_date + td(days=-3)] = "Jueves Santo [Holy Thursday]"
+        self[easter_date + td(days=-2)] = "Viernes Santo [Holy Friday]"
 
         self[easter_date] = "Día de Pascuas [Easter Day]"
 

--- a/holidays/countries/uruguay.py
+++ b/holidays/countries/uruguay.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -74,12 +74,12 @@ class Uruguay(HolidayBase):
         # Carnival days
         # revisar este día para futuros casos
         name = "Día de Carnaval [Carnival's Day]"
-        self[easter_date + rd(days=-48)] = name
-        self[easter_date + rd(days=-47)] = name
+        self[easter_date + timedelta(days=-48)] = name
+        self[easter_date + timedelta(days=-47)] = name
 
         # Holy Week.
-        self[easter_date + rd(days=-3)] = "Jueves Santo [Holy Thursday]"
-        self[easter_date + rd(days=-2)] = "Viernes Santo [Holy Friday]"
+        self[easter_date + timedelta(days=-3)] = "Jueves Santo [Holy Thursday]"
+        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Holy Friday]"
 
         self[easter_date] = "Día de Pascuas [Easter Day]"
 

--- a/holidays/countries/venezuela.py
+++ b/holidays/countries/venezuela.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import JAN, APR, MAY, JUN, JUL, OCT, DEC
 from holidays.holiday_base import HolidayBase
@@ -43,16 +42,18 @@ class Venezuela(HolidayBase):
 
         easter_date = easter(year)
         self[
-            easter_date + rd(days=-48)
+            easter_date + timedelta(days=-48)
         ] = "Lunes de Carnaval [Monday of Carnival]"
 
         self[
-            easter_date + rd(days=-47)
+            easter_date + timedelta(days=-47)
         ] = "Martes de Carnaval [Tuesday of Carnival]"
 
-        self[easter_date + rd(days=-3)] = "Jueves Santo [Maundy Thursday]"
+        self[
+            easter_date + timedelta(days=-3)
+        ] = "Jueves Santo [Maundy Thursday]"
 
-        self[easter_date + rd(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
 
         # Note: not sure about the start year, but this event happened in 1811
         if year >= 1811:

--- a/holidays/countries/venezuela.py
+++ b/holidays/countries/venezuela.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -42,18 +43,16 @@ class Venezuela(HolidayBase):
 
         easter_date = easter(year)
         self[
-            easter_date + timedelta(days=-48)
+            easter_date + td(days=-48)
         ] = "Lunes de Carnaval [Monday of Carnival]"
 
         self[
-            easter_date + timedelta(days=-47)
+            easter_date + td(days=-47)
         ] = "Martes de Carnaval [Tuesday of Carnival]"
 
-        self[
-            easter_date + timedelta(days=-3)
-        ] = "Jueves Santo [Maundy Thursday]"
+        self[easter_date + td(days=-3)] = "Jueves Santo [Maundy Thursday]"
 
-        self[easter_date + timedelta(days=-2)] = "Viernes Santo [Good Friday]"
+        self[easter_date + td(days=-2)] = "Viernes Santo [Good Friday]"
 
         # Note: not sure about the start year, but this event happened in 1811
         if year >= 1811:

--- a/holidays/countries/vietnam.py
+++ b/holidays/countries/vietnam.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 # Installation: pip install korean_lunar_calendar
 # URL: https://github.com/usingsky/korean_lunar_calendar_py/
@@ -34,9 +35,9 @@ class Vietnam(HolidayBase):
 
     def _add_observed(self, holiday: date) -> None:
         if self._is_weekend(holiday):
-            next_workday = holiday + timedelta(days=+1)
+            next_workday = holiday + td(days=+1)
             while self._is_weekend(next_workday) or self.get(next_workday):
-                next_workday += timedelta(days=+1)
+                next_workday += td(days=+1)
             self[next_workday] = self[holiday] + " observed"
 
     def _populate(self, year):
@@ -76,7 +77,7 @@ class Vietnam(HolidayBase):
         )
         hol_date = self.get_solar_date(year, 1, 1)
         for d, name in names:
-            self[(hol_date + timedelta(days=+d))] = name
+            self[(hol_date + td(days=+d))] = name
 
     # convert lunar calendar date to solar
     def get_solar_date(self, year, month, day):

--- a/holidays/countries/vietnam.py
+++ b/holidays/countries/vietnam.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 # Installation: pip install korean_lunar_calendar
 # URL: https://github.com/usingsky/korean_lunar_calendar_py/
@@ -36,9 +34,9 @@ class Vietnam(HolidayBase):
 
     def _add_observed(self, holiday: date) -> None:
         if self._is_weekend(holiday):
-            next_workday = holiday + rd(days=+1)
+            next_workday = holiday + timedelta(days=+1)
             while self._is_weekend(next_workday) or self.get(next_workday):
-                next_workday += rd(days=+1)
+                next_workday += timedelta(days=+1)
             self[next_workday] = self[holiday] + " observed"
 
     def _populate(self, year):
@@ -78,7 +76,7 @@ class Vietnam(HolidayBase):
         )
         hol_date = self.get_solar_date(year, 1, 1)
         for d, name in names:
-            self[(hol_date + rd(days=+d))] = name
+            self[(hol_date + timedelta(days=+d))] = name
 
     # convert lunar calendar date to solar
     def get_solar_date(self, year, month, day):

--- a/holidays/countries/zambia.py
+++ b/holidays/countries/zambia.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -68,9 +69,9 @@ class Zambia(HolidayBase):
         self[date(year, MAR, 12)] = "Youth Day"
 
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
-        self[easter_date + timedelta(days=-1)] = "Holy Saturday"
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-1)] = "Holy Saturday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
 
         if year >= 2022:
             self[date(year, APR, 28)] = "Kenneth Kaunda Day"
@@ -81,7 +82,7 @@ class Zambia(HolidayBase):
         # 1st Monday of July = "Heroes' Day"
         dt = date(year, JUL, 1) + rd(weekday=MO)
         self[dt] = "Heroes' Day"
-        self[dt + timedelta(days=+1)] = "Unity Day"
+        self[dt + td(days=+1)] = "Unity Day"
 
         # 1st Monday of Aug = "Farmers' Day"
         dt = date(year, AUG, 1) + rd(weekday=MO)
@@ -98,7 +99,7 @@ class Zambia(HolidayBase):
         if self.observed:
             for k, v in list(self.items()):
                 if k.year == year and k.weekday() == SUN:
-                    self[k + timedelta(days=+1)] = v + " (Observed)"
+                    self[k + td(days=+1)] = v + " (Observed)"
 
 
 class ZM(Zambia):

--- a/holidays/countries/zambia.py
+++ b/holidays/countries/zambia.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -68,9 +68,9 @@ class Zambia(HolidayBase):
         self[date(year, MAR, 12)] = "Youth Day"
 
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
-        self[easter_date + rd(days=-1)] = "Holy Saturday"
-        self[easter_date + rd(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-1)] = "Holy Saturday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
         if year >= 2022:
             self[date(year, APR, 28)] = "Kenneth Kaunda Day"
@@ -81,7 +81,7 @@ class Zambia(HolidayBase):
         # 1st Monday of July = "Heroes' Day"
         dt = date(year, JUL, 1) + rd(weekday=MO)
         self[dt] = "Heroes' Day"
-        self[dt + rd(days=+1)] = "Unity Day"
+        self[dt + timedelta(days=+1)] = "Unity Day"
 
         # 1st Monday of Aug = "Farmers' Day"
         dt = date(year, AUG, 1) + rd(weekday=MO)
@@ -98,7 +98,7 @@ class Zambia(HolidayBase):
         if self.observed:
             for k, v in list(self.items()):
                 if k.year == year and k.weekday() == SUN:
-                    self[k + rd(days=+1)] = v + " (Observed)"
+                    self[k + timedelta(days=+1)] = v + " (Observed)"
 
 
 class ZM(Zambia):

--- a/holidays/countries/zimbabwe.py
+++ b/holidays/countries/zimbabwe.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -41,9 +42,9 @@ class Zimbabwe(HolidayBase):
             ] = "Robert Gabriel Mugabe National Youth Day"
 
         easter_date = easter(year)
-        self[easter_date + timedelta(days=-2)] = "Good Friday"
-        self[easter_date + timedelta(days=-1)] = "Easter Saturday"
-        self[easter_date + timedelta(days=+1)] = "Easter Monday"
+        self[easter_date + td(days=-2)] = "Good Friday"
+        self[easter_date + td(days=-1)] = "Easter Saturday"
+        self[easter_date + td(days=+1)] = "Easter Monday"
 
         self[date(year, APR, 18)] = "Independence Day"
 
@@ -55,7 +56,7 @@ class Zimbabwe(HolidayBase):
         self[zimbabwe_heroes_day] = "Zimbabwe Heroes' Day"
 
         # Tuesday after 2nd Monday of August
-        defence_forces_day = zimbabwe_heroes_day + timedelta(days=+1)
+        defence_forces_day = zimbabwe_heroes_day + td(days=+1)
         self[defence_forces_day] = "Defense Forces Day"
 
         self[date(year, DEC, 22)] = "Unity Day"
@@ -65,9 +66,9 @@ class Zimbabwe(HolidayBase):
         if self.observed:
             for k, v in list(self.items()):
                 if k.weekday() == SUN and k.year == year:
-                    dt = k + timedelta(days=+1)
+                    dt = k + td(days=+1)
                     while self.get(dt):
-                        dt += timedelta(days=+1)
+                        dt += td(days=+1)
                     self[dt] = v + " (Observed)"
 
 

--- a/holidays/countries/zimbabwe.py
+++ b/holidays/countries/zimbabwe.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
@@ -41,9 +41,9 @@ class Zimbabwe(HolidayBase):
             ] = "Robert Gabriel Mugabe National Youth Day"
 
         easter_date = easter(year)
-        self[easter_date + rd(days=-2)] = "Good Friday"
-        self[easter_date + rd(days=-1)] = "Easter Saturday"
-        self[easter_date + rd(days=+1)] = "Easter Monday"
+        self[easter_date + timedelta(days=-2)] = "Good Friday"
+        self[easter_date + timedelta(days=-1)] = "Easter Saturday"
+        self[easter_date + timedelta(days=+1)] = "Easter Monday"
 
         self[date(year, APR, 18)] = "Independence Day"
 
@@ -55,7 +55,7 @@ class Zimbabwe(HolidayBase):
         self[zimbabwe_heroes_day] = "Zimbabwe Heroes' Day"
 
         # Tuesday after 2nd Monday of August
-        defence_forces_day = zimbabwe_heroes_day + rd(days=+1)
+        defence_forces_day = zimbabwe_heroes_day + timedelta(days=+1)
         self[defence_forces_day] = "Defense Forces Day"
 
         self[date(year, DEC, 22)] = "Unity Day"
@@ -65,9 +65,9 @@ class Zimbabwe(HolidayBase):
         if self.observed:
             for k, v in list(self.items()):
                 if k.weekday() == SUN and k.year == year:
-                    dt = k + rd(days=+1)
+                    dt = k + timedelta(days=+1)
                     while self.get(dt):
-                        dt += rd(days=+1)
+                        dt += timedelta(days=+1)
                     self[dt] = v + " (Observed)"
 
 

--- a/holidays/financial/european_central_bank.py
+++ b/holidays/financial/european_central_bank.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import DEC, JAN, MAY
 from holidays.holiday_base import HolidayBase
@@ -32,8 +31,8 @@ class EuropeanCentralBank(HolidayBase):
 
         self[date(year, JAN, 1)] = "New Year's Day"
         e = easter(year)
-        self[e + rd(days=-2)] = "Good Friday"
-        self[e + rd(days=+1)] = "Easter Monday"
+        self[e + timedelta(days=-2)] = "Good Friday"
+        self[e + timedelta(days=+1)] = "Easter Monday"
         self[date(year, MAY, 1)] = "1 May (Labour Day)"
         self[date(year, DEC, 25)] = "Christmas Day"
         self[date(year, DEC, 26)] = "26 December"

--- a/holidays/financial/european_central_bank.py
+++ b/holidays/financial/european_central_bank.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 
@@ -31,8 +32,8 @@ class EuropeanCentralBank(HolidayBase):
 
         self[date(year, JAN, 1)] = "New Year's Day"
         e = easter(year)
-        self[e + timedelta(days=-2)] = "Good Friday"
-        self[e + timedelta(days=+1)] = "Easter Monday"
+        self[e + td(days=-2)] = "Good Friday"
+        self[e + td(days=+1)] = "Easter Monday"
         self[date(year, MAY, 1)] = "1 May (Labour Day)"
         self[date(year, DEC, 25)] = "Christmas Day"
         self[date(year, DEC, 26)] = "26 December"

--- a/holidays/financial/ny_stock_exchange.py
+++ b/holidays/financial/ny_stock_exchange.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, TH, FR
@@ -63,9 +64,7 @@ class NewYorkStockExchange(HolidayBase):
         # needs to be observed on Friday (Dec 31 of previous year).
         dec_31 = date(year, DEC, 31)
         if dec_31.weekday() == FRI:
-            self._set_observed_date(
-                dec_31 + timedelta(days=+1), "New Year's Day"
-            )
+            self._set_observed_date(dec_31 + td(days=+1), "New Year's Day")
 
         # MLK - observed 1998 - 3rd Monday of Jan
         if year >= 1998:
@@ -90,7 +89,7 @@ class NewYorkStockExchange(HolidayBase):
         # GOOD FRIDAY - closed every year except 1898, 1906, and 1907
         e = easter(year)
         if year not in {1898, 1906, 1907}:
-            self[e + timedelta(days=-2)] = "Good Friday"
+            self[e + td(days=-2)] = "Good Friday"
 
         # MEM DAY (May 30) - closed every year since 1873
         # last Mon in May since 1971
@@ -129,7 +128,7 @@ class NewYorkStockExchange(HolidayBase):
         # closed until 1969, then closed pres years 1972-80
         if year <= 1968 or year in {1972, 1976, 1980}:
             self[
-                date(year, NOV, 1) + rd(weekday=MO) + timedelta(days=+1)
+                date(year, NOV, 1) + rd(weekday=MO) + td(days=+1)
             ] = "Election Day"
 
         # VETERAN'S DAY: Nov 11 - closed 1918, 1921, 1934-1953
@@ -180,8 +179,7 @@ class NewYorkStockExchange(HolidayBase):
             begin = date(year, JUL, 31)
             end = date(year, NOV, 27)
             for d in (
-                begin + timedelta(days=n)
-                for n in range((end - begin).days + 1)
+                begin + td(days=n) for n in range((end - begin).days + 1)
             ):
                 if self._is_weekend(d):
                     continue
@@ -212,8 +210,7 @@ class NewYorkStockExchange(HolidayBase):
             begin = date(year, MAR, 6)
             end = date(year, MAR, 14)
             for d in (
-                begin + timedelta(days=n)
-                for n in range((end - begin).days + 1)
+                begin + td(days=n) for n in range((end - begin).days + 1)
             ):
                 if self._is_weekend(d):
                     continue
@@ -242,8 +239,7 @@ class NewYorkStockExchange(HolidayBase):
             begin = date(year, JUN, 12)
             end = date(year, DEC, 31)
             for d in (
-                begin + timedelta(days=n)
-                for n in range((end - begin).days + 1)
+                begin + td(days=n) for n in range((end - begin).days + 1)
             ):
                 if d.weekday() != WED:  # Wednesday special holiday
                     continue

--- a/holidays/financial/ny_stock_exchange.py
+++ b/holidays/financial/ny_stock_exchange.py
@@ -9,7 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.easter import easter
 from dateutil.relativedelta import MO, TH, FR
@@ -63,7 +63,9 @@ class NewYorkStockExchange(HolidayBase):
         # needs to be observed on Friday (Dec 31 of previous year).
         dec_31 = date(year, DEC, 31)
         if dec_31.weekday() == FRI:
-            self._set_observed_date(dec_31 + rd(days=+1), "New Year's Day")
+            self._set_observed_date(
+                dec_31 + timedelta(days=+1), "New Year's Day"
+            )
 
         # MLK - observed 1998 - 3rd Monday of Jan
         if year >= 1998:
@@ -88,7 +90,7 @@ class NewYorkStockExchange(HolidayBase):
         # GOOD FRIDAY - closed every year except 1898, 1906, and 1907
         e = easter(year)
         if year not in {1898, 1906, 1907}:
-            self[e + rd(days=-2)] = "Good Friday"
+            self[e + timedelta(days=-2)] = "Good Friday"
 
         # MEM DAY (May 30) - closed every year since 1873
         # last Mon in May since 1971
@@ -127,7 +129,7 @@ class NewYorkStockExchange(HolidayBase):
         # closed until 1969, then closed pres years 1972-80
         if year <= 1968 or year in {1972, 1976, 1980}:
             self[
-                date(year, NOV, 1) + rd(weekday=MO) + rd(days=+1)
+                date(year, NOV, 1) + rd(weekday=MO) + timedelta(days=+1)
             ] = "Election Day"
 
         # VETERAN'S DAY: Nov 11 - closed 1918, 1921, 1934-1953
@@ -178,7 +180,8 @@ class NewYorkStockExchange(HolidayBase):
             begin = date(year, JUL, 31)
             end = date(year, NOV, 27)
             for d in (
-                begin + rd(days=n) for n in range((end - begin).days + 1)
+                begin + timedelta(days=n)
+                for n in range((end - begin).days + 1)
             ):
                 if self._is_weekend(d):
                     continue
@@ -209,7 +212,8 @@ class NewYorkStockExchange(HolidayBase):
             begin = date(year, MAR, 6)
             end = date(year, MAR, 14)
             for d in (
-                begin + rd(days=n) for n in range((end - begin).days + 1)
+                begin + timedelta(days=n)
+                for n in range((end - begin).days + 1)
             ):
                 if self._is_weekend(d):
                     continue
@@ -238,7 +242,8 @@ class NewYorkStockExchange(HolidayBase):
             begin = date(year, JUN, 12)
             end = date(year, DEC, 31)
             for d in (
-                begin + rd(days=n) for n in range((end - begin).days + 1)
+                begin + timedelta(days=n)
+                for n in range((end - begin).days + 1)
             ):
                 if d.weekday() != WED:  # Wednesday special holiday
                     continue

--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -17,7 +17,6 @@ from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple
 from typing import Union, cast
 
 from dateutil.parser import parse
-from dateutil.relativedelta import relativedelta as rd
 
 from holidays.constants import SAT, SUN
 
@@ -363,7 +362,7 @@ class HolidayBase(Dict[date, str]):
 
             days_in_range = []
             for delta_days in range(0, date_diff.days, step):
-                day = start + rd(days=delta_days)
+                day = start + timedelta(days=delta_days)
                 try:
                     self.__getitem__(day)
                     days_in_range.append(day)

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -19,11 +19,10 @@ __all__ = (
 
 import inspect
 import warnings
-from datetime import date
+from datetime import date, timedelta
 from functools import lru_cache
 from typing import Dict, Iterable, List, Optional, Union
 
-from dateutil.relativedelta import relativedelta as rd
 from hijri_converter import convert
 from hijri_converter.ummalqura import GREGORIAN_RANGE
 
@@ -680,7 +679,7 @@ class _ChineseLuniSolar:
         # leap_month = self._get_leap_month(year)
         # for m in range(1, 1 + (1 > leap_month)):
         #     span_days += self._lunar_month_days(year, m)
-        return self.SOLAR_START_DATE + rd(days=span_days)
+        return self.SOLAR_START_DATE + timedelta(days=span_days)
 
     def lunar_to_gre(
         self, year: int, month: int, day: int, leap: bool = True
@@ -706,7 +705,7 @@ class _ChineseLuniSolar:
         for m in range(1, month + (month > leap_month)):
             span_days += self._lunar_month_days(year, m)
         span_days += day - 1
-        return self.SOLAR_START_DATE + rd(days=span_days)
+        return self.SOLAR_START_DATE + timedelta(days=span_days)
 
     def vesak_date(self, year: int) -> date:
         """
@@ -727,7 +726,7 @@ class _ChineseLuniSolar:
         for m in range(1, 4 + (4 > leap_month)):
             span_days += self._lunar_month_days(year, m)
         span_days += 14
-        return self.SOLAR_START_DATE + rd(days=span_days)
+        return self.SOLAR_START_DATE + timedelta(days=span_days)
 
     def vesak_may_date(self, year: int) -> date:
         """
@@ -743,10 +742,10 @@ class _ChineseLuniSolar:
             Estimated Gregorian date of Vesak (first full moon in May).
         """
         span_days = self._span_days(year)
-        vesak_may_date = self.SOLAR_START_DATE + rd(days=span_days + 14)
+        vesak_may_date = self.SOLAR_START_DATE + timedelta(days=span_days + 14)
         m = 1
         while vesak_may_date.month < 5:
-            vesak_may_date += rd(days=self._lunar_month_days(year, m))
+            vesak_may_date += timedelta(days=self._lunar_month_days(year, m))
             m += 1
         return vesak_may_date
 
@@ -770,7 +769,7 @@ class _ChineseLuniSolar:
         for m in range(1, 10 + (10 > leap_month)):
             span_days += self._lunar_month_days(year, m)
         span_days -= 2
-        return self.SOLAR_START_DATE + rd(days=span_days)
+        return self.SOLAR_START_DATE + timedelta(days=span_days)
 
     def thaipusam_date(self, year: int) -> date:
         """
@@ -791,4 +790,4 @@ class _ChineseLuniSolar:
         for m in range(1, 1 + (leap_month <= 6)):
             span_days += self._lunar_month_days(year, m)
         span_days -= 15
-        return self.SOLAR_START_DATE + rd(days=span_days)
+        return self.SOLAR_START_DATE + timedelta(days=span_days)

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -19,7 +19,8 @@ __all__ = (
 
 import inspect
 import warnings
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 from functools import lru_cache
 from typing import Dict, Iterable, List, Optional, Union
 
@@ -679,7 +680,7 @@ class _ChineseLuniSolar:
         # leap_month = self._get_leap_month(year)
         # for m in range(1, 1 + (1 > leap_month)):
         #     span_days += self._lunar_month_days(year, m)
-        return self.SOLAR_START_DATE + timedelta(days=span_days)
+        return self.SOLAR_START_DATE + td(days=span_days)
 
     def lunar_to_gre(
         self, year: int, month: int, day: int, leap: bool = True
@@ -705,7 +706,7 @@ class _ChineseLuniSolar:
         for m in range(1, month + (month > leap_month)):
             span_days += self._lunar_month_days(year, m)
         span_days += day - 1
-        return self.SOLAR_START_DATE + timedelta(days=span_days)
+        return self.SOLAR_START_DATE + td(days=span_days)
 
     def vesak_date(self, year: int) -> date:
         """
@@ -726,7 +727,7 @@ class _ChineseLuniSolar:
         for m in range(1, 4 + (4 > leap_month)):
             span_days += self._lunar_month_days(year, m)
         span_days += 14
-        return self.SOLAR_START_DATE + timedelta(days=span_days)
+        return self.SOLAR_START_DATE + td(days=span_days)
 
     def vesak_may_date(self, year: int) -> date:
         """
@@ -742,10 +743,10 @@ class _ChineseLuniSolar:
             Estimated Gregorian date of Vesak (first full moon in May).
         """
         span_days = self._span_days(year)
-        vesak_may_date = self.SOLAR_START_DATE + timedelta(days=span_days + 14)
+        vesak_may_date = self.SOLAR_START_DATE + td(days=span_days + 14)
         m = 1
         while vesak_may_date.month < 5:
-            vesak_may_date += timedelta(days=self._lunar_month_days(year, m))
+            vesak_may_date += td(days=self._lunar_month_days(year, m))
             m += 1
         return vesak_may_date
 
@@ -769,7 +770,7 @@ class _ChineseLuniSolar:
         for m in range(1, 10 + (10 > leap_month)):
             span_days += self._lunar_month_days(year, m)
         span_days -= 2
-        return self.SOLAR_START_DATE + timedelta(days=span_days)
+        return self.SOLAR_START_DATE + td(days=span_days)
 
     def thaipusam_date(self, year: int) -> date:
         """
@@ -790,4 +791,4 @@ class _ChineseLuniSolar:
         for m in range(1, 1 + (leap_month <= 6)):
             span_days += self._lunar_month_days(year, m)
         span_days -= 15
-        return self.SOLAR_START_DATE + timedelta(days=span_days)
+        return self.SOLAR_START_DATE + td(days=span_days)


### PR DESCRIPTION
Resolves #891 

This PR contains business logic only changes. See #901 for tests changes.

My simple benchmark results for the following code:
```
def create_country_holidays():
    for country in list_supported_countries():
        country_holidays(country, years=range(2020, 2031))
```

  - the `relativedelta`:
```
timeit.timeit(create_country_holidays, number=1000)
339.802383083
```

  - the `timedelta`:
```
timeit.timeit(create_country_holidays, number=1000)
313.579699042
```