### PR TITLE
Fix readthedocs.io build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,7 @@ MANIFEST
 coverage.xml
 .tox
 .venv
-docs/_build
 docs/build
-docs/source/_build
 holidays/locale/pot
 
 # IDE Stuff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,13 @@ repos:
     hooks:
       - id: check-ast
       - id: check-builtin-literals
+      - id: check-yaml
       - id: end-of-file-fixer
-      - id: trailing-whitespace
       - id: fix-encoding-pragma
         args: [--remove]
       - id: mixed-line-ending
         args: [--fix=lf]
+      - id: trailing-whitespace
 
   - repo: https://github.com/python/black
     rev: 23.1.0

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,18 @@
+# Read the Docs configuration file.
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details.
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: '3.11'
+
+python:
+  install:
+    - requirements: requirements/docs.txt
+
+sphinx:
+  builder: html
+  configuration: docs/source/conf.py
+  fail_on_warning: true

--- a/Makefile
+++ b/Makefile
@@ -11,10 +11,14 @@ help:
 
 check:
 	make pre-commit
+	make doc
 	make test
 
 coverage:
 	pytest --cov=. --cov-config=pyproject.toml --cov-report term-missing --no-cov-on-fail --numprocesses auto
+
+doc:
+	sphinx-build -E -T -W -b html -D language=en -j auto -q docs/source docs/build
 
 l10n:
 	mkdir -p holidays/locale/pot
@@ -25,7 +29,7 @@ pre-commit:
 	pre-commit run --all-files
 
 setup:
-	pip install -U pip
+	pip install --upgrade pip
 	pip install --requirement requirements/dev.txt
 	pip install --requirement requirements/docs.txt
 	pre-commit install --hook-type pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -11,14 +11,15 @@ deps =
 
 [testenv:docs]
 # Test docs.
-# We run it in Python 3.9 to match
+# We run it in Python 3.11 to match
 # https://docs.readthedocs.io/en/stable/config-file/v2.html?#build-image
 allowlist_externals =
     cmd
+    make
     sphinx-build
-basepython = python3.9
+basepython = python3.11
 commands =
-    sphinx-build -W -j auto docs/source docs/_build
+    make doc
 deps =
     -r{toxinidir}/requirements/dev.txt
     -r{toxinidir}/requirements/docs.txt


### PR DESCRIPTION
The fix and related changes include:
  - Add .readthedocs.yaml.
  - Update .gitignore.
  - Update .pre-commit-config.yaml.
  - Update Makefile.
  - Update tox.ini.