### PR TITLE
Botswana observed holidays performance optimization

### DIFF
--- a/holidays/countries/botswana.py
+++ b/holidays/countries/botswana.py
@@ -16,8 +16,7 @@ from dateutil.easter import easter
 from dateutil.relativedelta import MO
 from dateutil.relativedelta import relativedelta as rd
 
-from holidays.constants import JAN, MAY, JUL, SEP, OCT, DEC, SAT, SUN
-from holidays.constants import HOLIDAY_NAME_DELIMITER
+from holidays.constants import JAN, MAY, JUL, SEP, DEC, SAT, SUN
 from holidays.holiday_base import HolidayBase
 
 
@@ -33,67 +32,62 @@ class Botswana(HolidayBase):
     special_holidays = {2019: ((JUL, 2, "Public Holiday"),)}
 
     def _populate(self, year: int):
+        def _add_with_observed(
+            hol_date: date, hol_name1: str, hol_name2: str = ""
+        ) -> None:
+            self[hol_date] = hol_name1
+            if hol_name2:
+                self[hol_date + td(days=+1)] = hol_name2
+            if self.observed and year >= 1995:
+                if hol_date.weekday() == SUN:
+                    obs_date = hol_date + td(days=2 if hol_name2 else 1)
+                    self[obs_date] = f"{hol_name1} (Observed)"
+                elif hol_date.weekday() == SAT and hol_name2:
+                    obs_date = hol_date + td(days=+2)
+                    self[obs_date] = f"{hol_name2} (Observed)"
+
         if year <= 1965:
             return
         super()._populate(year)
 
-        self[date(year, JAN, 1)] = "New Year's Day"
-        self[date(year, JAN, 2)] = "New Year's Day Holiday"
+        _add_with_observed(
+            date(year, JAN, 1), "New Year's Day", "New Year's Day Holiday"
+        )
 
         # Easter and easter related calculations
         easter_date = easter(year)
         self[easter_date + td(days=-2)] = "Good Friday"
         self[easter_date + td(days=-1)] = "Holy Saturday"
         self[easter_date + td(days=+1)] = "Easter Monday"
-
-        self[date(year, MAY, 1)] = "Labour Day"
         self[easter_date + td(days=+39)] = "Ascension Day"
 
-        self[date(year, JUL, 1)] = "Sir Seretse Khama Day"
+        _add_with_observed(date(year, MAY, 1), "Labour Day")
+        if (
+            self.observed
+            and year >= 2016
+            and date(year, MAY, 1).weekday() == SAT
+        ):
+            self[date(year, MAY, 1) + td(days=+2)] = "Labour Day Holiday"
+
+        _add_with_observed(date(year, JUL, 1), "Sir Seretse Khama Day")
 
         # 3rd Monday of July = "President's Day"
-        d = date(year, JUL, 1) + rd(weekday=MO(+3))
-        self[d] = "President's Day"
-        self[d + td(days=+1)] = "President's Day Holiday"
+        dt = date(year, JUL, 1) + rd(weekday=MO(+3))
+        self[dt] = "President's Day"
+        self[dt + td(days=+1)] = "President's Day Holiday"
 
-        self[date(year, SEP, 30)] = "Botswana Day"
-        self[date(year, OCT, 1)] = "Botswana Day Holiday"
+        _add_with_observed(
+            date(year, SEP, 30), "Botswana Day", "Botswana Day Holiday"
+        )
 
-        self[date(year, DEC, 25)] = "Christmas Day"
-        self[date(year, DEC, 26)] = "Boxing Day"
+        _add_with_observed(date(year, DEC, 25), "Christmas Day", "Boxing Day")
 
-        if self.observed:
-            for k, v in list(self.items()):
-                # Whenever Boxing Day falls on a Saturday,
-                # it rolls over to the following Monday
-                if (
-                    2016 <= year == k.year
-                    and k.weekday() == SAT
-                    and v.upper() in {"BOXING DAY", "LABOUR DAY"}
-                ):
-                    # Add the (Observed) holiday
-                    self[k + td(days=+2)] = v + " Holiday"
-                if (
-                    1995 <= year == k.year
-                    and k.weekday() == SUN
-                    and v.upper() != "NEW YEAR'S DAY HOLIDAY"
-                ):
-                    # Add the (Observed) holiday
-                    self[k + td(days=+1)] = v + " (Observed)"
-
-                # If there is a holiday and an (Observed) holiday
-                # on the same day, add an (Observed) holiday for that holiday
-                hol_names = self.get(k).split(HOLIDAY_NAME_DELIMITER)
-                if len(hol_names) > 1:
-                    # self.get(date) returns a string containing holidays as a
-                    # comma delimited string split on delimiter to determine if
-                    # there are multiple on the same day
-                    # Add an (Observed) for the one that is not (Observed)
-                    for name in hol_names:
-                        if " (Observed)" not in name:
-                            self[k + td(days=+1)] = (
-                                name.lstrip() + " (Observed)"
-                            )
+        if (
+            self.observed
+            and year >= 2016
+            and date(year, DEC, 26).weekday() == SAT
+        ):
+            self[date(year, DEC, 26) + td(days=+2)] = "Boxing Day Holiday"
 
 
 class BW(Botswana):

--- a/test/countries/test_botswana.py
+++ b/test/countries/test_botswana.py
@@ -9,56 +9,174 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import unittest
-from datetime import date
-
-import holidays
+from holidays.countries.botswana import Botswana, BW, BWA
+from test.common import TestCase
 
 
-class TestBotswana(unittest.TestCase):
+class TestBotswana(TestCase):
     def setUp(self):
-        self.holidays = holidays.BW()
+        self.holidays = Botswana()
+        self.holidays_no_observed = Botswana(observed=False)
 
-    def test_new_years(self):
-        self.assertIn(date(1966, 1, 1), self.holidays)
-        self.assertIn(date(2018, 1, 1), self.holidays)
-        self.assertIn(date(2999, 1, 1), self.holidays)
-        self.assertIn(date(2017, 1, 2), self.holidays)  # sunday
+    def test_country_aliases(self):
+        self.assertCountryAliases(Botswana, BW, BWA)
 
-    def test_easter(self):
-        self.assertIn(date(2017, 4, 14), self.holidays)
-        self.assertIn(date(2017, 4, 17), self.holidays)
-        self.assertIn(date(1994, 4, 1), self.holidays)
-
-    def test_presidents_day(self):
-        self.assertIn(date(2000, 7, 17), self.holidays)
-        self.assertIn(date(2000, 7, 18), self.holidays)
-        self.assertIn(date(2020, 7, 20), self.holidays)
-        self.assertIn(date(2020, 7, 21), self.holidays)
-        self.assertIn(date(2021, 7, 19), self.holidays)
-        self.assertIn(date(2021, 7, 20), self.holidays)
-        self.assertIn(date(2022, 7, 18), self.holidays)
-        self.assertIn(date(2022, 7, 19), self.holidays)
-
-    def test_static(self):
-        self.assertIn(date(2004, 7, 1), self.holidays)
-        self.assertIn(date(2022, 12, 26), self.holidays)  # Christmas
-
-    def test_not_holiday(self):
-        self.assertNotIn(date(2016, 12, 28), self.holidays)
-        self.assertNotIn(date(2015, 3, 2), self.holidays)
-        self.assertNotIn(date(1964, 4, 16), self.holidays)
+    def test_no_holidays(self):
+        self.assertNoHolidays(Botswana(years=1965))
 
     def test_special_holidays(self):
-        self.assertIn(date(2019, 7, 2), self.holidays)
+        self.assertHoliday("2019-07-02")
 
-    def test_saturday_and_monday(self):
-        self.assertIn(date(2020, 12, 26), self.holidays)
+    def test_new_years(self):
+        for year in range(1966, 2050):
+            self.assertHoliday(f"{year}-01-01", f"{year}-01-02")
 
-    def test_not_observed(self):
-        self.holidays = holidays.BW(observed=False)
-        self.assertNotIn(date(2018, 7, 2), self.holidays)
-        self.assertNotIn(date(2018, 10, 2), self.holidays)
-        self.assertNotIn(date(2021, 12, 27), self.holidays)
-        self.assertNotIn(date(2022, 5, 2), self.holidays)
-        self.assertNotIn(date(2022, 12, 27), self.holidays)
+        dt = (
+            "2011-01-03",
+            "2012-01-03",
+            "2017-01-03",
+            "2022-01-03",
+            "2023-01-03",
+        )
+        self.assertHoliday(dt)
+        self.assertNoHoliday(self.holidays_no_observed, dt)
+
+    def test_easter(self):
+        dt = (
+            "2020-04-10",
+            "2020-04-11",
+            "2020-04-13",
+            "2020-05-21",
+            "2022-04-15",
+            "2022-04-16",
+            "2022-04-18",
+            "2022-05-26",
+        )
+        self.assertHoliday(dt)
+        self.assertHoliday(self.holidays_no_observed, dt)
+
+    def test_labour_day(self):
+        self.assertHoliday(f"{year}-05-01" for year in range(1966, 2050))
+        dt = (
+            "2011-05-02",
+            "2016-05-02",
+            "2022-05-02",
+        )
+        self.assertHoliday(dt)
+        self.assertNoHoliday(self.holidays_no_observed, dt)
+
+        dt = (
+            "2021-05-03",
+            "2027-05-03",
+            "2032-05-03",
+        )
+        self.assertHolidaysName("Labour Day Holiday", dt)
+        self.assertNoHoliday(self.holidays_no_observed, dt)
+
+    def test_presidents_day(self):
+        self.assertHoliday(
+            "2019-07-15",
+            "2019-07-16",
+            "2020-07-20",
+            "2020-07-21",
+            "2021-07-19",
+            "2021-07-20",
+            "2022-07-18",
+            "2022-07-19",
+        )
+
+    def test_botswana_day(self):
+        for year in range(1966, 2050):
+            self.assertHoliday(f"{year}-09-30", f"{year}-10-01")
+
+        dt = (
+            "2012-10-02",
+            "2017-10-02",
+            "2018-10-02",
+            "2023-10-02",
+        )
+        self.assertHoliday(dt)
+        self.assertNoHoliday(self.holidays_no_observed, dt)
+
+    def test_christmas_day(self):
+        for year in range(1966, 2050):
+            self.assertHoliday(f"{year}-12-25", f"{year}-12-26")
+
+        dt = (
+            "2010-12-27",
+            "2011-12-27",
+            "2016-12-27",
+            "2021-12-27",
+            "2022-12-27",
+        )
+        self.assertHoliday(dt)
+        self.assertNoHoliday(self.holidays_no_observed, dt)
+
+        dt = (
+            "2020-12-28",
+            "2026-12-28",
+            "2037-12-28",
+        )
+        self.assertHolidaysName("Boxing Day Holiday", dt)
+        self.assertNoHoliday(self.holidays_no_observed, dt)
+
+    def test_2021(self):
+        self.assertHolidayDates(
+            "2021-01-01",
+            "2021-01-02",
+            "2021-04-02",
+            "2021-04-03",
+            "2021-04-05",
+            "2021-05-01",
+            "2021-05-03",
+            "2021-05-13",
+            "2021-07-01",
+            "2021-07-19",
+            "2021-07-20",
+            "2021-09-30",
+            "2021-10-01",
+            "2021-12-25",
+            "2021-12-26",
+            "2021-12-27",
+        )
+
+    def test_2022(self):
+        self.assertHolidayDates(
+            "2022-01-01",
+            "2022-01-02",
+            "2022-01-03",
+            "2022-04-15",
+            "2022-04-16",
+            "2022-04-18",
+            "2022-05-01",
+            "2022-05-02",
+            "2022-05-26",
+            "2022-07-01",
+            "2022-07-18",
+            "2022-07-19",
+            "2022-09-30",
+            "2022-10-01",
+            "2022-12-25",
+            "2022-12-26",
+            "2022-12-27",
+        )
+
+    def test_2023(self):
+        self.assertHolidayDates(
+            "2023-01-01",
+            "2023-01-02",
+            "2023-01-03",
+            "2023-04-07",
+            "2023-04-08",
+            "2023-04-10",
+            "2023-05-01",
+            "2023-05-18",
+            "2023-07-01",
+            "2023-07-17",
+            "2023-07-18",
+            "2023-09-30",
+            "2023-10-01",
+            "2023-10-02",
+            "2023-12-25",
+            "2023-12-26",
+        )


### PR DESCRIPTION
Observed holidays calculation method changed. Here are some performance tests.
```
def calc_hol1():
    for year in range(1966, 2100):
        hols = Botswana(years=year)

def calc_hol2():
    hols = Botswana(years=range(1966, 2100))

t1 = timeit.timeit(calc_hol1, number=100)
t2 = timeit.timeit(calc_hol2, number=100)
```
| Test | Current beta |   PR  |
|:----:|:------------:|:-----:|
|  t1  |        2.740 | 2.379 |
|  t2  |       39.242 | 2.157 |