### PR TITLE
National Day for Truth and Reconciliation in British Columbia (Canada) since 2023

### DIFF
--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -243,7 +243,9 @@ class Canada(HolidayBase):
             )
 
         # National Day for Truth and Reconciliation
-        if year >= 2021 and self.subdiv in {"MB", "NS"}:
+        if (year >= 2021 and self.subdiv in {"MB", "NS"}) or (
+            year >= 2023 and self.subdiv == "BC"
+        ):
             self[date(year, SEP, 30)] = self.tr(
                 "National Day for Truth and Reconciliation"
             )

--- a/tests/countries/test_canada.py
+++ b/tests/countries/test_canada.py
@@ -313,19 +313,37 @@ class TestCA(TestCase):
             self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_national_day_for_truth_and_reconciliation(self):
+        mb_holidays = Canada(subdiv="MB")
+        ns_holidays = Canada(subdiv="NS")
+        bc_holidays = Canada(subdiv="BC")
         for dt in [
             date(1991, 9, 30),
             date(2020, 9, 30),
         ]:
             self.assertNotIn(dt, self.holidays)
             self.assertNotIn(dt + td(days=-1), self.holidays)
-        mb_holidays = Canada(subdiv="MB")
+            self.assertNotIn(dt, mb_holidays)
+            self.assertNotIn(dt, ns_holidays)
         for dt in [
             date(2021, 9, 30),
+            date(2022, 9, 30),
+        ]:
+            self.assertIn(dt, mb_holidays)
+            self.assertIn(dt, ns_holidays)
+            self.assertNotIn(dt + td(days=-1), mb_holidays)
+            self.assertNotIn(dt + td(days=-1), ns_holidays)
+            self.assertNotIn(dt, self.holidays)
+        for dt in [
+            date(2023, 9, 30),
+            date(2024, 9, 30),
             date(2030, 9, 30),
         ]:
             self.assertIn(dt, mb_holidays)
+            self.assertIn(dt, ns_holidays)
+            self.assertIn(dt, bc_holidays)
             self.assertNotIn(dt + td(days=-1), mb_holidays)
+            self.assertNotIn(dt + td(days=-1), ns_holidays)
+            self.assertNotIn(dt + td(days=-1), bc_holidays)
             self.assertNotIn(dt, self.holidays)
 
     def test_thanksgiving(self):

--- a/tests/countries/test_canada.py
+++ b/tests/countries/test_canada.py
@@ -313,9 +313,10 @@ class TestCA(TestCase):
             self.assertNotIn(dt + td(days=+1), self.holidays)
 
     def test_national_day_for_truth_and_reconciliation(self):
+        bc_holidays = Canada(subdiv="BC")
         mb_holidays = Canada(subdiv="MB")
         ns_holidays = Canada(subdiv="NS")
-        bc_holidays = Canada(subdiv="BC")
+
         for dt in [
             date(1991, 9, 30),
             date(2020, 9, 30),


### PR DESCRIPTION
https://www.cbc.ca/news/canada/british-columbia/bc-truth-and-reconciliation-day-statutory-holiday-1.6740033