### PR TITLE
Add United States Minor Outlying Islands (ISO-3666-2 code US-UM)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -432,7 +432,7 @@ following countries and their subdivisions are available:
      - Subdivisions: England, Northern Ireland, Scotland, **UK** (default), Wales; For Isle of Man use country code IM
    * - United States
      - US
-     - States and territories: AL, AK, AS, AZ, AR, CA, CO, CT, DE, DC, FL, GA, GU, HI, ID, IL, IN, IA, KS, KY, LA, ME, MD, MH, MA, MI, FM, MN, MS, MO, MT, NE, NV, NH, NJ, NM, NY, NC, ND, MP, OH, OK, OR, PW, PA, PR, RI, SC, SD, TN, TX, UT, VT, VA, VI, WA, WV, WI, WY
+     - States and territories: AL, AK, AS, AZ, AR, CA, CO, CT, DE, DC, FL, GA, GU, HI, ID, IL, IN, IA, KS, KY, LA, ME, MD, MH, MA, MI, FM, MN, MS, MO, MT, NE, NV, NH, NJ, NM, NY, NC, ND, MP, OH, OK, OR, PW, PA, PR, RI, SC, SD, TN, TX, UM, UT, VT, VA, VI, WA, WV, WI, WY
    * - Uruguay
      - UY
      - None

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -79,6 +79,7 @@ class UnitedStates(HolidayBase):
         "SD",
         "TN",
         "TX",
+        "UM",
         "UT",
         "VT",
         "VA",


### PR DESCRIPTION
Only US Federal Holidays are "observed".  From Wikipedia: 

> Except for [Palmyra Atoll](https://en.wikipedia.org/wiki/Palmyra_Atoll), all of these islands are [unincorporated](https://en.wikipedia.org/wiki/Territories_of_the_United_States#Incorporated_vs._unincorporated_territories) [unorganized territories of the United States](https://en.wikipedia.org/wiki/Territories_of_the_United_States#Organized_vs._unorganized_territories). Currently, none of the islands have any permanent residents, although military personnel, U.S. Fish and Wildlife Service personnel, and temporarily stationed scientific and research staff are posted to some of the islands