### PR TITLE
Update Mexico holidays

### DIFF
--- a/holidays/countries/mexico.py
+++ b/holidays/countries/mexico.py
@@ -34,14 +34,7 @@ class Mexico(HolidayBase):
 
         # New Year's Day
         name = "Año Nuevo [New Year's Day]"
-        dt = date(year, JAN, 1)
-        self[dt] = name
-        if self.observed and self._is_sunday(dt):
-            self[dt + td(days=+1)] = name + " (Observed)"
-        # The next year's observed New Year's Day can be in this year
-        # when it falls on a Friday (Jan 1st is a Saturday)
-        if self.observed and self._is_friday(year, DEC, 31):
-            self[date(year, DEC, 31)] = name + " (Observed)"
+        self[date(year, JAN, 1)] = name
 
         # Constitution Day
         name = "Día de la Constitución [Constitution Day]"
@@ -71,8 +64,7 @@ class Mexico(HolidayBase):
 
         # Independence Day
         name = "Día de la Independencia [Independence Day]"
-        dt = date(year, SEP, 16)
-        self._add_with_observed(dt, name)
+        self[date(year, SEP, 16)] = name
 
         # Revolution Day
         name = "Día de la Revolución [Revolution Day]"


### PR DESCRIPTION
According to this official document from the Mexico government (https://www.gob.mx/profedet/articulos/sabes-cuales-son-los-dias-de-descanso-obligatorios-163134?idiom=es) (in Spanish) New Year's and Independence Day are not re-calculated even if they happen on a weekend day

From the list in the doc, holidays should be:
1. January 1st
2. February 5th, or the first Monday in February
3. March 21st, or the third Monday in March
4. May 1st
5. September 16th
6. November 20th, or the third Monday in November
7. Every 6 years, December 1st, corresponding to `Change of Federal Government`
8. December 25th