### PR TITLE
Refactor `HolidayBase::get_named`

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -188,7 +188,9 @@ class TestCase(unittest.TestCase):
             instance_name=instance_name,
         )
         self.assertEqual(
-            len(holidays.years), len(holidays.get_named(name)), name
+            len(holidays.years),
+            len(holidays.get_named(name, lookup="exact")),
+            name,
         )
 
     def assertHolidayName(self, name, *args):
@@ -274,7 +276,7 @@ class TestCase(unittest.TestCase):
             args,
             instance_name=instance_name,
         )
-        self.assertFalse(holidays.get_named(name), name)
+        self.assertFalse(holidays.get_named(name, lookup="exact"), name)
 
     def assertNoHolidayName(self, name, *args):
         """Assert a holiday with a specific name doesn't exist."""

--- a/tests/countries/test_chile.py
+++ b/tests/countries/test_chile.py
@@ -270,12 +270,14 @@ class TestChile(TestCase):
         )
 
         self.assertHolidayName(
-            "Día del Respeto a la Diversidad",
+            "Día del Respeto a la Diversidad "
+            "[Day of the Meeting of Two Worlds]",
             Chile(years=range(2000, 2020)),
         )
 
         self.assertHolidayName(
-            "Día del Descubrimiento de dos Mundos",
+            "Día del Descubrimiento de dos Mundos "
+            "[Discovery of Two Worlds' Day]",
             Chile(years=range(2020, 2050)),
         )
 

--- a/tests/test_holiday_base.py
+++ b/tests/test_holiday_base.py
@@ -467,18 +467,100 @@ class TestBasics(unittest.TestCase):
 
         self.assertIn(date(2014, 12, 31), Dec31Holiday())
 
-    def test_get_named(self):
-        us = holidays.UnitedStates(years=[2020])
+    def test_get_named_contains(self):
+        us = holidays.UnitedStates(years=2020)
+
         holidays_count = len(us.keys())
-        # check for "New Year's Day" presence in get_named("new")
-        self.assertIn(date(2020, 1, 1), us.get_named("new"))
+        for name in ("New", "Year"):
+            self.assertIn(date(2020, 1, 1), us.get_named(name))
+        for name in ("new", "year", "NEW Year"):
+            self.assertNotIn(
+                date(2020, 1, 1), us.get_named(name, lookup="contains")
+            )
         self.assertEqual(holidays_count, len(us.keys()))
 
-        # check for searching holiday in US when the observed holiday is on
-        # a different year than input one
-        us = holidays.US(years=[2022])
-        us.get_named("Thanksgiving")
+        us = holidays.UnitedStates(years=2022)
+        self.assertEqual(
+            1, len(us.get_named("Thanksgiving", lookup="contains"))
+        )
+        self.assertEqual(1, len(us.get_named("Thanksgivi", lookup="contains")))
+        self.assertEqual(0, len(us.get_named("thanks", lookup="contains")))
         self.assertEqual([2022], list(us.years))
+
+        us = holidays.UnitedStates(observed=False, years=2022)
+        self.assertEqual(
+            2, len(us.get_named("Independence Day", lookup="contains"))
+        )
+        self.assertEqual(
+            0, len(us.get_named("independence day", lookup="contains"))
+        )
+
+    def test_get_named_exact(self):
+        us = holidays.UnitedStates(years=2020)
+        holidays_count = len(us.keys())
+        for name in ("New Year's Day", "Christmas Day"):
+            self.assertEqual(1, len(us.get_named(name)))
+        for name in ("New", "Day"):
+            self.assertEqual(0, len(us.get_named(name, lookup="exact")))
+        self.assertEqual(holidays_count, len(us.keys()))
+
+        us = holidays.UnitedStates(years=2022)
+        self.assertEqual(1, len(us.get_named("Thanksgiving", lookup="exact")))
+        self.assertEqual(0, len(us.get_named("thanksgiving", lookup="exact")))
+        self.assertEqual([2022], list(us.years))
+
+        us = holidays.UnitedStates(observed=False, years=2022)
+        self.assertEqual(
+            1, len(us.get_named("Independence Day", lookup="exact"))
+        )
+
+    def test_get_named_icontains(self):
+        us = holidays.UnitedStates(years=2020)
+        holidays_count = len(us.keys())
+        self.assertEqual(holidays_count, len(us.keys()))
+        for name in ("New", "Year", "new", "year", "NEW Year"):
+            self.assertIn(date(2020, 1, 1), us.get_named(name))
+
+        us = holidays.UnitedStates(years=2022)
+        for name in ("Thanksgiving", "thanksgiving", "Thanksgivi"):
+            self.assertEqual(1, len(us.get_named(name, lookup="icontains")))
+        self.assertEqual([2022], list(us.years))
+
+        us = holidays.UnitedStates(observed=False, years=2022)
+        self.assertEqual(
+            2, len(us.get_named("Independence Day", lookup="icontains"))
+        )
+
+    def test_get_named_iexact(self):
+        us = holidays.UnitedStates(years=2020)
+        holidays_count = len(us.keys())
+        self.assertEqual(holidays_count, len(us.keys()))
+
+        for name in ("new year's day", "New Year's Day"):
+            self.assertIn(
+                date(2020, 1, 1), us.get_named(name, lookup="iexact")
+            )
+        for name in ("New Year Day", "New Year", "year", "NEW Year"):
+            self.assertNotIn(
+                date(2020, 1, 1), us.get_named(name, lookup="iexact")
+            )
+
+        us = holidays.UnitedStates(years=2022)
+        self.assertEqual(1, len(us.get_named("thanksgiving", lookup="iexact")))
+        self.assertEqual(0, len(us.get_named("Thanksgivin", lookup="iexact")))
+        self.assertEqual([2022], list(us.years))
+
+        us = holidays.UnitedStates(years=2022)
+        self.assertEqual(
+            1, len(us.get_named("independence day", lookup="iexact"))
+        )
+
+    def test_get_named_lookup_invalid(self):
+        us = holidays.UnitedStates(years=2020)
+        self.assertRaises(
+            AttributeError,
+            lambda: us.get_named("Holiday name", lookup="invalid"),
+        )
 
 
 class TestArgs(unittest.TestCase):


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change
The PR aims to impove `HolidayBase::get_named` flexibility in terms of available holiday name lookup types:
  - Add `lookup` parameter.
  - Add `contains/iexact/icontains/iexact` lookup types.
  - Keep the current behavior with `icontains` as default lookup type.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country holidays support (thank you!)
- [ ] Supported country holidays update (calendar discrepancy fix, localization)
- [x] Existing code/tests/processes improvement (best practice, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (adds functionality to python-holidays in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts
- [x] The code style looks good (`make pre-commit`)
- [x] I've added tests to verify that the new code works and all tests pass locally (`make test`)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
