### PR TITLE
Add functions for relative weekdays calculation

### DIFF
--- a/holidays/calendars.py
+++ b/holidays/calendars.py
@@ -63,6 +63,41 @@ def _islamic_to_gre(g_year: int, h_month: int, h_day: int) -> Iterable[date]:
     return (gre_date for gre_date in gre_dates if gre_date.year == g_year)
 
 
+def _get_nth_weekday_from(n: int, weekday: int, from_dt: date) -> date:
+    """
+    Return date of a n-th weekday after (n is positive)
+    or before (n is negative) a specific date
+    (e.g. 1st Monday, 2nd Saturday, etc).
+    """
+
+    if n > 0:
+        delta = (n - 1) * 7 + (weekday - from_dt.weekday()) % 7
+    else:
+        delta = (n + 1) * 7 - (from_dt.weekday() - weekday) % 7
+    return from_dt + td(days=delta)
+
+
+def _get_nth_weekday_of_month(
+    n: int, weekday: int, month: int, year: int
+) -> date:
+    """
+    Return date of n-th weekday of month for a specific year
+    (e.g. 1st Monday of Apr, 2nd Friday of June, etc).
+    If n is negative the countdown starts at the end of month
+    (i.e. -1 is last).
+    """
+
+    if n < 0:
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+        start_date = date(year, month, 1) + td(days=-1)
+    else:
+        start_date = date(year, month, 1)
+    return _get_nth_weekday_from(n, weekday, start_date)
+
+
 class _ChineseLuniSolar:
     def __init__(self) -> None:
         """

--- a/holidays/countries/canada.py
+++ b/holidays/countries/canada.py
@@ -13,11 +13,10 @@ from datetime import date
 from datetime import timedelta as td
 
 from dateutil.easter import easter
-from dateutil.relativedelta import MO, SU
-from dateutil.relativedelta import relativedelta as rd
 
+from holidays.calendars import _get_nth_weekday_from, _get_nth_weekday_of_month
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP
-from holidays.constants import OCT, NOV, DEC
+from holidays.constants import OCT, NOV, DEC, SUN, MON
 from holidays.holiday_base import HolidayBase
 
 
@@ -47,10 +46,8 @@ class Canada(HolidayBase):
         HolidayBase.__init__(self, **kwargs)
 
     def _get_nearest_monday(self, dt: date) -> date:
-        return (
-            dt + rd(weekday=MO(-1))
-            if not self._is_friday(dt) and not self._is_weekend(dt)
-            else dt + rd(weekday=MO)
+        return _get_nth_weekday_from(
+            1 if self._is_friday(dt) or self._is_weekend(dt) else -1, MON, dt
         )
 
     def _populate(self, year):
@@ -63,7 +60,7 @@ class Canada(HolidayBase):
         name = self.tr("New Year's Day")
         self[date(year, JAN, 1)] = name
         if self.observed and self._is_weekend(year, JAN, 1):
-            self[date(year, JAN, 1) + rd(weekday=MO)] = (
+            self[_get_nth_weekday_of_month(1, MON, JAN, year)] = (
                 self.tr("%s (Observed)") % name
             )
 
@@ -75,34 +72,34 @@ class Canada(HolidayBase):
             or (self.subdiv == "ON" and year >= 2008)
             or (self.subdiv == "NB" and year >= 2018)
         ):
-            self[date(year, FEB, 1) + rd(weekday=MO(+3))] = self.tr(
+            self[_get_nth_weekday_of_month(3, MON, FEB, year)] = self.tr(
                 "Family Day"
             )
         elif self.subdiv == "BC":
             if 2013 <= year <= 2018:
-                self[date(year, FEB, 1) + rd(weekday=MO(+2))] = self.tr(
+                self[_get_nth_weekday_of_month(2, MON, FEB, year)] = self.tr(
                     "Family Day"
                 )
             elif year > 2018:
-                self[date(year, FEB, 1) + rd(weekday=MO(+3))] = self.tr(
+                self[_get_nth_weekday_of_month(3, MON, FEB, year)] = self.tr(
                     "Family Day"
                 )
         elif self.subdiv == "MB" and year >= 2008:
-            self[date(year, FEB, 1) + rd(weekday=MO(+3))] = self.tr(
+            self[_get_nth_weekday_of_month(3, MON, FEB, year)] = self.tr(
                 "Louis Riel Day"
             )
         elif self.subdiv == "PE" and year >= 2010:
-            self[date(year, FEB, 1) + rd(weekday=MO(+3))] = self.tr(
+            self[_get_nth_weekday_of_month(3, MON, FEB, year)] = self.tr(
                 "Islander Day"
             )
         elif self.subdiv == "PE" and year == 2009:
-            self[date(year, FEB, 1) + rd(weekday=MO(+2))] = self.tr(
+            self[_get_nth_weekday_of_month(2, MON, FEB, year)] = self.tr(
                 "Islander Day"
             )
         # http://novascotia.ca/lae/employmentrights/NovaScotiaHeritageDay.asp
         elif self.subdiv == "NS" and year >= 2015:
             # Heritage Day.
-            self[date(year, FEB, 1) + rd(weekday=MO(+3))] = self.tr(
+            self[_get_nth_weekday_of_month(3, MON, FEB, year)] = self.tr(
                 "Heritage Day"
             )
         elif self.subdiv == "YT" and year >= 1974:
@@ -114,12 +111,7 @@ class Canada(HolidayBase):
             # http://heritageyukon.ca/programs/heritage-day
             # https://en.wikipedia.org/wiki/Family_Day_(Canada)#Yukon_Heritage_Day
             # Friday before the last Sunday in February
-            dt = (
-                date(year, MAR, 1)
-                + td(days=-1)
-                + rd(weekday=SU(-1))
-                + td(days=-2)
-            )
+            dt = _get_nth_weekday_of_month(-1, SUN, FEB, year) + td(days=-2)
             # Heritage Day.
             self[dt] = self.tr("Heritage Day")
 
@@ -149,7 +141,7 @@ class Canada(HolidayBase):
 
         # Victoria Day / National Patriots' Day (QC)
         if year >= 1953:
-            dt = date(year, MAY, 24) + rd(weekday=MO(-1))
+            dt = _get_nth_weekday_from(-1, MON, date(year, MAY, 24))
             if self.subdiv not in {"NB", "NS", "PE", "NL", "QC"}:
                 self[dt] = self.tr("Victoria Day")
             elif self.subdiv == "QC":
@@ -173,7 +165,7 @@ class Canada(HolidayBase):
             dt = self._get_nearest_monday(date(year, JUN, 24))
             self[dt] = self.tr("Discovery Day")
         elif self.subdiv == "YT" and year >= 1912:
-            self[date(year, AUG, 1) + rd(weekday=MO(+3))] = self.tr(
+            self[_get_nth_weekday_of_month(3, MON, AUG, year)] = self.tr(
                 "Discovery Day"
             )
 
@@ -189,7 +181,9 @@ class Canada(HolidayBase):
         dt = date(year, JUL, 1)
         self[dt] = name
         if year >= 1879 and self.observed and self._is_weekend(dt):
-            self[dt + rd(weekday=MO)] = self.tr("%s (Observed)") % name
+            self[_get_nth_weekday_from(1, MON, dt)] = (
+                self.tr("%s (Observed)") % name
+            )
 
         # Nunavut Day
         if self.subdiv == "NU":
@@ -204,33 +198,37 @@ class Canada(HolidayBase):
 
         # Civic Holiday
         if year >= 1900 and self.subdiv in {"MB", "NT", "ON"}:
-            self[date(year, AUG, 1) + rd(weekday=MO)] = self.tr(
+            self[_get_nth_weekday_of_month(1, MON, AUG, year)] = self.tr(
                 "Civic Holiday"
             )
         # https://en.wikipedia.org/wiki/Civic_Holiday#Alberta
         elif year >= 1974 and self.subdiv == "AB":
             # Heritage Day.
-            self[date(year, AUG, 1) + rd(weekday=MO)] = self.tr("Heritage Day")
+            self[_get_nth_weekday_of_month(1, MON, AUG, year)] = self.tr(
+                "Heritage Day"
+            )
         # https://en.wikipedia.org/wiki/Civic_Holiday
         elif year >= 1974 and self.subdiv == "BC":
             # British Columbia Day.
-            self[date(year, AUG, 1) + rd(weekday=MO)] = self.tr(
+            self[_get_nth_weekday_of_month(1, MON, AUG, year)] = self.tr(
                 "British Columbia Day"
             )
         # https://en.wikipedia.org/wiki/Civic_Holiday
         elif year >= 1900 and self.subdiv == "NB":
-            self[date(year, AUG, 1) + rd(weekday=MO)] = self.tr(
+            self[_get_nth_weekday_of_month(1, MON, AUG, year)] = self.tr(
                 "New Brunswick Day"
             )
         # https://en.wikipedia.org/wiki/Civic_Holiday
         elif year >= 1900 and self.subdiv == "SK":
-            self[date(year, AUG, 1) + rd(weekday=MO)] = self.tr(
+            self[_get_nth_weekday_of_month(1, MON, AUG, year)] = self.tr(
                 "Saskatchewan Day"
             )
 
         # Labour Day
         if year >= 1894:
-            self[date(year, SEP, 1) + rd(weekday=MO)] = self.tr("Labour Day")
+            self[_get_nth_weekday_of_month(1, MON, SEP, year)] = self.tr(
+                "Labour Day"
+            )
 
         # Funeral of Queen Elizabeth II
         # https://www.narcity.com/provinces-territories-will-have-a-day-off-monday-mourn-queen
@@ -263,7 +261,7 @@ class Canada(HolidayBase):
             if year == 1935:
                 self[date(1935, OCT, 25)] = self.tr("Thanksgiving")
             else:
-                self[date(year, OCT, 1) + rd(weekday=MO(+2))] = self.tr(
+                self[_get_nth_weekday_of_month(2, MON, OCT, year)] = self.tr(
                     "Thanksgiving"
                 )
 
@@ -277,7 +275,9 @@ class Canada(HolidayBase):
                 and self._is_sunday(dt)
                 and self.subdiv in {"NS", "NL", "NT", "PE", "SK"}
             ):
-                self[dt + rd(weekday=MO)] = self.tr("%s (Observed)") % name
+                self[_get_nth_weekday_from(1, MON, dt)] = (
+                    self.tr("%s (Observed)") % name
+                )
 
         # Christmas Day,
         name = self.tr("Christmas Day")

--- a/holidays/countries/united_states.py
+++ b/holidays/countries/united_states.py
@@ -13,11 +13,10 @@ from datetime import date
 from datetime import timedelta as td
 
 from dateutil.easter import easter
-from dateutil.relativedelta import MO, TU, TH, FR
-from dateutil.relativedelta import relativedelta as rd
 
+from holidays.calendars import _get_nth_weekday_from, _get_nth_weekday_of_month
 from holidays.constants import JAN, FEB, MAR, APR, MAY, JUN, JUL, AUG, SEP
-from holidays.constants import OCT, NOV, DEC
+from holidays.constants import OCT, NOV, DEC, MON, TUE, THU, FRI
 from holidays.holiday_base import HolidayBase
 
 
@@ -130,10 +129,10 @@ class UnitedStates(HolidayBase):
         if self.subdiv == "VA" and year <= 2020:
             name = "Lee Jackson Day"
             if year >= 2000:
-                dt = date(year, JAN, 1) + rd(weekday=MO(+3)) + td(days=-3)
+                dt = _get_nth_weekday_of_month(3, MON, JAN, year) + td(days=-3)
                 self[dt] = name
             elif year >= 1983:
-                self[date(year, JAN, 1) + rd(weekday=MO(+3))] = name
+                self[_get_nth_weekday_of_month(3, MON, JAN, year)] = name
             elif year >= 1889:
                 self[date(year, JAN, 19)] = name
 
@@ -167,7 +166,7 @@ class UnitedStates(HolidayBase):
                 name = "Robert E. Lee's Birthday"
             elif self.subdiv == "ID" and year >= 2006:
                 name = "Martin Luther King Jr. - Idaho Human Rights Day"
-            self[date(year, JAN, 1) + rd(weekday=MO(+3))] = name
+            self[_get_nth_weekday_of_month(3, MON, JAN, year)] = name
 
         # Lincoln's Birthday
         if (
@@ -194,7 +193,7 @@ class UnitedStates(HolidayBase):
             name = "Presidents' Day"
         if self.subdiv not in {"DE", "FL", "GA", "NM", "PR"}:
             if year >= 1971:
-                self[date(year, FEB, 1) + rd(weekday=MO(+3))] = name
+                self[_get_nth_weekday_of_month(3, MON, FEB, year)] = name
             elif year >= 1879:
                 self[date(year, FEB, 22)] = name
         elif self.subdiv == "GA":
@@ -203,7 +202,7 @@ class UnitedStates(HolidayBase):
             else:
                 self[date(year, DEC, 26)] = name
         elif self.subdiv in {"PR", "VI"}:
-            self[date(year, FEB, 1) + rd(weekday=MO(+3))] = name
+            self[_get_nth_weekday_of_month(3, MON, FEB, year)] = name
 
         easter_date = easter(year)
         # Mardi Gras
@@ -212,11 +211,15 @@ class UnitedStates(HolidayBase):
 
         # Guam Discovery Day
         if self.subdiv == "GU" and year >= 1970:
-            self[date(year, MAR, 1) + rd(weekday=MO)] = "Guam Discovery Day"
+            self[
+                _get_nth_weekday_of_month(1, MON, MAR, year)
+            ] = "Guam Discovery Day"
 
         # Casimir Pulaski Day
         if self.subdiv == "IL" and year >= 1978:
-            self[date(year, MAR, 1) + rd(weekday=MO)] = "Casimir Pulaski Day"
+            self[
+                _get_nth_weekday_of_month(1, MON, MAR, year)
+            ] = "Casimir Pulaski Day"
 
         # Texas Independence Day
         if self.subdiv == "TX" and year >= 1874:
@@ -224,7 +227,9 @@ class UnitedStates(HolidayBase):
 
         # Town Meeting Day
         if self.subdiv == "VT" and year >= 1800:
-            self[date(year, MAR, 1) + rd(weekday=TU)] = "Town Meeting Day"
+            self[
+                _get_nth_weekday_of_month(1, TUE, MAR, year)
+            ] = "Town Meeting Day"
 
         # Evacuation Day
         if self.subdiv == "MA" and year >= 1901:
@@ -232,7 +237,7 @@ class UnitedStates(HolidayBase):
             dt = date(year, MAR, 17)
             self[dt] = name
             if self.observed and self._is_weekend(dt):
-                self[dt + rd(weekday=MO)] = f"{name} (Observed)"
+                self[_get_nth_weekday_from(1, MON, dt)] = f"{name} (Observed)"
 
         # Emancipation Day
         if self.subdiv == "PR":
@@ -256,7 +261,7 @@ class UnitedStates(HolidayBase):
         if self.subdiv == "AK":
             name = "Seward's Day"
             if year >= 1955:
-                self[date(year, MAR, 31) + rd(weekday=MO(-1))] = name
+                self[_get_nth_weekday_of_month(-1, MON, MAR, year)] = name
             elif year >= 1918:
                 self[date(year, MAR, 30)] = name
 
@@ -280,7 +285,7 @@ class UnitedStates(HolidayBase):
         if self.subdiv in {"MA", "ME"}:
             name = "Patriots' Day"
             if year >= 1969:
-                self[date(year, APR, 1) + rd(weekday=MO(+3))] = name
+                self[_get_nth_weekday_of_month(3, MON, APR, year)] = name
             elif year >= 1894:
                 self[date(year, APR, 19)] = name
 
@@ -318,7 +323,7 @@ class UnitedStates(HolidayBase):
             if self.subdiv == "GA" and year == 2020:
                 self[date(year, APR, 10)] = name
             else:
-                self[date(year, APR, 1) + rd(weekday=MO(+4))] = name
+                self[_get_nth_weekday_of_month(4, MON, APR, year)] = name
         elif self.subdiv == "TX" and year >= 1931:
             self[date(year, JAN, 19)] = name
 
@@ -330,7 +335,7 @@ class UnitedStates(HolidayBase):
         if self.subdiv == "NE":
             name = "Arbor Day"
             if year >= 1989:
-                self[date(year, APR, 30) + rd(weekday=FR(-1))] = name
+                self[_get_nth_weekday_of_month(-1, FRI, APR, year)] = name
             elif year >= 1875:
                 self[date(year, APR, 22)] = name
 
@@ -339,7 +344,7 @@ class UnitedStates(HolidayBase):
             (year >= 2006 and year % 2 == 0) or year >= 2015
         ):
             self[
-                (date(year, MAY, 1) + rd(weekday=MO) + td(days=+1))
+                _get_nth_weekday_of_month(1, MON, MAY, year) + td(days=+1)
             ] = "Primary Election Day"
 
         # Truman Day
@@ -348,7 +353,9 @@ class UnitedStates(HolidayBase):
 
         # Memorial Day
         if year >= 1971:
-            self[date(year, MAY, 31) + rd(weekday=MO(-1))] = "Memorial Day"
+            self[
+                _get_nth_weekday_of_month(-1, MON, MAY, year)
+            ] = "Memorial Day"
         elif year >= 1888:
             self[date(year, MAY, 30)] = "Memorial Day"
 
@@ -361,7 +368,7 @@ class UnitedStates(HolidayBase):
         # Jefferson Davis Birthday
         name = "Jefferson Davis Birthday"
         if self.subdiv == "AL" and year >= 1890:
-            self[date(year, JUN, 1) + rd(weekday=MO)] = name
+            self[_get_nth_weekday_of_month(1, MON, JUN, year)] = name
 
         # Kamehameha Day
         if self.subdiv == "HI" and year >= 1872:
@@ -404,11 +411,13 @@ class UnitedStates(HolidayBase):
 
         # Victory Day
         if self.subdiv == "RI" and year >= 1948:
-            self[date(year, AUG, 1) + rd(weekday=MO(+2))] = "Victory Day"
+            self[_get_nth_weekday_of_month(2, MON, AUG, year)] = "Victory Day"
 
         # Statehood Day (Hawaii)
         if self.subdiv == "HI" and year >= 1959:
-            self[date(year, AUG, 1) + rd(weekday=FR(+3))] = "Statehood Day"
+            self[
+                _get_nth_weekday_of_month(3, FRI, AUG, year)
+            ] = "Statehood Day"
 
         # Bennington Battle Day
         if self.subdiv == "VT" and year >= 1778:
@@ -422,7 +431,7 @@ class UnitedStates(HolidayBase):
 
         # Labor Day
         if year >= 1894:
-            self[date(year, SEP, 1) + rd(weekday=MO)] = "Labor Day"
+            self[_get_nth_weekday_of_month(1, MON, SEP, year)] = "Labor Day"
 
         # Columbus Day
         if self.subdiv not in {"AK", "AR", "DE", "FL", "HI", "NV"}:
@@ -433,14 +442,14 @@ class UnitedStates(HolidayBase):
             else:
                 name = "Columbus Day"
             if year >= 1970:
-                self[date(year, OCT, 1) + rd(weekday=MO(+2))] = name
+                self[_get_nth_weekday_of_month(2, MON, OCT, year)] = name
             elif year >= 1937:
                 self[date(year, OCT, 12)] = name
 
         # Commonwealth Cultural Day in Northern Mariana Islands
         if self.subdiv == "MP":
             self[
-                date(year, OCT, 1) + rd(weekday=MO(+2))
+                _get_nth_weekday_of_month(2, MON, OCT, year)
             ] = "Commonwealth Cultural Day"
 
         # Alaska Day
@@ -451,7 +460,7 @@ class UnitedStates(HolidayBase):
         if self.subdiv == "NV" and year >= 1933:
             dt = date(year, OCT, 31)
             if year >= 2000:
-                dt += rd(weekday=FR(-1))
+                dt = _get_nth_weekday_of_month(-1, FRI, OCT, year)
             self._add_with_observed(dt, "Nevada Day")
 
         # Liberty Day
@@ -478,7 +487,7 @@ class UnitedStates(HolidayBase):
             and year % 2 == 0
         ) or (self.subdiv in {"IN", "NY"} and year >= 2015):
             self[
-                date(year, NOV, 1) + rd(weekday=MO) + td(days=+1)
+                _get_nth_weekday_of_month(1, MON, NOV, year) + td(days=+1)
             ] = "Election Day"
 
         # All Souls' Day
@@ -495,7 +504,7 @@ class UnitedStates(HolidayBase):
         else:
             name = "Armistice Day"
         if 1971 <= year <= 1977:
-            self[date(year, OCT, 1) + rd(weekday=MO(+4))] = name
+            self[_get_nth_weekday_of_month(4, MON, OCT, year)] = name
         elif year >= 1938:
             self._add_with_observed(date(year, NOV, 11), name)
 
@@ -507,7 +516,7 @@ class UnitedStates(HolidayBase):
 
         # Thanksgiving
         if year >= 1871:
-            self[date(year, NOV, 1) + rd(weekday=TH(+4))] = "Thanksgiving"
+            self[_get_nth_weekday_of_month(4, THU, NOV, year)] = "Thanksgiving"
 
         # Day After Thanksgiving
         # Friday After Thanksgiving
@@ -536,7 +545,9 @@ class UnitedStates(HolidayBase):
                 name = "Family Day"
             if self.subdiv == "NM":
                 name = "Presidents' Day"
-            self[date(year, NOV, 1) + rd(weekday=TH(+4)) + td(days=+1)] = name
+            self[
+                _get_nth_weekday_of_month(4, THU, NOV, year) + td(days=+1)
+            ] = name
 
         # Robert E. Lee's Birthday
         if self.subdiv == "GA" and year >= 1986:
@@ -544,7 +555,9 @@ class UnitedStates(HolidayBase):
                 name = "State Holiday"
             else:
                 name = "Robert E. Lee's Birthday"
-            self[date(year, NOV, 29) + rd(weekday=FR(-1))] = name
+            self[
+                _get_nth_weekday_of_month(4, THU, NOV, year) + td(days=+1)
+            ] = name
 
         # Lady of Camarin Day
         if self.subdiv == "GU":
@@ -569,7 +582,7 @@ class UnitedStates(HolidayBase):
                 self[dt + td(days=-1)] = f"{name} (Observed)"
             # If on Saturday or Sunday, observed on Friday
             elif self.observed and self._is_weekend(dt):
-                self[dt + rd(weekday=FR(-1))] = f"{name} (Observed)"
+                self[_get_nth_weekday_from(-1, FRI, dt)] = f"{name} (Observed)"
 
         # Christmas Day
         if year >= 1871:
@@ -582,7 +595,7 @@ class UnitedStates(HolidayBase):
             self[dt] = name
             # If on Saturday or Sunday, observed on Monday
             if self.observed and self._is_weekend(dt):
-                self[dt + rd(weekday=MO)] = f"{name} (Observed)"
+                self[_get_nth_weekday_from(1, MON, dt)] = f"{name} (Observed)"
             # If on Monday, observed on Tuesday
             elif self.observed and self._is_monday(dt):
                 self[dt + td(days=+1)] = f"{name} (Observed)"

--- a/tests/test_calendars.py
+++ b/tests/test_calendars.py
@@ -13,6 +13,7 @@ import unittest
 from datetime import date
 
 from holidays import calendars
+from holidays.calendars import _get_nth_weekday_of_month
 from holidays.constants import FEB, MAR, MAY, JUN, JUL, AUG, OCT
 
 
@@ -110,3 +111,18 @@ class TestThaiLuniSolarCalendar(unittest.TestCase):
                 visakha_bucha_year_date[year],
                 self.calendar.visakha_bucha_date(year),
             )
+
+
+class TestRelativeWeekdays(unittest.TestCase):
+    def test_weekday_of_month(self):
+        # 1st Monday of 2023 months
+        for month, day in enumerate((3, 7, 7, 4, 2, 6, 4, 1, 5, 3, 7, 5), 1):
+            first_monday = _get_nth_weekday_of_month(1, 1, month, 2023)
+            self.assertEqual(first_monday.day, day)
+
+        # Last Saturday of 2023 months
+        for month, day in enumerate(
+            (28, 25, 25, 29, 27, 24, 29, 26, 30, 28, 25, 30), 1
+        ):
+            last_friday = _get_nth_weekday_of_month(-1, 5, month, 2023)
+            self.assertEqual(last_friday.day, day)


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Optimize relative weekdays calculation. Most common cases of `dateutil.relativedelta` use (n-th weekday of month, n-th weekday from date) replaced with own simple functions. To start, I chose 2 countries that have many such holidays - US and Canada.

Perhaps functions names need to be corrected. :)

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country holidays support (thank you!)
- [ ] Supported country holidays update (calendar discrepancy fix, localization)
- [x] Existing code/tests/processes improvement (best practice, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (adds functionality to python-holidays in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts
- [x] The code style looks good (`make pre-commit`)
- [x] I've added tests to verify that the new code works and all tests pass locally (`make test`)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)