### PR TITLE
Refactor days offset calculation: replace `relativedelta` with `timedelta` (tests)

### DIFF
--- a/test/countries/test_argentina.py
+++ b/test/countries/test_argentina.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.constants import MAY, JUN, JUL, AUG, OCT
 from holidays.countries.argentina import AR, ARG, Argentina
@@ -41,8 +39,8 @@ class TestArgentina(TestCase):
             dt = date(year, 1, 1)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + rd(days=-1),
-                dt + rd(days=+1),
+                dt + timedelta(days=-1),
+                dt + timedelta(days=+1),
             )
 
     def test_carnival_day(self):
@@ -98,8 +96,8 @@ class TestArgentina(TestCase):
             dt = date(year, MAY, 1)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + rd(days=-1),
-                dt + rd(days=+1),
+                dt + timedelta(days=-1),
+                dt + timedelta(days=+1),
             )
 
     def test_may_revolution_day(self):
@@ -114,8 +112,8 @@ class TestArgentina(TestCase):
             dt = date(year, MAY, 25)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + rd(days=-1),
-                dt + rd(days=+1),
+                dt + timedelta(days=-1),
+                dt + timedelta(days=+1),
             )
 
     def test_guemes_day(self):
@@ -123,8 +121,8 @@ class TestArgentina(TestCase):
             dt = date(year, JUN, 17)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + rd(days=-1),
-                dt + rd(days=+1),
+                dt + timedelta(days=-1),
+                dt + timedelta(days=+1),
             )
 
     def test_belgrano_day(self):
@@ -132,8 +130,8 @@ class TestArgentina(TestCase):
             dt = date(year, JUN, 20)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + rd(days=-1),
-                dt + rd(days=+1),
+                dt + timedelta(days=-1),
+                dt + timedelta(days=+1),
             )
 
     def test_independence_day(self):
@@ -153,8 +151,8 @@ class TestArgentina(TestCase):
             dt = date(year, JUL, 9)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + rd(days=-1),
-                dt + rd(days=+1),
+                dt + timedelta(days=-1),
+                dt + timedelta(days=+1),
             )
 
     def test_san_martin_day(self):
@@ -169,8 +167,8 @@ class TestArgentina(TestCase):
             dt = date(year, AUG, 17)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + rd(days=-1),
-                dt + rd(days=+1),
+                dt + timedelta(days=-1),
+                dt + timedelta(days=+1),
             )
 
     def test_cultural_day(self):
@@ -185,8 +183,8 @@ class TestArgentina(TestCase):
             dt = date(year, OCT, 12)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + rd(days=-1),
-                dt + rd(days=+1),
+                dt + timedelta(days=-1),
+                dt + timedelta(days=+1),
             )
 
     def test_national_sovereignty_day(self):
@@ -197,8 +195,8 @@ class TestArgentina(TestCase):
             else:
                 self.assertHoliday(dt)
                 self.assertNoHoliday(
-                    dt + rd(days=-1),
-                    dt + rd(days=+1),
+                    dt + timedelta(days=-1),
+                    dt + timedelta(days=+1),
                 )
 
     def test_immaculate_conception_day(self):
@@ -213,8 +211,8 @@ class TestArgentina(TestCase):
             dt = date(year, 12, 8)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + rd(days=-1),
-                dt + rd(days=+1),
+                dt + timedelta(days=-1),
+                dt + timedelta(days=+1),
             )
 
     def test_christmas(self):
@@ -222,8 +220,8 @@ class TestArgentina(TestCase):
             dt = date(year, 12, 25)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + rd(days=-1),
-                dt + rd(days=+1),
+                dt + timedelta(days=-1),
+                dt + timedelta(days=+1),
             )
 
     def test_2022(self):

--- a/test/countries/test_argentina.py
+++ b/test/countries/test_argentina.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.constants import MAY, JUN, JUL, AUG, OCT
 from holidays.countries.argentina import AR, ARG, Argentina
@@ -39,8 +40,8 @@ class TestArgentina(TestCase):
             dt = date(year, 1, 1)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + timedelta(days=-1),
-                dt + timedelta(days=+1),
+                dt + td(days=-1),
+                dt + td(days=+1),
             )
 
     def test_carnival_day(self):
@@ -96,8 +97,8 @@ class TestArgentina(TestCase):
             dt = date(year, MAY, 1)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + timedelta(days=-1),
-                dt + timedelta(days=+1),
+                dt + td(days=-1),
+                dt + td(days=+1),
             )
 
     def test_may_revolution_day(self):
@@ -112,8 +113,8 @@ class TestArgentina(TestCase):
             dt = date(year, MAY, 25)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + timedelta(days=-1),
-                dt + timedelta(days=+1),
+                dt + td(days=-1),
+                dt + td(days=+1),
             )
 
     def test_guemes_day(self):
@@ -121,8 +122,8 @@ class TestArgentina(TestCase):
             dt = date(year, JUN, 17)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + timedelta(days=-1),
-                dt + timedelta(days=+1),
+                dt + td(days=-1),
+                dt + td(days=+1),
             )
 
     def test_belgrano_day(self):
@@ -130,8 +131,8 @@ class TestArgentina(TestCase):
             dt = date(year, JUN, 20)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + timedelta(days=-1),
-                dt + timedelta(days=+1),
+                dt + td(days=-1),
+                dt + td(days=+1),
             )
 
     def test_independence_day(self):
@@ -151,8 +152,8 @@ class TestArgentina(TestCase):
             dt = date(year, JUL, 9)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + timedelta(days=-1),
-                dt + timedelta(days=+1),
+                dt + td(days=-1),
+                dt + td(days=+1),
             )
 
     def test_san_martin_day(self):
@@ -167,8 +168,8 @@ class TestArgentina(TestCase):
             dt = date(year, AUG, 17)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + timedelta(days=-1),
-                dt + timedelta(days=+1),
+                dt + td(days=-1),
+                dt + td(days=+1),
             )
 
     def test_cultural_day(self):
@@ -183,8 +184,8 @@ class TestArgentina(TestCase):
             dt = date(year, OCT, 12)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + timedelta(days=-1),
-                dt + timedelta(days=+1),
+                dt + td(days=-1),
+                dt + td(days=+1),
             )
 
     def test_national_sovereignty_day(self):
@@ -195,8 +196,8 @@ class TestArgentina(TestCase):
             else:
                 self.assertHoliday(dt)
                 self.assertNoHoliday(
-                    dt + timedelta(days=-1),
-                    dt + timedelta(days=+1),
+                    dt + td(days=-1),
+                    dt + td(days=+1),
                 )
 
     def test_immaculate_conception_day(self):
@@ -211,8 +212,8 @@ class TestArgentina(TestCase):
             dt = date(year, 12, 8)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + timedelta(days=-1),
-                dt + timedelta(days=+1),
+                dt + td(days=-1),
+                dt + td(days=+1),
             )
 
     def test_christmas(self):
@@ -220,8 +221,8 @@ class TestArgentina(TestCase):
             dt = date(year, 12, 25)
             self.assertHoliday(dt)
             self.assertNoHoliday(
-                dt + timedelta(days=-1),
-                dt + timedelta(days=+1),
+                dt + td(days=-1),
+                dt + td(days=+1),
             )
 
     def test_2022(self):

--- a/test/countries/test_australia.py
+++ b/test/countries/test_australia.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -125,7 +123,7 @@ class TestAU(unittest.TestCase):
         ]:
             self.assertIn(dt, self.holidays)
             self.assertEqual(self.holidays[dt], "Easter Monday")
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_bank_holiday(self):
         for dt in [
@@ -328,7 +326,7 @@ class TestAU(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
         self.assertNotIn(date(2010, 12, 24), self.holidays)
         self.assertNotEqual(
             self.holidays[date(2011, 12, 26)], "Christmas Day (Observed)"
@@ -372,7 +370,7 @@ class TestAU(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(date(2009, 12, 28), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_australia.py
+++ b/test/countries/test_australia.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -123,7 +124,7 @@ class TestAU(unittest.TestCase):
         ]:
             self.assertIn(dt, self.holidays)
             self.assertEqual(self.holidays[dt], "Easter Monday")
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_bank_holiday(self):
         for dt in [
@@ -326,7 +327,7 @@ class TestAU(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
         self.assertNotIn(date(2010, 12, 24), self.holidays)
         self.assertNotEqual(
             self.holidays[date(2011, 12, 26)], "Christmas Day (Observed)"
@@ -370,7 +371,7 @@ class TestAU(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(date(2009, 12, 28), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_austria.py
+++ b/test/countries/test_austria.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -23,16 +24,16 @@ class TestAT(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_christmas(self):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+2), self.holidays)
+            self.assertIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+2), self.holidays)
 
     def test_easter_monday(self):
         for dt in [
@@ -47,20 +48,20 @@ class TestAT(unittest.TestCase):
             date(2020, 4, 13),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_national_day(self):
         for year in range(1919, 1934):
             dt = date(year, 11, 12)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         for year in range(1967, 2100):
             dt = date(year, 10, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_all_holidays_present(self):
         at_2015 = holidays.AT(years=[2015])

--- a/test/countries/test_austria.py
+++ b/test/countries/test_austria.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -25,16 +23,16 @@ class TestAT(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_christmas(self):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+2), self.holidays)
+            self.assertIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+2), self.holidays)
 
     def test_easter_monday(self):
         for dt in [
@@ -49,20 +47,20 @@ class TestAT(unittest.TestCase):
             date(2020, 4, 13),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_national_day(self):
         for year in range(1919, 1934):
             dt = date(year, 11, 12)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         for year in range(1967, 2100):
             dt = date(year, 10, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_all_holidays_present(self):
         at_2015 = holidays.AT(years=[2015])

--- a/test/countries/test_bulgaria.py
+++ b/test/countries/test_bulgaria.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -87,9 +88,9 @@ class TestBulgaria(unittest.TestCase):
             (2022, 4, 24),
         ]:
             easter = date(year, month, day)
-            easter_friday = easter + timedelta(days=-2)
-            easter_saturday = easter + timedelta(days=-1)
-            easter_monday = easter + timedelta(days=+1)
+            easter_friday = easter + td(days=-2)
+            easter_saturday = easter + td(days=-1)
+            easter_monday = easter + td(days=+1)
             for holiday in [
                 easter_friday,
                 easter_saturday,

--- a/test/countries/test_bulgaria.py
+++ b/test/countries/test_bulgaria.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -89,9 +87,9 @@ class TestBulgaria(unittest.TestCase):
             (2022, 4, 24),
         ]:
             easter = date(year, month, day)
-            easter_friday = easter + rd(days=-2)
-            easter_saturday = easter + rd(days=-1)
-            easter_monday = easter + rd(days=+1)
+            easter_friday = easter + timedelta(days=-2)
+            easter_saturday = easter + timedelta(days=-1)
+            easter_monday = easter + timedelta(days=+1)
             for holiday in [
                 easter_friday,
                 easter_saturday,

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -34,8 +32,8 @@ class TestCA(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_islander_day(self):
         pei_holidays = holidays.CA(subdiv="PE")
@@ -55,8 +53,8 @@ class TestCA(unittest.TestCase):
             elif dt.year == 2009:
                 self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, pei_holidays)
-            self.assertNotIn(dt + rd(days=-1), pei_holidays)
-            self.assertNotIn(dt + rd(days=+1), pei_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), pei_holidays)
+            self.assertNotIn(dt + timedelta(days=+1), pei_holidays)
 
     def test_yukon_heritage_day(self):
         # https://www.timeanddate.com/holidays/canada/heritage-day-yukon
@@ -70,8 +68,8 @@ class TestCA(unittest.TestCase):
             date(2022, 2, 25),
         ]:
             self.assertIn(dt, yt_holidays)
-            self.assertNotIn(dt + rd(days=-1), yt_holidays)
-            self.assertNotIn(dt + rd(days=+1), yt_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), yt_holidays)
+            self.assertNotIn(dt + timedelta(days=+1), yt_holidays)
 
     def test_family_day(self):
         ab_holidays = holidays.CA(subdiv="AB")
@@ -140,8 +138,8 @@ class TestCA(unittest.TestCase):
         ]:
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, nl_holidays)
-            self.assertNotIn(dt + rd(days=-1), nl_holidays)
-            self.assertNotIn(dt + rd(days=+1), nl_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), nl_holidays)
+            self.assertNotIn(dt + timedelta(days=+1), nl_holidays)
 
     def test_good_friday(self):
         for dt in [
@@ -156,8 +154,8 @@ class TestCA(unittest.TestCase):
             date(2020, 4, 10),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_easter_monday(self):
         for dt in [
@@ -172,8 +170,8 @@ class TestCA(unittest.TestCase):
             date(2020, 4, 13),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_st_georges_day(self):
         nl_holidays = holidays.CA(subdiv="NL")
@@ -186,8 +184,8 @@ class TestCA(unittest.TestCase):
         ]:
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, nl_holidays)
-            self.assertNotIn(dt + rd(days=-1), nl_holidays)
-            self.assertNotIn(dt + rd(days=+1), nl_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), nl_holidays)
+            self.assertNotIn(dt + timedelta(days=+1), nl_holidays)
 
     def test_victoria_day(self):
         for dt in [
@@ -199,8 +197,8 @@ class TestCA(unittest.TestCase):
             date(2020, 5, 18),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_national_aboriginal_day(self):
         nt_holidays = holidays.CA(subdiv="NT")
@@ -209,8 +207,8 @@ class TestCA(unittest.TestCase):
             dt = date(year, 6, 21)
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, nt_holidays)
-            self.assertNotIn(dt + rd(days=-1), nt_holidays)
-            self.assertNotIn(dt + rd(days=+1), nt_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), nt_holidays)
+            self.assertNotIn(dt + timedelta(days=+1), nt_holidays)
 
     def test_st_jean_baptiste_day(self):
         qc_holidays = holidays.CA(subdiv="QC", observed=False)
@@ -219,8 +217,8 @@ class TestCA(unittest.TestCase):
             dt = date(year, 6, 24)
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, qc_holidays)
-            self.assertNotIn(dt + rd(days=-1), qc_holidays)
-            self.assertNotIn(dt + rd(days=+1), qc_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), qc_holidays)
+            self.assertNotIn(dt + timedelta(days=+1), qc_holidays)
         self.assertNotIn(date(2001, 6, 25), qc_holidays)
         qc_holidays.observed = True
         self.assertIn(date(2001, 6, 25), qc_holidays)
@@ -255,8 +253,8 @@ class TestCA(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 7, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(date(2006, 7, 3), self.holidays)
         self.assertNotIn(date(2007, 7, 2), self.holidays)
         self.holidays.observed = True
@@ -272,8 +270,8 @@ class TestCA(unittest.TestCase):
             dt = date(year, 7, 9)
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, nu_holidays)
-            self.assertNotIn(dt + rd(days=-1), nu_holidays)
-            self.assertNotIn(dt + rd(days=+1), nu_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), nu_holidays)
+            self.assertNotIn(dt + timedelta(days=+1), nu_holidays)
         self.assertNotIn(date(2017, 7, 10), nu_holidays)
         nu_holidays.observed = True
         self.assertIn(date(2017, 7, 10), nu_holidays)
@@ -305,8 +303,8 @@ class TestCA(unittest.TestCase):
             date(2015, 9, 7),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_national_day_for_truth_and_reconciliation(self):
         for dt in [
@@ -314,14 +312,14 @@ class TestCA(unittest.TestCase):
             date(2020, 9, 30),
         ]:
             self.assertNotIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
         mb_holidays = holidays.CA(subdiv="MB")
         for dt in [
             date(2021, 9, 30),
             date(2030, 9, 30),
         ]:
             self.assertIn(dt, mb_holidays)
-            self.assertNotIn(dt + rd(days=-1), mb_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), mb_holidays)
             self.assertNotIn(dt, self.holidays)
 
     def test_thanksgiving(self):
@@ -335,8 +333,8 @@ class TestCA(unittest.TestCase):
             date(2020, 10, 12),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             self.assertNotIn(dt, ns_holidays)
 
     def test_remembrance_day(self):
@@ -349,8 +347,8 @@ class TestCA(unittest.TestCase):
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, ab_holidays)
             self.assertIn(dt, nl_holidays)
-            self.assertNotIn(dt + rd(days=-1), nl_holidays)
-            self.assertNotIn(dt + rd(days=+1), nl_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), nl_holidays)
+            self.assertNotIn(dt + timedelta(days=+1), nl_holidays)
         self.assertNotIn(date(2007, 11, 12), ab_holidays)
         self.assertNotIn(date(2007, 11, 12), nl_holidays)
         ab_holidays.observed = True
@@ -363,7 +361,7 @@ class TestCA(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.assertNotEqual(
             self.holidays[date(2011, 12, 26)], "Christmas Day (Observed)"
@@ -378,7 +376,7 @@ class TestCA(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(date(2009, 12, 28), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_canada.py
+++ b/test/countries/test_canada.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -32,8 +33,8 @@ class TestCA(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_islander_day(self):
         pei_holidays = holidays.CA(subdiv="PE")
@@ -53,8 +54,8 @@ class TestCA(unittest.TestCase):
             elif dt.year == 2009:
                 self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, pei_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), pei_holidays)
-            self.assertNotIn(dt + timedelta(days=+1), pei_holidays)
+            self.assertNotIn(dt + td(days=-1), pei_holidays)
+            self.assertNotIn(dt + td(days=+1), pei_holidays)
 
     def test_yukon_heritage_day(self):
         # https://www.timeanddate.com/holidays/canada/heritage-day-yukon
@@ -68,8 +69,8 @@ class TestCA(unittest.TestCase):
             date(2022, 2, 25),
         ]:
             self.assertIn(dt, yt_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), yt_holidays)
-            self.assertNotIn(dt + timedelta(days=+1), yt_holidays)
+            self.assertNotIn(dt + td(days=-1), yt_holidays)
+            self.assertNotIn(dt + td(days=+1), yt_holidays)
 
     def test_family_day(self):
         ab_holidays = holidays.CA(subdiv="AB")
@@ -138,8 +139,8 @@ class TestCA(unittest.TestCase):
         ]:
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, nl_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), nl_holidays)
-            self.assertNotIn(dt + timedelta(days=+1), nl_holidays)
+            self.assertNotIn(dt + td(days=-1), nl_holidays)
+            self.assertNotIn(dt + td(days=+1), nl_holidays)
 
     def test_good_friday(self):
         for dt in [
@@ -154,8 +155,8 @@ class TestCA(unittest.TestCase):
             date(2020, 4, 10),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_easter_monday(self):
         for dt in [
@@ -170,8 +171,8 @@ class TestCA(unittest.TestCase):
             date(2020, 4, 13),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_st_georges_day(self):
         nl_holidays = holidays.CA(subdiv="NL")
@@ -184,8 +185,8 @@ class TestCA(unittest.TestCase):
         ]:
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, nl_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), nl_holidays)
-            self.assertNotIn(dt + timedelta(days=+1), nl_holidays)
+            self.assertNotIn(dt + td(days=-1), nl_holidays)
+            self.assertNotIn(dt + td(days=+1), nl_holidays)
 
     def test_victoria_day(self):
         for dt in [
@@ -197,8 +198,8 @@ class TestCA(unittest.TestCase):
             date(2020, 5, 18),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_national_aboriginal_day(self):
         nt_holidays = holidays.CA(subdiv="NT")
@@ -207,8 +208,8 @@ class TestCA(unittest.TestCase):
             dt = date(year, 6, 21)
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, nt_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), nt_holidays)
-            self.assertNotIn(dt + timedelta(days=+1), nt_holidays)
+            self.assertNotIn(dt + td(days=-1), nt_holidays)
+            self.assertNotIn(dt + td(days=+1), nt_holidays)
 
     def test_st_jean_baptiste_day(self):
         qc_holidays = holidays.CA(subdiv="QC", observed=False)
@@ -217,8 +218,8 @@ class TestCA(unittest.TestCase):
             dt = date(year, 6, 24)
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, qc_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), qc_holidays)
-            self.assertNotIn(dt + timedelta(days=+1), qc_holidays)
+            self.assertNotIn(dt + td(days=-1), qc_holidays)
+            self.assertNotIn(dt + td(days=+1), qc_holidays)
         self.assertNotIn(date(2001, 6, 25), qc_holidays)
         qc_holidays.observed = True
         self.assertIn(date(2001, 6, 25), qc_holidays)
@@ -253,8 +254,8 @@ class TestCA(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 7, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(date(2006, 7, 3), self.holidays)
         self.assertNotIn(date(2007, 7, 2), self.holidays)
         self.holidays.observed = True
@@ -270,8 +271,8 @@ class TestCA(unittest.TestCase):
             dt = date(year, 7, 9)
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, nu_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), nu_holidays)
-            self.assertNotIn(dt + timedelta(days=+1), nu_holidays)
+            self.assertNotIn(dt + td(days=-1), nu_holidays)
+            self.assertNotIn(dt + td(days=+1), nu_holidays)
         self.assertNotIn(date(2017, 7, 10), nu_holidays)
         nu_holidays.observed = True
         self.assertIn(date(2017, 7, 10), nu_holidays)
@@ -303,8 +304,8 @@ class TestCA(unittest.TestCase):
             date(2015, 9, 7),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_national_day_for_truth_and_reconciliation(self):
         for dt in [
@@ -312,14 +313,14 @@ class TestCA(unittest.TestCase):
             date(2020, 9, 30),
         ]:
             self.assertNotIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
         mb_holidays = holidays.CA(subdiv="MB")
         for dt in [
             date(2021, 9, 30),
             date(2030, 9, 30),
         ]:
             self.assertIn(dt, mb_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), mb_holidays)
+            self.assertNotIn(dt + td(days=-1), mb_holidays)
             self.assertNotIn(dt, self.holidays)
 
     def test_thanksgiving(self):
@@ -333,8 +334,8 @@ class TestCA(unittest.TestCase):
             date(2020, 10, 12),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertNotIn(dt, ns_holidays)
 
     def test_remembrance_day(self):
@@ -347,8 +348,8 @@ class TestCA(unittest.TestCase):
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, ab_holidays)
             self.assertIn(dt, nl_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), nl_holidays)
-            self.assertNotIn(dt + timedelta(days=+1), nl_holidays)
+            self.assertNotIn(dt + td(days=-1), nl_holidays)
+            self.assertNotIn(dt + td(days=+1), nl_holidays)
         self.assertNotIn(date(2007, 11, 12), ab_holidays)
         self.assertNotIn(date(2007, 11, 12), nl_holidays)
         ab_holidays.observed = True
@@ -361,7 +362,7 @@ class TestCA(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.assertNotEqual(
             self.holidays[date(2011, 12, 26)], "Christmas Day (Observed)"
@@ -376,7 +377,7 @@ class TestCA(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(date(2009, 12, 28), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_colombia.py
+++ b/test/countries/test_colombia.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 from holidays.constants import APR, AUG, DEC, JAN, JUL, JUN, MAR, MAY, NOV, OCT
@@ -25,7 +23,7 @@ class TestCO(unittest.TestCase):
     def _check_all_dates(self, year, expected_holidays):
         start_date = date(year, 1, 1)
         end_date = date(year, 12, 31)
-        delta = rd(days=+1)
+        delta = timedelta(days=+1)
 
         while start_date <= end_date:
             if start_date in expected_holidays:

--- a/test/countries/test_colombia.py
+++ b/test/countries/test_colombia.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 from holidays.constants import APR, AUG, DEC, JAN, JUL, JUN, MAR, MAY, NOV, OCT
@@ -23,7 +24,7 @@ class TestCO(unittest.TestCase):
     def _check_all_dates(self, year, expected_holidays):
         start_date = date(year, 1, 1)
         end_date = date(year, 12, 31)
-        delta = timedelta(days=+1)
+        delta = td(days=+1)
 
         while start_date <= end_date:
             if start_date in expected_holidays:

--- a/test/countries/test_cuba.py
+++ b/test/countries/test_cuba.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 from holidays.constants import APR, DEC, JAN, JUL, MAR, MAY, OCT
@@ -25,7 +23,7 @@ class TestCuba(unittest.TestCase):
     def _check_all_dates(self, year, expected_holidays):
         start_date = date(year, 1, 1)
         end_date = date(year, 12, 31)
-        delta = rd(days=+1)
+        delta = timedelta(days=+1)
 
         while start_date <= end_date:
             if start_date in expected_holidays:

--- a/test/countries/test_cuba.py
+++ b/test/countries/test_cuba.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 from holidays.constants import APR, DEC, JAN, JUL, MAR, MAY, OCT
@@ -23,7 +24,7 @@ class TestCuba(unittest.TestCase):
     def _check_all_dates(self, year, expected_holidays):
         start_date = date(year, 1, 1)
         end_date = date(year, 12, 31)
-        delta = timedelta(days=+1)
+        delta = td(days=+1)
 
         while start_date <= end_date:
             if start_date in expected_holidays:

--- a/test/countries/test_ireland.py
+++ b/test/countries/test_ireland.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -49,8 +47,8 @@ class TestIreland(unittest.TestCase):
             date(2020, 5, 4),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_st_stephens_day(self):
         # St. Stephen's Day
@@ -59,7 +57,7 @@ class TestIreland(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(date(2009, 12, 28), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_ireland.py
+++ b/test/countries/test_ireland.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -47,8 +48,8 @@ class TestIreland(unittest.TestCase):
             date(2020, 5, 4),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_st_stephens_day(self):
         # St. Stephen's Day
@@ -57,7 +58,7 @@ class TestIreland(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(date(2009, 12, 28), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_israel.py
+++ b/test/countries/test_israel.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -40,8 +41,8 @@ class TestIsrael(unittest.TestCase):
 
         # Postponed
         il_holidays = holidays.IL(years=[2017], observed=True)
-        official_memorial_day = date(2017, 4, 30) + timedelta(days=days_delta)
-        observed_memorial_day = date(2017, 5, 1) + timedelta(days=days_delta)
+        official_memorial_day = date(2017, 4, 30) + td(days=days_delta)
+        observed_memorial_day = date(2017, 5, 1) + td(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
         self.assertIn(observed_memorial_day, il_holidays)
@@ -51,8 +52,8 @@ class TestIsrael(unittest.TestCase):
 
         # Earlier
         il_holidays = holidays.IL(years=[2018], observed=True)
-        official_memorial_day = date(2018, 4, 19) + timedelta(days=days_delta)
-        observed_memorial_day = date(2018, 4, 18) + timedelta(days=days_delta)
+        official_memorial_day = date(2018, 4, 19) + td(days=days_delta)
+        observed_memorial_day = date(2018, 4, 18) + td(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
         self.assertIn(observed_memorial_day, il_holidays)
@@ -62,7 +63,7 @@ class TestIsrael(unittest.TestCase):
 
         # On time
         il_holidays = holidays.IL(years=[2020], observed=True)
-        official_memorial_day = date(2020, 4, 28) + timedelta(days=days_delta)
+        official_memorial_day = date(2020, 4, 28) + td(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
 
@@ -74,23 +75,23 @@ class TestIsrael(unittest.TestCase):
 
         # Postponed
         il_holidays = holidays.IL(years=[2017], observed=False)
-        official_memorial_day = date(2017, 4, 30) + timedelta(days=days_delta)
-        observed_memorial_day = date(2017, 5, 1) + timedelta(days=days_delta)
+        official_memorial_day = date(2017, 4, 30) + td(days=days_delta)
+        observed_memorial_day = date(2017, 5, 1) + td(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
         self.assertNotEqual(il_holidays[observed_memorial_day], "Memorial Day")
 
         # Earlier
         il_holidays = holidays.IL(years=[2018], observed=False)
-        official_memorial_day = date(2018, 4, 19) + timedelta(days=days_delta)
-        observed_memorial_day = date(2018, 4, 18) + timedelta(days=days_delta)
+        official_memorial_day = date(2018, 4, 19) + td(days=days_delta)
+        observed_memorial_day = date(2018, 4, 18) + td(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
         self.assertNotIn(observed_memorial_day, il_holidays)
 
         # On time
         il_holidays = holidays.IL(years=[2020], observed=False)
-        official_memorial_day = date(2020, 4, 28) + timedelta(days=days_delta)
+        official_memorial_day = date(2020, 4, 28) + td(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
 

--- a/test/countries/test_israel.py
+++ b/test/countries/test_israel.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -42,8 +40,8 @@ class TestIsrael(unittest.TestCase):
 
         # Postponed
         il_holidays = holidays.IL(years=[2017], observed=True)
-        official_memorial_day = date(2017, 4, 30) + rd(days=days_delta)
-        observed_memorial_day = date(2017, 5, 1) + rd(days=days_delta)
+        official_memorial_day = date(2017, 4, 30) + timedelta(days=days_delta)
+        observed_memorial_day = date(2017, 5, 1) + timedelta(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
         self.assertIn(observed_memorial_day, il_holidays)
@@ -53,8 +51,8 @@ class TestIsrael(unittest.TestCase):
 
         # Earlier
         il_holidays = holidays.IL(years=[2018], observed=True)
-        official_memorial_day = date(2018, 4, 19) + rd(days=days_delta)
-        observed_memorial_day = date(2018, 4, 18) + rd(days=days_delta)
+        official_memorial_day = date(2018, 4, 19) + timedelta(days=days_delta)
+        observed_memorial_day = date(2018, 4, 18) + timedelta(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
         self.assertIn(observed_memorial_day, il_holidays)
@@ -64,7 +62,7 @@ class TestIsrael(unittest.TestCase):
 
         # On time
         il_holidays = holidays.IL(years=[2020], observed=True)
-        official_memorial_day = date(2020, 4, 28) + rd(days=days_delta)
+        official_memorial_day = date(2020, 4, 28) + timedelta(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
 
@@ -76,23 +74,23 @@ class TestIsrael(unittest.TestCase):
 
         # Postponed
         il_holidays = holidays.IL(years=[2017], observed=False)
-        official_memorial_day = date(2017, 4, 30) + rd(days=days_delta)
-        observed_memorial_day = date(2017, 5, 1) + rd(days=days_delta)
+        official_memorial_day = date(2017, 4, 30) + timedelta(days=days_delta)
+        observed_memorial_day = date(2017, 5, 1) + timedelta(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
         self.assertNotEqual(il_holidays[observed_memorial_day], "Memorial Day")
 
         # Earlier
         il_holidays = holidays.IL(years=[2018], observed=False)
-        official_memorial_day = date(2018, 4, 19) + rd(days=days_delta)
-        observed_memorial_day = date(2018, 4, 18) + rd(days=days_delta)
+        official_memorial_day = date(2018, 4, 19) + timedelta(days=days_delta)
+        observed_memorial_day = date(2018, 4, 18) + timedelta(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
         self.assertNotIn(observed_memorial_day, il_holidays)
 
         # On time
         il_holidays = holidays.IL(years=[2020], observed=False)
-        official_memorial_day = date(2020, 4, 28) + rd(days=days_delta)
+        official_memorial_day = date(2020, 4, 28) + timedelta(days=days_delta)
         self.assertIn(official_memorial_day, il_holidays)
         self.assertIn(holiday_name, il_holidays[official_memorial_day])
 

--- a/test/countries/test_mexico.py
+++ b/test/countries/test_mexico.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -31,8 +29,8 @@ class TestMX(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_constitution_day(self):
         for dt in [
@@ -48,8 +46,8 @@ class TestMX(unittest.TestCase):
             date(2022, 2, 5),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.holidays.observed = True
         for dt in [
             date(2005, 2, 5),
@@ -89,8 +87,8 @@ class TestMX(unittest.TestCase):
             date(2024, 3, 21),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.holidays.observed = True
         for dt in [
             date(2005, 3, 21),
@@ -130,8 +128,8 @@ class TestMX(unittest.TestCase):
         for year in range(1923, 2100):
             dt = date(year, 5, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_independence_day(self):
         self.assertNotIn(date(2006, 9, 15), self.holidays)
@@ -143,8 +141,8 @@ class TestMX(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 9, 16)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_revolution_day(self):
         for dt in [
@@ -162,8 +160,8 @@ class TestMX(unittest.TestCase):
             date(2023, 11, 20),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.holidays.observed = True
         for dt in [
             date(2005, 11, 20),
@@ -190,8 +188,8 @@ class TestMX(unittest.TestCase):
             dt = date(year, 12, 1)
             if (year >= 1970) and ((2096 - year) % 6) == 0:
                 self.assertIn(dt, self.holidays)
-                self.assertNotIn(dt + rd(days=-1), self.holidays)
-                self.assertNotIn(dt + rd(days=+1), self.holidays)
+                self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+                self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             else:
                 self.assertNotIn(dt, self.holidays)
 
@@ -199,8 +197,8 @@ class TestMX(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(date(2010, 12, 24), self.holidays)
         self.assertNotIn(date(2016, 12, 26), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_mexico.py
+++ b/test/countries/test_mexico.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -29,8 +30,8 @@ class TestMX(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_constitution_day(self):
         for dt in [
@@ -46,8 +47,8 @@ class TestMX(unittest.TestCase):
             date(2022, 2, 5),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.holidays.observed = True
         for dt in [
             date(2005, 2, 5),
@@ -87,8 +88,8 @@ class TestMX(unittest.TestCase):
             date(2024, 3, 21),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.holidays.observed = True
         for dt in [
             date(2005, 3, 21),
@@ -128,8 +129,8 @@ class TestMX(unittest.TestCase):
         for year in range(1923, 2100):
             dt = date(year, 5, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_independence_day(self):
         self.assertNotIn(date(2006, 9, 15), self.holidays)
@@ -141,8 +142,8 @@ class TestMX(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 9, 16)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_revolution_day(self):
         for dt in [
@@ -160,8 +161,8 @@ class TestMX(unittest.TestCase):
             date(2023, 11, 20),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.holidays.observed = True
         for dt in [
             date(2005, 11, 20),
@@ -188,8 +189,8 @@ class TestMX(unittest.TestCase):
             dt = date(year, 12, 1)
             if (year >= 1970) and ((2096 - year) % 6) == 0:
                 self.assertIn(dt, self.holidays)
-                self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-                self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+                self.assertNotIn(dt + td(days=-1), self.holidays)
+                self.assertNotIn(dt + td(days=+1), self.holidays)
             else:
                 self.assertNotIn(dt, self.holidays)
 
@@ -197,8 +198,8 @@ class TestMX(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(date(2010, 12, 24), self.holidays)
         self.assertNotIn(date(2016, 12, 26), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_new_zealand.py
+++ b/test/countries/test_new_zealand.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -148,8 +149,8 @@ class TestNZ(unittest.TestCase):
             date(2020, 4, 10),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_easter_monday(self):
         for dt in [
@@ -163,8 +164,8 @@ class TestNZ(unittest.TestCase):
             date(2020, 4, 13),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_anzac_day(self):
         for year in range(1900, 1921):
@@ -282,8 +283,8 @@ class TestNZ(unittest.TestCase):
         ]:
             self.assertIn(dt, self.holidays)
             self.assertEqual(self.holidays[dt], "Matariki")
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_labour_day(self):
         for year, day in enumerate(
@@ -321,7 +322,7 @@ class TestNZ(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
         self.assertNotIn(date(2010, 12, 24), self.holidays)
         self.assertNotEqual(
             self.holidays[date(2011, 12, 26)], "Christmas Day (Observed)"
@@ -365,7 +366,7 @@ class TestNZ(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(date(2009, 12, 28), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_new_zealand.py
+++ b/test/countries/test_new_zealand.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -150,8 +148,8 @@ class TestNZ(unittest.TestCase):
             date(2020, 4, 10),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_easter_monday(self):
         for dt in [
@@ -165,8 +163,8 @@ class TestNZ(unittest.TestCase):
             date(2020, 4, 13),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_anzac_day(self):
         for year in range(1900, 1921):
@@ -284,8 +282,8 @@ class TestNZ(unittest.TestCase):
         ]:
             self.assertIn(dt, self.holidays)
             self.assertEqual(self.holidays[dt], "Matariki")
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_labour_day(self):
         for year, day in enumerate(
@@ -323,7 +321,7 @@ class TestNZ(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
         self.assertNotIn(date(2010, 12, 24), self.holidays)
         self.assertNotEqual(
             self.holidays[date(2011, 12, 26)], "Christmas Day (Observed)"
@@ -367,7 +365,7 @@ class TestNZ(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(date(2009, 12, 28), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_pakistan.py
+++ b/test/countries/test_pakistan.py
@@ -9,9 +9,7 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 from holidays.countries.pakistan import Pakistan, PK, PAK
 from test.common import TestCase
@@ -86,8 +84,8 @@ class TestPakistan(TestCase):
             date(2023, 4, 21),
         ):
             self.assertHoliday(dt)
-            self.assertHoliday(dt + rd(days=+1))
-            self.assertHoliday(dt + rd(days=+2))
+            self.assertHoliday(dt + timedelta(days=+1))
+            self.assertHoliday(dt + timedelta(days=+2))
             self.assertIn(name, self.holidays.get(dt))
 
     def test_eid_ul_adha(self):
@@ -109,8 +107,8 @@ class TestPakistan(TestCase):
             date(2023, 6, 28),
         ):
             self.assertHoliday(dt)
-            self.assertHoliday(dt + rd(days=+1))
-            self.assertHoliday(dt + rd(days=+2))
+            self.assertHoliday(dt + timedelta(days=+1))
+            self.assertHoliday(dt + timedelta(days=+2))
             self.assertIn(name, self.holidays.get(dt))
 
     def test_eid_milad_un_nabi(self):
@@ -153,5 +151,5 @@ class TestPakistan(TestCase):
             date(2023, 7, 28),
         ):
             self.assertHoliday(dt)
-            self.assertHoliday(dt + rd(days=+1))
+            self.assertHoliday(dt + timedelta(days=+1))
             self.assertIn(name, self.holidays.get(dt))

--- a/test/countries/test_pakistan.py
+++ b/test/countries/test_pakistan.py
@@ -9,7 +9,8 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from holidays.countries.pakistan import Pakistan, PK, PAK
 from test.common import TestCase
@@ -84,8 +85,8 @@ class TestPakistan(TestCase):
             date(2023, 4, 21),
         ):
             self.assertHoliday(dt)
-            self.assertHoliday(dt + timedelta(days=+1))
-            self.assertHoliday(dt + timedelta(days=+2))
+            self.assertHoliday(dt + td(days=+1))
+            self.assertHoliday(dt + td(days=+2))
             self.assertIn(name, self.holidays.get(dt))
 
     def test_eid_ul_adha(self):
@@ -107,8 +108,8 @@ class TestPakistan(TestCase):
             date(2023, 6, 28),
         ):
             self.assertHoliday(dt)
-            self.assertHoliday(dt + timedelta(days=+1))
-            self.assertHoliday(dt + timedelta(days=+2))
+            self.assertHoliday(dt + td(days=+1))
+            self.assertHoliday(dt + td(days=+2))
             self.assertIn(name, self.holidays.get(dt))
 
     def test_eid_milad_un_nabi(self):
@@ -151,5 +152,5 @@ class TestPakistan(TestCase):
             date(2023, 7, 28),
         ):
             self.assertHoliday(dt)
-            self.assertHoliday(dt + timedelta(days=+1))
+            self.assertHoliday(dt + td(days=+1))
             self.assertIn(name, self.holidays.get(dt))

--- a/test/countries/test_paraguay.py
+++ b/test/countries/test_paraguay.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -152,7 +153,7 @@ class TestParaguay(unittest.TestCase):
             (2022, 4, 17),
         ]:
             easter = date(year, month, day)
-            easter_thursday = easter + timedelta(days=-3)
-            easter_friday = easter + timedelta(days=-2)
+            easter_thursday = easter + td(days=-3)
+            easter_friday = easter + td(days=-2)
             for holiday in [easter_thursday, easter_friday, easter]:
                 self.assertIn(holiday, self.holidays)

--- a/test/countries/test_paraguay.py
+++ b/test/countries/test_paraguay.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -154,7 +152,7 @@ class TestParaguay(unittest.TestCase):
             (2022, 4, 17),
         ]:
             easter = date(year, month, day)
-            easter_thursday = easter + rd(days=-3)
-            easter_friday = easter + rd(days=-2)
+            easter_thursday = easter + timedelta(days=-3)
+            easter_friday = easter + timedelta(days=-2)
             for holiday in [easter_thursday, easter_friday, easter]:
                 self.assertIn(holiday, self.holidays)

--- a/test/countries/test_united_kingdom.py
+++ b/test/countries/test_united_kingdom.py
@@ -10,7 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.relativedelta import relativedelta as rd
 
@@ -44,9 +44,9 @@ class TestUK(unittest.TestCase):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
             if year == 2000:
-                self.assertIn(dt + rd(days=-1), self.holidays)
+                self.assertIn(dt + timedelta(days=-1), self.holidays)
             else:
-                self.assertNotIn(dt + rd(days=-1), self.holidays)
+                self.assertNotIn(dt + timedelta(days=-1), self.holidays)
 
     def test_good_friday(self):
         for dt in [
@@ -61,8 +61,8 @@ class TestUK(unittest.TestCase):
             date(2020, 4, 10),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_easter_monday(self):
         for dt in [
@@ -77,8 +77,8 @@ class TestUK(unittest.TestCase):
             date(2020, 4, 13),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_royal_weddings(self):
         for dt in [date(1981, 7, 29), date(2011, 4, 29)]:
@@ -119,8 +119,8 @@ class TestUK(unittest.TestCase):
             date(2020, 5, 8),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(date(2020, 5, 4), self.holidays)
 
     def test_spring_bank_holiday(self):
@@ -137,16 +137,16 @@ class TestUK(unittest.TestCase):
             date(2022, 6, 2),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
             if dt != date(2022, 6, 2):
-                self.assertNotIn(dt + rd(days=+1), self.holidays)
+                self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_christmas_day(self):
         self.holidays.observed = False
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
         self.assertNotIn(date(2010, 12, 24), self.holidays)
         self.assertNotEqual(
             self.holidays[date(2011, 12, 26)], "Christmas Day (Observed)"
@@ -191,7 +191,7 @@ class TestUK(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(date(2009, 12, 28), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_united_kingdom.py
+++ b/test/countries/test_united_kingdom.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.relativedelta import relativedelta as rd
 
@@ -44,9 +45,9 @@ class TestUK(unittest.TestCase):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
             if year == 2000:
-                self.assertIn(dt + timedelta(days=-1), self.holidays)
+                self.assertIn(dt + td(days=-1), self.holidays)
             else:
-                self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+                self.assertNotIn(dt + td(days=-1), self.holidays)
 
     def test_good_friday(self):
         for dt in [
@@ -61,8 +62,8 @@ class TestUK(unittest.TestCase):
             date(2020, 4, 10),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_easter_monday(self):
         for dt in [
@@ -77,8 +78,8 @@ class TestUK(unittest.TestCase):
             date(2020, 4, 13),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_royal_weddings(self):
         for dt in [date(1981, 7, 29), date(2011, 4, 29)]:
@@ -119,8 +120,8 @@ class TestUK(unittest.TestCase):
             date(2020, 5, 8),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(date(2020, 5, 4), self.holidays)
 
     def test_spring_bank_holiday(self):
@@ -137,16 +138,16 @@ class TestUK(unittest.TestCase):
             date(2022, 6, 2),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
             if dt != date(2022, 6, 2):
-                self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+                self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_christmas_day(self):
         self.holidays.observed = False
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
         self.assertNotIn(date(2010, 12, 24), self.holidays)
         self.assertNotEqual(
             self.holidays[date(2011, 12, 26)], "Christmas Day (Observed)"
@@ -191,7 +192,7 @@ class TestUK(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(date(2009, 12, 28), self.holidays)
         self.assertNotIn(date(2010, 12, 27), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_united_states.py
+++ b/test/countries/test_united_states.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 from holidays.constants import SAT, SUN
@@ -30,8 +31,8 @@ class TestUS(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_Juneteenth_day(self):
 
@@ -118,8 +119,8 @@ class TestUS(unittest.TestCase):
             date(2020, 1, 20),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(
             "Martin Luther King Jr. Day", holidays.US(years=[1985]).values()
         )
@@ -286,8 +287,8 @@ class TestUS(unittest.TestCase):
             date(2020, 2, 17),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertNotIn(dt, de_holidays)
             self.assertNotEqual(fl_holidays.get(dt), "Washington's Birthday")
             self.assertNotIn(dt, ga_holidays)
@@ -620,8 +621,8 @@ class TestUS(unittest.TestCase):
             dt = date(year, 5, 8)
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, mo_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), mo_holidays)
-            self.assertNotIn(dt + timedelta(days=+1), mo_holidays)
+            self.assertNotIn(dt + td(days=-1), mo_holidays)
+            self.assertNotIn(dt + td(days=+1), mo_holidays)
         self.assertNotIn(date(2004, 5, 7), mo_holidays)
         self.assertNotIn(date(2005, 5, 9), mo_holidays)
         mo_holidays.observed = True
@@ -644,8 +645,8 @@ class TestUS(unittest.TestCase):
             date(2020, 5, 25),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_jefferson_davis_birthday(self):
         al_holidays = holidays.US(subdiv="AL")
@@ -724,8 +725,8 @@ class TestUS(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 7, 4)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(date(2010, 7, 5), self.holidays)
         self.assertNotIn(date(2020, 7, 3), self.holidays)
         self.holidays.observed = True
@@ -841,8 +842,8 @@ class TestUS(unittest.TestCase):
             date(2020, 9, 7),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_columbus_day(self):
         ak_holidays = holidays.US(subdiv="AK")
@@ -867,8 +868,8 @@ class TestUS(unittest.TestCase):
             self.assertNotIn(dt, de_holidays)
             self.assertNotIn(dt, fl_holidays)
             self.assertNotIn(dt, hi_holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertEqual(sd_holidays.get(dt), "Native American Day")
             self.assertEqual(
                 vi_holidays.get(dt),
@@ -986,8 +987,8 @@ class TestUS(unittest.TestCase):
             date(2020, 11, 11),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn("Armistice Day", holidays.US(years=[1937]).values())
         self.assertNotIn("Armistice Day", holidays.US(years=[1937]).values())
         self.assertIn("Armistice Day", holidays.US(years=[1938]).values())
@@ -1034,66 +1035,64 @@ class TestUS(unittest.TestCase):
             date(2020, 11, 26),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertIn(dt + timedelta(days=+1), de_holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertIn(dt + td(days=+1), de_holidays)
             self.assertEqual(
-                ca_holidays.get(dt + timedelta(days=+1)),
+                ca_holidays.get(dt + td(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                de_holidays.get(dt + timedelta(days=+1)),
+                de_holidays.get(dt + td(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                nh_holidays.get(dt + timedelta(days=+1)),
+                nh_holidays.get(dt + td(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                nc_holidays.get(dt + timedelta(days=+1)),
+                nc_holidays.get(dt + td(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                ok_holidays.get(dt + timedelta(days=+1)),
+                ok_holidays.get(dt + td(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                pa_holidays.get(dt + timedelta(days=+1)),
+                pa_holidays.get(dt + td(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                wv_holidays.get(dt + timedelta(days=+1)),
+                wv_holidays.get(dt + td(days=+1)),
                 "Day After Thanksgiving",
             )
-            self.assertIn(dt + timedelta(days=+1), fl_holidays)
+            self.assertIn(dt + td(days=+1), fl_holidays)
             self.assertEqual(
-                fl_holidays.get(dt + timedelta(days=+1)),
+                fl_holidays.get(dt + td(days=+1)),
                 "Friday After Thanksgiving",
             )
-            self.assertIn(dt + timedelta(days=+1), tx_holidays)
+            self.assertIn(dt + td(days=+1), tx_holidays)
             self.assertEqual(
-                tx_holidays.get(dt + timedelta(days=+1)),
+                tx_holidays.get(dt + td(days=+1)),
                 "Friday After Thanksgiving",
             )
+            self.assertEqual(nv_holidays.get(dt + td(days=+1)), "Family Day")
             self.assertEqual(
-                nv_holidays.get(dt + timedelta(days=+1)), "Family Day"
-            )
-            self.assertEqual(
-                nm_holidays.get(dt + timedelta(days=+1)), "Presidents' Day"
+                nm_holidays.get(dt + td(days=+1)), "Presidents' Day"
             )
             if dt.year >= 2008:
                 self.assertEqual(
-                    md_holidays.get(dt + timedelta(days=+1)),
+                    md_holidays.get(dt + td(days=+1)),
                     "American Indian Heritage Day",
                 )
             if dt.year >= 2010:
                 self.assertEqual(
-                    in_holidays.get(dt + timedelta(days=+1)),
+                    in_holidays.get(dt + td(days=+1)),
                     "Lincoln's Birthday",
                 )
             else:
                 self.assertNotEqual(
-                    in_holidays.get(dt + timedelta(days=+1)),
+                    in_holidays.get(dt + td(days=+1)),
                     "Lincoln's Birthday",
                 )
 
@@ -1190,8 +1189,8 @@ class TestUS(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
         self.assertNotIn(date(2010, 12, 24), self.holidays)
         self.assertNotIn(date(2016, 12, 26), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_united_states.py
+++ b/test/countries/test_united_states.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 from holidays.constants import SAT, SUN
@@ -32,8 +30,8 @@ class TestUS(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_Juneteenth_day(self):
 
@@ -120,8 +118,8 @@ class TestUS(unittest.TestCase):
             date(2020, 1, 20),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(
             "Martin Luther King Jr. Day", holidays.US(years=[1985]).values()
         )
@@ -288,8 +286,8 @@ class TestUS(unittest.TestCase):
             date(2020, 2, 17),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             self.assertNotIn(dt, de_holidays)
             self.assertNotEqual(fl_holidays.get(dt), "Washington's Birthday")
             self.assertNotIn(dt, ga_holidays)
@@ -622,8 +620,8 @@ class TestUS(unittest.TestCase):
             dt = date(year, 5, 8)
             self.assertNotIn(dt, self.holidays)
             self.assertIn(dt, mo_holidays)
-            self.assertNotIn(dt + rd(days=-1), mo_holidays)
-            self.assertNotIn(dt + rd(days=+1), mo_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), mo_holidays)
+            self.assertNotIn(dt + timedelta(days=+1), mo_holidays)
         self.assertNotIn(date(2004, 5, 7), mo_holidays)
         self.assertNotIn(date(2005, 5, 9), mo_holidays)
         mo_holidays.observed = True
@@ -646,8 +644,8 @@ class TestUS(unittest.TestCase):
             date(2020, 5, 25),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_jefferson_davis_birthday(self):
         al_holidays = holidays.US(subdiv="AL")
@@ -726,8 +724,8 @@ class TestUS(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 7, 4)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(date(2010, 7, 5), self.holidays)
         self.assertNotIn(date(2020, 7, 3), self.holidays)
         self.holidays.observed = True
@@ -843,8 +841,8 @@ class TestUS(unittest.TestCase):
             date(2020, 9, 7),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_columbus_day(self):
         ak_holidays = holidays.US(subdiv="AK")
@@ -869,8 +867,8 @@ class TestUS(unittest.TestCase):
             self.assertNotIn(dt, de_holidays)
             self.assertNotIn(dt, fl_holidays)
             self.assertNotIn(dt, hi_holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             self.assertEqual(sd_holidays.get(dt), "Native American Day")
             self.assertEqual(
                 vi_holidays.get(dt),
@@ -988,8 +986,8 @@ class TestUS(unittest.TestCase):
             date(2020, 11, 11),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn("Armistice Day", holidays.US(years=[1937]).values())
         self.assertNotIn("Armistice Day", holidays.US(years=[1937]).values())
         self.assertIn("Armistice Day", holidays.US(years=[1938]).values())
@@ -1036,64 +1034,66 @@ class TestUS(unittest.TestCase):
             date(2020, 11, 26),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertIn(dt + rd(days=+1), de_holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertIn(dt + timedelta(days=+1), de_holidays)
             self.assertEqual(
-                ca_holidays.get(dt + rd(days=+1)),
+                ca_holidays.get(dt + timedelta(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                de_holidays.get(dt + rd(days=+1)),
+                de_holidays.get(dt + timedelta(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                nh_holidays.get(dt + rd(days=+1)),
+                nh_holidays.get(dt + timedelta(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                nc_holidays.get(dt + rd(days=+1)),
+                nc_holidays.get(dt + timedelta(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                ok_holidays.get(dt + rd(days=+1)),
+                ok_holidays.get(dt + timedelta(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                pa_holidays.get(dt + rd(days=+1)),
+                pa_holidays.get(dt + timedelta(days=+1)),
                 "Day After Thanksgiving",
             )
             self.assertEqual(
-                wv_holidays.get(dt + rd(days=+1)),
+                wv_holidays.get(dt + timedelta(days=+1)),
                 "Day After Thanksgiving",
             )
-            self.assertIn(dt + rd(days=+1), fl_holidays)
+            self.assertIn(dt + timedelta(days=+1), fl_holidays)
             self.assertEqual(
-                fl_holidays.get(dt + rd(days=+1)),
+                fl_holidays.get(dt + timedelta(days=+1)),
                 "Friday After Thanksgiving",
             )
-            self.assertIn(dt + rd(days=+1), tx_holidays)
+            self.assertIn(dt + timedelta(days=+1), tx_holidays)
             self.assertEqual(
-                tx_holidays.get(dt + rd(days=+1)),
+                tx_holidays.get(dt + timedelta(days=+1)),
                 "Friday After Thanksgiving",
             )
-            self.assertEqual(nv_holidays.get(dt + rd(days=+1)), "Family Day")
             self.assertEqual(
-                nm_holidays.get(dt + rd(days=+1)), "Presidents' Day"
+                nv_holidays.get(dt + timedelta(days=+1)), "Family Day"
+            )
+            self.assertEqual(
+                nm_holidays.get(dt + timedelta(days=+1)), "Presidents' Day"
             )
             if dt.year >= 2008:
                 self.assertEqual(
-                    md_holidays.get(dt + rd(days=+1)),
+                    md_holidays.get(dt + timedelta(days=+1)),
                     "American Indian Heritage Day",
                 )
             if dt.year >= 2010:
                 self.assertEqual(
-                    in_holidays.get(dt + rd(days=+1)),
+                    in_holidays.get(dt + timedelta(days=+1)),
                     "Lincoln's Birthday",
                 )
             else:
                 self.assertNotEqual(
-                    in_holidays.get(dt + rd(days=+1)),
+                    in_holidays.get(dt + timedelta(days=+1)),
                     "Lincoln's Birthday",
                 )
 
@@ -1190,8 +1190,8 @@ class TestUS(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
         self.assertNotIn(date(2010, 12, 24), self.holidays)
         self.assertNotIn(date(2016, 12, 26), self.holidays)
         self.holidays.observed = True

--- a/test/countries/test_uruguay.py
+++ b/test/countries/test_uruguay.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -32,8 +30,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             self.assertEqual(self.holidays[dt], "Año Nuevo [New Year's Day]")
 
     def test_labor_day(self):
@@ -45,8 +43,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 5, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt],
                 "Día de los Trabajadores [International Workers' Day]",
@@ -56,8 +54,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 7, 18)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt], "Jura de la Constitución [Constitution Day]"
             )
@@ -66,8 +64,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 8, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt], "Día de la Independencia [Independence Day]"
             )
@@ -76,8 +74,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt], "Día de la Familia [Day of the Family]"
             )
@@ -97,8 +95,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 6, 19)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt],
                 "Natalicio de José Gervasio Artigas "
@@ -109,8 +107,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 11, 2)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt], "Día de los Difuntos [All Souls' Day]"
             )

--- a/test/countries/test_uruguay.py
+++ b/test/countries/test_uruguay.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -30,8 +31,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertEqual(self.holidays[dt], "Año Nuevo [New Year's Day]")
 
     def test_labor_day(self):
@@ -43,8 +44,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 5, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt],
                 "Día de los Trabajadores [International Workers' Day]",
@@ -54,8 +55,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 7, 18)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt], "Jura de la Constitución [Constitution Day]"
             )
@@ -64,8 +65,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 8, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt], "Día de la Independencia [Independence Day]"
             )
@@ -74,8 +75,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt], "Día de la Familia [Day of the Family]"
             )
@@ -95,8 +96,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 6, 19)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt],
                 "Natalicio de José Gervasio Artigas "
@@ -107,8 +108,8 @@ class TestUY(unittest.TestCase):
         for year in range(1900, 2100):
             dt = date(year, 11, 2)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertEqual(
                 self.holidays[dt], "Día de los Difuntos [All Souls' Day]"
             )

--- a/test/countries/test_venezuela.py
+++ b/test/countries/test_venezuela.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, OCT, DEC
@@ -25,7 +23,7 @@ class TestVenezuela(unittest.TestCase):
     def _check_all_dates(self, year, expected_holidays):
         start_date = date(year, 1, 1)
         end_date = date(year, 12, 31)
-        delta = rd(days=+1)
+        delta = timedelta(days=+1)
 
         while start_date <= end_date:
             if start_date in expected_holidays:

--- a/test/countries/test_venezuela.py
+++ b/test/countries/test_venezuela.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, OCT, DEC
@@ -23,7 +24,7 @@ class TestVenezuela(unittest.TestCase):
     def _check_all_dates(self, year, expected_holidays):
         start_date = date(year, 1, 1)
         end_date = date(year, 12, 31)
-        delta = timedelta(days=+1)
+        delta = td(days=+1)
 
         while start_date <= end_date:
             if start_date in expected_holidays:

--- a/test/countries/test_vietnam.py
+++ b/test/countries/test_vietnam.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -51,7 +49,7 @@ class TestVietnam(unittest.TestCase):
             (2022, 2, 1),
         ):
             self.assertEqual(
-                self.holidays[date(year, month, day) + rd(days=-1)],
+                self.holidays[date(year, month, day) + timedelta(days=-1)],
                 "Vietnamese New Year's Eve",
             )
             self.assertEqual(
@@ -59,19 +57,19 @@ class TestVietnam(unittest.TestCase):
                 "Vietnamese New Year",
             )
             self.assertEqual(
-                self.holidays[date(year, month, day) + rd(days=+1)],
+                self.holidays[date(year, month, day) + timedelta(days=+1)],
                 "The second day of Tet Holiday",
             )
             self.assertEqual(
-                self.holidays[date(year, month, day) + rd(days=+2)],
+                self.holidays[date(year, month, day) + timedelta(days=+2)],
                 "The third day of Tet Holiday",
             )
             self.assertEqual(
-                self.holidays[date(year, month, day) + rd(days=+3)],
+                self.holidays[date(year, month, day) + timedelta(days=+3)],
                 "The forth day of Tet Holiday",
             )
             self.assertEqual(
-                self.holidays[date(year, month, day) + rd(days=+4)],
+                self.holidays[date(year, month, day) + timedelta(days=+4)],
                 "The fifth day of Tet Holiday",
             )
 

--- a/test/countries/test_vietnam.py
+++ b/test/countries/test_vietnam.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -49,7 +50,7 @@ class TestVietnam(unittest.TestCase):
             (2022, 2, 1),
         ):
             self.assertEqual(
-                self.holidays[date(year, month, day) + timedelta(days=-1)],
+                self.holidays[date(year, month, day) + td(days=-1)],
                 "Vietnamese New Year's Eve",
             )
             self.assertEqual(
@@ -57,19 +58,19 @@ class TestVietnam(unittest.TestCase):
                 "Vietnamese New Year",
             )
             self.assertEqual(
-                self.holidays[date(year, month, day) + timedelta(days=+1)],
+                self.holidays[date(year, month, day) + td(days=+1)],
                 "The second day of Tet Holiday",
             )
             self.assertEqual(
-                self.holidays[date(year, month, day) + timedelta(days=+2)],
+                self.holidays[date(year, month, day) + td(days=+2)],
                 "The third day of Tet Holiday",
             )
             self.assertEqual(
-                self.holidays[date(year, month, day) + timedelta(days=+3)],
+                self.holidays[date(year, month, day) + td(days=+3)],
                 "The forth day of Tet Holiday",
             )
             self.assertEqual(
-                self.holidays[date(year, month, day) + timedelta(days=+4)],
+                self.holidays[date(year, month, day) + td(days=+4)],
                 "The fifth day of Tet Holiday",
             )
 

--- a/test/financial/test_european_central_bank.py
+++ b/test/financial/test_european_central_bank.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 import holidays
 
@@ -23,7 +24,7 @@ class TestTAR(unittest.TestCase):
         for year in range(1974, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
 
     def test_good_friday(self):
         for dt in [
@@ -38,8 +39,8 @@ class TestTAR(unittest.TestCase):
             date(2020, 4, 10),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_easter_monday(self):
         for dt in [
@@ -54,27 +55,27 @@ class TestTAR(unittest.TestCase):
             date(2020, 4, 13),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_labour_day(self):
         for year in range(1900, 2100):
             dt = date(year, 5, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_christmas_day(self):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
 
     def test_26_december_day(self):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_all_holidays_present(self):
         tar_2015 = holidays.TAR(years=[2015])

--- a/test/financial/test_european_central_bank.py
+++ b/test/financial/test_european_central_bank.py
@@ -10,9 +10,7 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
-
-from dateutil.relativedelta import relativedelta as rd
+from datetime import date, timedelta
 
 import holidays
 
@@ -25,7 +23,7 @@ class TestTAR(unittest.TestCase):
         for year in range(1974, 2100):
             dt = date(year, 1, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
 
     def test_good_friday(self):
         for dt in [
@@ -40,8 +38,8 @@ class TestTAR(unittest.TestCase):
             date(2020, 4, 10),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_easter_monday(self):
         for dt in [
@@ -56,27 +54,27 @@ class TestTAR(unittest.TestCase):
             date(2020, 4, 13),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_labour_day(self):
         for year in range(1900, 2100):
             dt = date(year, 5, 1)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_christmas_day(self):
         for year in range(1900, 2100):
             dt = date(year, 12, 25)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
 
     def test_26_december_day(self):
         for year in range(1900, 2100):
             dt = date(year, 12, 26)
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_all_holidays_present(self):
         tar_2015 = holidays.TAR(years=[2015])

--- a/test/financial/test_ny_stock_exchange.py
+++ b/test/financial/test_ny_stock_exchange.py
@@ -10,10 +10,9 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date
+from datetime import date, timedelta
 
 from dateutil.relativedelta import WE
-from dateutil.relativedelta import relativedelta as rd
 
 import holidays
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP
@@ -40,9 +39,9 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2027, DEC, 31),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
 
     def test_mlk(self):
         for dt in [
@@ -56,10 +55,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, JAN, 17),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
         for dt in [
             date(1997, JAN, 20),
@@ -75,10 +74,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1968, FEB, 12),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
         for dt in [
             date(1954, FEB, 12),
@@ -110,10 +109,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, FEB, 21),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
     def test_good_friday(self):
         for dt in [
@@ -130,10 +129,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, APR, 15),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
     def test_memday(self):
         for dt in [
@@ -154,10 +153,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, MAY, 30),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
     def test_flagday(self):
         for dt in [
@@ -169,10 +168,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1953, JUN, 15),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
         for dt in [
             date(1954, JUN, 14),
@@ -187,10 +186,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, JUN, 20),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
         for dt in [
             date(1954, JUN, 18),
@@ -214,10 +213,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, SEP, 5),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
         for dt in [
             date(1886, SEP, 6),
@@ -234,10 +233,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1953, OCT, 12),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
         for dt in [
             date(1908, OCT, 12),
@@ -260,9 +259,9 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1980, NOV, 4),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
         for dt in [
             date(1969, NOV, 4),
@@ -292,10 +291,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1953, NOV, 11),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
         for dt in [
             date(1917, NOV, 12),
@@ -324,10 +323,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, NOV, 24),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=+7), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
     def test_christmas_day(self):
         for dt in [
@@ -344,9 +343,9 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, DEC, 26),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
-            self.assertNotIn(dt + rd(days=-7), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
 
     def test_special_holidays(self):
         # add to this list as new historical holidays are added
@@ -420,7 +419,8 @@ class TestNewYorkStockExchange(unittest.TestCase):
         def _make_special_holiday_list(begin, end, days=None, weekends=False):
             _list = []
             for d in (
-                begin + rd(days=n) for n in range((end - begin).days + 1)
+                begin + timedelta(days=n)
+                for n in range((end - begin).days + 1)
             ):
                 if not weekends and d.weekday() in {SAT, SUN}:
                     continue
@@ -453,14 +453,14 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1968, JUN, 12),  # begin paper crisis holidays
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=-1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
 
         for dt in [
             date(1914, NOV, 27),  # end WWI holidays
             date(1933, MAR, 14),  # end oneoff bank holidays
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + rd(days=+1), self.holidays)
+            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
 
     def test_all_modern_holidays_present(self):
         nyse_2021 = holidays.NewYorkStockExchange(years=[2021])

--- a/test/financial/test_ny_stock_exchange.py
+++ b/test/financial/test_ny_stock_exchange.py
@@ -10,7 +10,8 @@
 #  License: MIT (see LICENSE file)
 
 import unittest
-from datetime import date, timedelta
+from datetime import date
+from datetime import timedelta as td
 
 from dateutil.relativedelta import WE
 
@@ -39,9 +40,9 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2027, DEC, 31),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
 
     def test_mlk(self):
         for dt in [
@@ -55,10 +56,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, JAN, 17),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
         for dt in [
             date(1997, JAN, 20),
@@ -74,10 +75,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1968, FEB, 12),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
         for dt in [
             date(1954, FEB, 12),
@@ -109,10 +110,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, FEB, 21),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
     def test_good_friday(self):
         for dt in [
@@ -129,10 +130,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, APR, 15),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
     def test_memday(self):
         for dt in [
@@ -153,10 +154,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, MAY, 30),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
     def test_flagday(self):
         for dt in [
@@ -168,10 +169,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1953, JUN, 15),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
         for dt in [
             date(1954, JUN, 14),
@@ -186,10 +187,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, JUN, 20),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
         for dt in [
             date(1954, JUN, 18),
@@ -213,10 +214,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, SEP, 5),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
         for dt in [
             date(1886, SEP, 6),
@@ -233,10 +234,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1953, OCT, 12),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
         for dt in [
             date(1908, OCT, 12),
@@ -259,9 +260,9 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1980, NOV, 4),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
         for dt in [
             date(1969, NOV, 4),
@@ -291,10 +292,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1953, NOV, 11),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
         for dt in [
             date(1917, NOV, 12),
@@ -323,10 +324,10 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, NOV, 24),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+7), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+7), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
     def test_christmas_day(self):
         for dt in [
@@ -343,9 +344,9 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(2022, DEC, 26),
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
-            self.assertNotIn(dt + timedelta(days=-7), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=-7), self.holidays)
 
     def test_special_holidays(self):
         # add to this list as new historical holidays are added
@@ -419,8 +420,7 @@ class TestNewYorkStockExchange(unittest.TestCase):
         def _make_special_holiday_list(begin, end, days=None, weekends=False):
             _list = []
             for d in (
-                begin + timedelta(days=n)
-                for n in range((end - begin).days + 1)
+                begin + td(days=n) for n in range((end - begin).days + 1)
             ):
                 if not weekends and d.weekday() in {SAT, SUN}:
                     continue
@@ -453,14 +453,14 @@ class TestNewYorkStockExchange(unittest.TestCase):
             date(1968, JUN, 12),  # begin paper crisis holidays
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=-1), self.holidays)
+            self.assertNotIn(dt + td(days=-1), self.holidays)
 
         for dt in [
             date(1914, NOV, 27),  # end WWI holidays
             date(1933, MAR, 14),  # end oneoff bank holidays
         ]:
             self.assertIn(dt, self.holidays)
-            self.assertNotIn(dt + timedelta(days=+1), self.holidays)
+            self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_all_modern_holidays_present(self):
         nyse_2021 = holidays.NewYorkStockExchange(years=[2021])

--- a/test/test_holiday_base.py
+++ b/test/test_holiday_base.py
@@ -13,7 +13,8 @@ import pathlib
 import pickle
 import unittest
 import warnings
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
+from datetime import timedelta as td
 
 from dateutil.relativedelta import MO
 from dateutil.relativedelta import relativedelta as rd
@@ -76,21 +77,15 @@ class TestBasics(unittest.TestCase):
             self.holidays[date(2013, 12, 31) : date(2014, 1, 2) : -3], []
         )
         self.assertListEqual(
-            self.holidays[
-                date(2014, 1, 1) : date(2013, 12, 24) : timedelta(days=3)
-            ],
+            self.holidays[date(2014, 1, 1) : date(2013, 12, 24) : td(days=3)],
             [date(2014, 1, 1)],
         )
         self.assertListEqual(
-            self.holidays[
-                date(2014, 1, 1) : date(2013, 12, 24) : timedelta(days=7)
-            ],
+            self.holidays[date(2014, 1, 1) : date(2013, 12, 24) : td(days=7)],
             [date(2014, 1, 1), date(2013, 12, 25)],
         )
         self.assertListEqual(
-            self.holidays[
-                date(2013, 12, 31) : date(2014, 1, 2) : timedelta(days=3)
-            ],
+            self.holidays[date(2013, 12, 31) : date(2014, 1, 2) : td(days=3)],
             [],
         )
         self.assertRaises(


### PR DESCRIPTION
Resolves https://github.com/dr-prodigy/python-holidays/issues/891

This PR contains tests only changes. See #900 for the business logic changes.