### PR TITLE
Fix Islamic holidays calculation

### DIFF
--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -25,7 +25,7 @@ from functools import lru_cache
 from typing import Dict, Iterable, List, Optional, Union
 
 from hijri_converter import convert
-from hijri_converter.ummalqura import GREGORIAN_RANGE
+from hijri_converter.ummalqura import GREGORIAN_RANGE, HIJRI_RANGE
 
 from holidays import countries, financial
 from holidays.holiday_base import HolidayBase
@@ -318,17 +318,18 @@ def _islamic_to_gre(g_year: int, h_month: int, h_day: int) -> Iterable[date]:
     """
 
     # To avoid hijri_converter check range OverflowError.
-    dt = (g_year, h_month, h_day)
-    dt_min, dt_max = GREGORIAN_RANGE
-    if dt < dt_min or dt > dt_max:
+    g_year_min, g_year_max = (d[0] for d in GREGORIAN_RANGE)
+    h_year_min, h_year_max = (d[0] for d in HIJRI_RANGE)
+    if g_year <= g_year_min or g_year > g_year_max:
         return ()
 
     h_year = convert.Gregorian(g_year, 1, 1).to_hijri().year
-    gre_dates = (
-        convert.Hijri(year, h_month, h_day).to_gregorian()
-        for year in range(h_year - 1, h_year + 2)
+    h_years = (
+        y for y in range(h_year, h_year + 3) if h_year_min <= y <= h_year_max
     )
-
+    gre_dates = (
+        convert.Hijri(y, h_month, h_day).to_gregorian() for y in h_years
+    )
     return (gre_date for gre_date in gre_dates if gre_date.year == g_year)
 
 

--- a/holidays/utils.py
+++ b/holidays/utils.py
@@ -301,7 +301,7 @@ def _islamic_to_gre(g_year: int, h_month: int, h_day: int) -> Iterable[date]:
     calendar is about 11 days shorter.
 
     Relies on package `hijri_converter
-    <https://www.pypy.org/package/hijri_converter>`__.
+    <https://www.pypi.org/project/hijri_converter>__.
 
     :param g_year:
         The Gregorian year.
@@ -313,8 +313,13 @@ def _islamic_to_gre(g_year: int, h_month: int, h_day: int) -> Iterable[date]:
         The Lunar Hijrī (Islamic) day.
 
     :return:
-        List of Gregorian dates within the Gregorian year specified that
-        matches the Islamic (Lunar Hijrī) calendar day and month specified.
+        An Iterable of Gregorian dates within the Gregorian year specified
+        that matches the Islamic (Lunar Hijrī) calendar day and month
+        specified. An empty Iterable is returned if the Gregorian year
+        is outside of the covered period, which as of hijri_converter 2.2.4
+        (in January 2023) is Gregorian years 1925 to 2076 inclusive, or
+        equal to the contents of hijri_converter.ummalqura.GREGORIAN_RANGE
+        plus/minus 1 year.
     """
 
     # To avoid hijri_converter check range OverflowError.

--- a/test/countries/test_bahrain.py
+++ b/test/countries/test_bahrain.py
@@ -78,5 +78,7 @@ class TestBahrain(TestCase):
 
         # Islamic New Year.
         self.assertHoliday(
+            "2008-01-10",
+            "2008-12-29",
             "2020-08-20",
         )

--- a/test/countries/test_djibouti.py
+++ b/test/countries/test_djibouti.py
@@ -30,7 +30,6 @@ class TestDjibouti(unittest.TestCase):
 
     def test_hijri_based(self):
         if importlib.util.find_spec("hijri_converter"):
-            self.holidays = holidays.DJ(years=[2010])
             self.assertIn(date(2019, 6, 5), self.holidays)
             self.assertIn(date(2019, 8, 10), self.holidays)
             self.assertIn(date(2019, 8, 11), self.holidays)
@@ -42,6 +41,8 @@ class TestDjibouti(unittest.TestCase):
             # eid_aladha
             self.assertIn(date(2019, 8, 11), self.holidays)
             # islamic_new_year
+            self.assertIn(date(2008, 1, 10), self.holidays)
+            self.assertIn(date(2008, 12, 29), self.holidays)
             self.assertIn(date(2019, 8, 31), self.holidays)
             # arafat_2019
             self.assertIn(date(2019, 8, 10), self.holidays)

--- a/test/countries/test_egypt.py
+++ b/test/countries/test_egypt.py
@@ -64,7 +64,6 @@ class TestEgypt(unittest.TestCase):
 
     def test_hijri_based(self):
         if importlib.util.find_spec("hijri_converter"):
-            self.holidays = holidays.EG(years=[2010])
             self.assertIn(date(2019, 6, 5), self.holidays)
             self.assertIn(date(2019, 8, 10), self.holidays)
             self.assertIn(date(2019, 8, 11), self.holidays)
@@ -76,6 +75,8 @@ class TestEgypt(unittest.TestCase):
             # eid_aladha
             self.assertIn(date(2019, 8, 11), self.holidays)
             # islamic_new_year
+            self.assertIn(date(2008, 1, 10), self.holidays)
+            self.assertIn(date(2008, 12, 29), self.holidays)
             self.assertIn(date(2019, 8, 31), self.holidays)
             # eid_elfetr_2010
             self.assertIn(date(2010, 9, 10), self.holidays)

--- a/test/countries/test_morocco.py
+++ b/test/countries/test_morocco.py
@@ -82,7 +82,6 @@ class TestMorocco(unittest.TestCase):
 
     def test_hijri_based(self):
         if importlib.util.find_spec("hijri_converter"):
-            self.holidays = holidays.Morocco(years=[2019, 1999])
             # eid_alfitr
             self.assertIn(date(2019, 6, 4), self.holidays)
             self.assertIn(date(2019, 6, 5), self.holidays)
@@ -90,6 +89,8 @@ class TestMorocco(unittest.TestCase):
             self.assertIn(date(2019, 8, 11), self.holidays)
             self.assertIn(date(2019, 8, 12), self.holidays)
             # islamic_new_year
+            self.assertIn(date(2008, 1, 10), self.holidays)
+            self.assertIn(date(2008, 12, 29), self.holidays)
             self.assertIn(date(2019, 8, 31), self.holidays)
 
             self.assertIn(date(2019, 11, 9), self.holidays)

--- a/test/countries/test_tunisia.py
+++ b/test/countries/test_tunisia.py
@@ -36,13 +36,13 @@ class TestTunisia(unittest.TestCase):
 
     def test_hijri_based(self):
         if importlib.util.find_spec("hijri_converter"):
-            self.holidays = holidays.TN(years=[2015])
-
             # eid_alfitr
             self.assertIn(date(2015, 7, 17), self.holidays)
             # eid_aladha
             self.assertIn(date(2015, 9, 24), self.holidays)
             # islamic_new_year
+            self.assertIn(date(2008, 1, 10), self.holidays)
+            self.assertIn(date(2008, 12, 29), self.holidays)
             self.assertIn(date(2015, 10, 14), self.holidays)
 
             # eid_elfetr_2019

--- a/test/countries/test_united_arab_emirates.py
+++ b/test/countries/test_united_arab_emirates.py
@@ -41,7 +41,6 @@ class UnitedArabEmirates(unittest.TestCase):
 
     def test_hijri_based(self):
         if importlib.util.find_spec("hijri_converter"):
-            self.holidays = holidays.AE(years=[2020])
             # Eid Al-Fitr
             self.assertIn(date(2020, 5, 24), self.holidays)
             self.assertIn(date(2020, 5, 25), self.holidays)
@@ -52,6 +51,8 @@ class UnitedArabEmirates(unittest.TestCase):
             self.assertIn(date(2020, 8, 1), self.holidays)
             self.assertIn(date(2020, 8, 2), self.holidays)
             # Islamic New Year
+            self.assertIn(date(2008, 1, 10), self.holidays)
+            self.assertIn(date(2008, 12, 29), self.holidays)
             self.assertIn(date(2020, 8, 23), self.holidays)
             # Leilat Al-Miraj 2018
             self.assertIn(date(2018, 4, 13), self.holidays)


### PR DESCRIPTION
- fix for holidays that happen twice in a Gregorian year (primarily islamic New Year)
- years range checking more strictly