### PR TITLE
Use the built-in library for time zone functions

### DIFF
--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -25,7 +25,7 @@ from holidays.holiday_base import HolidayBase
 # use standard library for timezone
 try:
     from zoneinfo import ZoneInfo
-except ImportError:
+except ImportError:  # pragma: no cover
     from backports.zoneinfo import ZoneInfo  # type: ignore[no-redef]
 
 

--- a/holidays/countries/chile.py
+++ b/holidays/countries/chile.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from datetime import timedelta as td
 
-from dateutil import tz
 from dateutil.easter import easter
 from dateutil.relativedelta import MO
 from dateutil.relativedelta import relativedelta as rd
@@ -22,6 +21,12 @@ from pymeeus.Sun import Sun
 from holidays.constants import JAN, MAY, JUN, JUL, AUG, SEP, OCT, NOV, DEC
 from holidays.constants import TUE, WED, THU, FRI, SAT, SUN
 from holidays.holiday_base import HolidayBase
+
+# use standard library for timezone
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:
+    from backports.zoneinfo import ZoneInfo  # type: ignore[no-redef]
 
 
 class Chile(HolidayBase):
@@ -112,8 +117,8 @@ class Chile(HolidayBase):
             # to match Chile's timezone
             # https://www.feriadoschilenos.cl/#DiaNacionalDeLosPueblosIndigenasII
             equinox = map(int, Epoch(epoch).get_full_date())
-            adjusted_date = datetime(*equinox, tzinfo=tz.UTC).astimezone(
-                tz.gettz("America/Santiago")
+            adjusted_date = datetime(*equinox, tzinfo=timezone.utc).astimezone(
+                ZoneInfo("America/Santiago")
             )
             self[date(year, JUN, adjusted_date.day)] = name
 

--- a/holidays/countries/japan.py
+++ b/holidays/countries/japan.py
@@ -9,10 +9,9 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from datetime import timedelta as td
 
-from dateutil import tz
 from dateutil.relativedelta import MO
 from dateutil.relativedelta import relativedelta as rd
 from pymeeus.Epoch import Epoch
@@ -21,6 +20,12 @@ from pymeeus.Sun import Sun
 from holidays.constants import SUN, JAN, FEB, APR, MAY, JUN, JUL, AUG, SEP
 from holidays.constants import OCT, NOV, DEC
 from holidays.holiday_base import HolidayBase
+
+# use standard library for timezone
+try:
+    from zoneinfo import ZoneInfo
+except ImportError:  # pragma: no cover
+    from backports.zoneinfo import ZoneInfo  # type: ignore[no-redef]
 
 
 class Japan(HolidayBase):
@@ -66,8 +71,8 @@ class Japan(HolidayBase):
         # Vernal Equinox Day
         epoch = Sun.get_equinox_solstice(year, target="spring")
         equinox = map(int, Epoch(epoch).get_full_date())
-        adjusted_date = datetime(*equinox, tzinfo=tz.UTC).astimezone(
-            tz.gettz("Asia/Tokyo")
+        adjusted_date = datetime(*equinox, tzinfo=timezone.utc).astimezone(
+            ZoneInfo("Asia/Tokyo")
         )
         self[adjusted_date.date()] = "春分の日"
 
@@ -116,8 +121,8 @@ class Japan(HolidayBase):
         # Autumnal Equinox Day
         epoch = Sun.get_equinox_solstice(year, target="autumn")
         equinox = map(int, Epoch(epoch).get_full_date())
-        adjusted_date = datetime(*equinox, tzinfo=tz.UTC).astimezone(
-            tz.gettz("Asia/Tokyo")
+        adjusted_date = datetime(*equinox, tzinfo=timezone.utc).astimezone(
+            ZoneInfo("Asia/Tokyo")
         )
         self[adjusted_date.date()] = "秋分の日"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,6 +37,8 @@ install_requires =
     hijri-converter
     korean-lunar-calendar
     python-dateutil
+    backports.zoneinfo;python_version<'3.9'
+    tzdata;os_name=='nt'
 python_requires = >=3.7
 
 [options.package_data]


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Use the built-in library for timezone functions.

Benefits:
* Implemented best practice of using built-in libraries when possible;
* Improved speed of line 120 of ``chile.py`` by ~1.6x;
* Removed dependency on external package ``python-dateutil`` for timezone.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country holidays support (thank you!)
- [ ] Supported country holidays update (calendar discrepancy fix, localization)
- [x] Existing code/tests/processes improvement (best practice, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (adds functionality to python-holidays in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts
- [x] The code style looks good (`make pre-commit`)
- [x] I've added tests to verify that the new code works and all tests pass locally (`make test`)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
