### PR TITLE
 February Bank Holiday in Ireland calculated wrong #917 

### DIFF
--- a/holidays/countries/ireland.py
+++ b/holidays/countries/ireland.py
@@ -39,9 +39,10 @@ class Ireland(HolidayBase):
         if year >= 2023:
             name = "St. Brigid's Day"
             dt = date(year, FEB, 1)
-            self[dt] = name
-            if self.observed and dt.weekday() != FRI:
-                self[dt + rd(weekday=MO)] = name + " (Observed)"
+            if dt.weekday() == FRI:
+                self[dt] = name
+            else:
+                self[dt + rd(weekday=MO)] = name
 
         # St. Patrick's Day
         name = "St. Patrick's Day"


### PR DESCRIPTION
   St Bridget's Holiday is first Monday of February in Ireland, unless 1st falls on a Friday.