### PR TITLE
Upgrade dependency: Update coverage[toml] requirement from <7.0.0 to <8.0.0

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,7 +6,7 @@ PyMeeus
 python-dateutil
 
 # Test requirements.
-coverage[toml]<7.0.0
+coverage[toml]<8.0.0
 flake8
 pre-commit
 pytest


### PR DESCRIPTION
coverage[toml] seems to have come a long way since [the initial buggy 7.0.1](https://github.com/TheKevJames/coveralls-python/issues/377), as seen in #883.

Here are some of the new improvements since 7.0. that we could use for this project:
> Version 7.1.0 — 2023-01-24
> Performance: fixed a slowdown with dynamic contexts that's been around since 6.4.3. The fix closes https://github.com/nedbat/coveragepy/issues/1538. Thankfully this doesn't break the https://github.com/nedbat/coveragepy/pull/1347 that fixed https://github.com/nedbat/coveragepy/issues/972. Thanks to Mathieu Kniewallner for the deep investigative work and comprehensive issue report.

Testing with `tox` locally seems to work, so the issue is probably solved by the coverall team by now.