### PR TITLE
Clean up Thailand localization and in-line code comments

### DIFF
--- a/holidays/countries/thailand.py
+++ b/holidays/countries/thailand.py
@@ -287,11 +287,7 @@ class Thailand(HolidayBase):
 
         super()._populate(year)
 
-        ########################
-        #
         # Fixed Date Holidays
-        #
-        ########################
 
         # New Year's Day.
         # วันขึ้นปีใหม่
@@ -576,11 +572,7 @@ class Thailand(HolidayBase):
 
         self[date(year, DEC, 31)] = self.tr("วันสิ้นปี")
 
-        ################################
-        #
         # Thai Lunar Calendar Holidays
-        #
-        ################################
 
         """
         See `_ThaiLuniSolar` in holidays/utils.py for more details.
@@ -645,11 +637,7 @@ class Thailand(HolidayBase):
                     "ชดเชย%s"
                 ) % self.tr("วันอาสาฬหบูชา")
 
-        #################################
-        #
         # No Future Fixed Date Holidays
-        #
-        #################################
 
         # Royal Ploughing Ceremony.
         # วันพืชมงคล

--- a/holidays/countries/thailand.py
+++ b/holidays/countries/thailand.py
@@ -114,13 +114,15 @@ class Thailand(HolidayBase):
     country = "TH"
     default_language = "th"
 
-    # วันหยุดพิเศษ (เพิ่มเติม) - see Bank of Thailand's DB for Cross-Check
+    # วันหยุดพิเศษ (เพิ่มเติม) - see Bank of Thailand's DB for Cross-Check.
+
     thai_special_in_lieu_holidays = tr("วันหยุดชดเชย")
     thai_election = tr("วันเลือกตั้ง")
     thai_election_in_lieu = tr("ชดเชย%s") % thai_election
     thai_bridge_public_holiday = tr("วันหยุดพิเศษ (เพิ่มเติม)")
 
-    # Special Cases
+    # Special Cases.
+
     rama_ix_golden_jubilee = tr("พระราชพิธีกาญจนาภิเษก พ.ศ. 2539")
     rama_ix_sixty_accession = tr(
         "พระราชพิธีฉลองสิริราชสมบัติครบ 60 ปี พ.ศ. 2549"
@@ -143,7 +145,7 @@ class Thailand(HolidayBase):
     songkran_festival_in_lieu_covid = tr("ชดเชย%s") % tr("วันสงกรานต์")
 
     special_holidays = {
-        # 1992-1994 (include In Lieus, Checked with Bank of Thailand Data)
+        # 1992-1994 (include In Lieus, Checked with Bank of Thailand Data).
         1992: (
             (MAY, 18, thai_special_in_lieu_holidays),
             (DEC, 7, thai_special_in_lieu_holidays),
@@ -161,9 +163,9 @@ class Thailand(HolidayBase):
             (OCT, 24, thai_special_in_lieu_holidays),
             (DEC, 12, thai_special_in_lieu_holidays),
         ),
-        # 1995-1997 (Bank of Thailand Data)
+        # 1995-1997 (Bank of Thailand Data).
         1996: ((JUN, 10, rama_ix_golden_jubilee),),
-        # 1998-2000 (include In Lieus, Checked with Bank of Thailand Data)
+        # 1998-2000 (include In Lieus, Checked with Bank of Thailand Data).
         1998: (
             (MAY, 11, thai_special_in_lieu_holidays),
             (DEC, 7, thai_special_in_lieu_holidays),
@@ -181,7 +183,7 @@ class Thailand(HolidayBase):
             (DEC, 11, thai_special_in_lieu_holidays),
             (DEC, 29, thai_election),
         ),
-        # From 2001 Onwards (Checked with Bank of Thailand Data)
+        # From 2001 Onwards (Checked with Bank of Thailand Data).
         2006: (
             (APR, 19, thai_election),
             (JUN, 9, rama_ix_sixty_accession),
@@ -251,8 +253,8 @@ class Thailand(HolidayBase):
         super().__init__(**kwargs)
 
     def _populate(self, year):
-        # Due to Thai Calendar Migration, this is capped off at 1941
-        # But certain holidays were implemented before 1941
+        # Due to Thai Calendar Migration, this is capped off at 1941.
+        # But certain holidays were implemented before 1941.
         if year <= 1940:
             return None
 
@@ -287,26 +289,27 @@ class Thailand(HolidayBase):
 
         ########################
         #
-        # FIXED DATED HOLIDAYS
+        # Fixed Date Holidays
         #
         ########################
 
-        # !!! New Year's Day !!!
+        # New Year's Day.
         # วันขึ้นปีใหม่
-        # Status: In-Use
-        # Starts in the present form in 1941 (B.E. 2484)
+        # Status: In-Use.
+        # Starts in the present form in 1941 (B.E. 2484).
         # TODO: Add check for 1941 if we support earlier dates.
 
         _add_with_observed(date(year, JAN, 1), self.tr("วันขึ้นปีใหม่"))
 
-        # !!! New Year's Eve (in lieu) !!!
+        # New Year's Eve (in lieu).
         # วันหยุดชดเชยวันสิ้นปี
-        # Status: In-Use
+        # Status: In-Use.
         # Added separately from New Year's Eve itself so that it would't
-        #   go over the next year
-        #   - CASE 1: SAT-SUN -> 1 in-lieu on TUE
-        #   - CASE 2: SUN-MON -> 1 in-lieu on TUE
-        # See in lieu logic in `_add_with_observed(dt, holiday_name)`
+        #   go over the next year.
+        #   - CASE 1: SAT-SUN -> 1 in-lieu on TUE.
+        #   - CASE 2: SUN-MON -> 1 in-lieu on TUE.
+        # See in lieu logic in `_add_with_observed(dt, holiday_name)`.
+
         new_years_eve_in_lieu = self.tr("ชดเชย%s") % self.tr("วันสิ้นปี")
 
         if self.observed and (1995 <= year <= 1997 or year >= 2001):
@@ -315,27 +318,28 @@ class Thailand(HolidayBase):
             elif self._is_sunday(date(year - 1, DEC, 31)):
                 self[date(year, JAN, 2)] = new_years_eve_in_lieu
 
-        # !!! Chakri Memorial Day !!!
+        # Chakri Memorial Day.
         # วันจักรี
-        # Status: In-Use
-        # Starts in present form in 1918 (B.E. 2461)
+        # Status: In-Use.
+        # Starts in present form in 1918 (B.E. 2461).
         # TODO: Add check for 1918 if we support earlier dates.
 
         _add_with_observed(date(year, APR, 6), self.tr("วันจักรี"))
 
-        # !!! Songkran Festival !!!
+        # Songkran Festival.
         # วันสงกรานต์
-        # Status: In-Use
-        # Used to be April 1st as Thai New Year Day
+        # Status: In-Use.
+        # Used to be April 1st as Thai New Year Day.
         # Initially abandoned in 1941 (B.E. 2484), declared again as
-        #   public holidays in 1948 (2491 B.E)
+        #   public holidays in 1948 (2491 B.E).
         #  - 1948-1953, celebrated on Apr 13-15
         #  - 1954-1956, abandoned as a public holiday
         #  - 1957-1988, only celebrated on Apr 13
         #  - 1989-1997, celebrated on Apr 12-14
         #  - 1998-Present, celebrated on Apr 13-15
         #    (Except for 2020 due to Covid-19 outbreaks)
-        # This has its own in-lieu trigger
+        # This has its own in-lieu trigger.
+
         songkran_festival = self.tr("วันสงกรานต์")
 
         if 1948 <= year <= 1953:
@@ -353,15 +357,15 @@ class Thailand(HolidayBase):
             self[date(year, APR, 14)] = songkran_festival
             self[date(year, APR, 15)] = songkran_festival
 
-        # !!! Songkran Festival (in lieu) !!!
+        # Songkran Festival (in lieu).
         # วันหยุดชดเชยวันสงกรานต์
         # If Songkran happened to be held on the weekends, only one in-lieu
-        #   public holiday is added, No in lieus for SUN-MON-TUE case
+        #   public holiday is added, No in lieus for SUN-MON-TUE case.
         #   - CASE 1: THU-FRI-SAT -> 1 in-lieu on MON
         #   - CASE 2: FRI-SAT-SUN -> 1 in-lieu on MON
         #   - CASE 3: SAT-SUN-MON -> 1 in-lieu on TUE
-        # See in lieu logic in `_add_with_observed(dt, holiday_name)`
-        # Status: In Use
+        # See in lieu logic in `_add_with_observed(dt, holiday_name)`.
+        # Status: In Use.
 
         songkran_festival_in_lieu = self.tr("ชดเชย%s") % songkran_festival
 
@@ -375,24 +379,24 @@ class Thailand(HolidayBase):
             elif self._is_monday(dt):
                 self[dt + td(days=+1)] = songkran_festival_in_lieu
 
-        # !!! National Labour day !!!
+        # National Labour day.
         # วันแรงงานแห่งชาติ
-        # Status: In-Use
-        # Starts in the present form in 1974 (B.E. 2517)
+        # Status: In-Use.
+        # Starts in the present form in 1974 (B.E. 2517).
         # Does existed officially since 1956 (B.E. 2499),
-        #   but wasn't a public holiday until then
-        # *** NOTE: only observed by financial and private sectors
+        #   but wasn't a public holiday until then.
+        # *** NOTE: only observed by financial and private sectors.
 
         if year >= 1974:
             _add_with_observed(
                 date(year, MAY, 1), self.tr("วันแรงงานแห่งชาติ")
             )
 
-        # !!! National Day (24 June) !!!
+        # National Day (24 June).
         # วันชาติ
-        # Status: Defunct (Historical)
-        # Starts in 1939 (B.E. 2482) by Plaek Phibunsongkhram
-        # Replaced by Rama IX's birthday in 1960 (B.E. 2503) by Sarit Thanarat
+        # Status: Defunct (Historical).
+        # Starts in 1939 (B.E. 2482) by Plaek Phibunsongkhram.
+        # Replaced by Rama IX's birthday in 1960 (B.E. 2503) by Sarit Thanarat.
         # TODO: Add check for 1939 if we support earlier dates.
 
         _add_with_observed(
@@ -400,11 +404,12 @@ class Thailand(HolidayBase):
             self.tr("วันชาติ"),
         )
 
-        # !!! Coronation Day !!!
+        # Coronation Day.
         # วันฉัตรมงคล
-        # Starts in 1958 (B.E. 2501) for Rama IX's Coronation: May 5th
-        # No celebration in 2017-2019 (B.E 2560-2562)
-        # Reestablished with Rama X's Coronation in 2020: May 4th
+        # Starts in 1958 (B.E. 2501) for Rama IX's Coronation: May 5th.
+        # No celebration in 2017-2019 (B.E 2560-2562).
+        # Reestablished with Rama X's Coronation in 2020: May 4th.
+
         coronation_day = self.tr("วันฉัตรมงคล")
 
         if 1958 <= year <= 2016:
@@ -412,10 +417,10 @@ class Thailand(HolidayBase):
         elif year >= 2020:
             _add_with_observed(date(year, MAY, 4), coronation_day)
 
-        # !!! HM Queen Suthida's Birthday !!!
+        # HM Queen Suthida's Birthday.
         # วันเฉลิมพระชนมพรรษา พระราชินี
-        # Status: In-Use
-        # Starts in 2019 (B.E. 2562)
+        # Status: In-Use.
+        # Starts in 2019 (B.E. 2562).
 
         if year >= 2019:
             _add_with_observed(
@@ -426,10 +431,10 @@ class Thailand(HolidayBase):
                 ),
             )
 
-        # !!! HM King Maha Vajiralongkorn's Birthday !!!
+        # HM King Maha Vajiralongkorn's Birthday.
         # วันเฉลิมพระชนมพรรษา รัชกาลที่ 10
-        # Status: In-Use
-        # Started in 2017 (B.E 2560)
+        # Status: In-Use.
+        # Started in 2017 (B.E 2560).
 
         if year >= 2017:
             _add_with_observed(
@@ -441,12 +446,12 @@ class Thailand(HolidayBase):
                 ),
             )
 
-        # !!! HM Queen Sirikit the Queen Mother's Birthday !!!
-        # วันเฉลิมพระชนมพรรษา พระบรมราชินีนาถ ( 1976-2017),
+        # HM Queen Sirikit the Queen Mother's Birthday.
+        # วันเฉลิมพระชนมพรรษา พระบรมราชินีนาถ ( 1976-2017)
         # วันเฉลิมพระชนมพรรษา พระบรมราชชนนีพันปีหลวง (2017-Present)
-        # Status: In-Use
-        # Started in 1976 (B.E. 2519) alongside Mother's Day
-        # Initial celebration as HM Queen Sirikit's Birthday
+        # Status: In-Use.
+        # Started in 1976 (B.E. 2519) alongside Mother's Day.
+        # Initial celebration as HM Queen Sirikit's Birthday.
         # Now acts as the Queen Mother from 2017 onwards.
 
         if 1976 <= year <= 2016:
@@ -463,13 +468,14 @@ class Thailand(HolidayBase):
                 self.tr("วันเฉลิมพระชนมพรรษาสมเด็จพระบรมราชชนนีพันปีหลวง"),
             )
 
-        # !!! National Mother's Day !!!
+        # National Mother's Day.
         # วันแม่แห่งชาติ
-        # Status: In-Use
+        # Status: In-Use.
         # Started 1950 (B.E 2493) initially as April 15 and cancelled in
         #   1958 (B.E 2501) when the Min. of Culture was abolished.
         # Restarts again in 1976 (B.E. 2519) on Queen Sirikit's Birthday
         #   (August 12) and stay that way from that point onwards.
+
         thai_mothers_day = self.tr("วันแม่แห่งชาติ")
 
         if 1950 <= year <= 1957:
@@ -477,11 +483,11 @@ class Thailand(HolidayBase):
         elif year >= 1976:
             _add_with_observed(date(year, AUG, 12), thai_mothers_day)
 
-        # !!! Anniversary for the Death of King Bhumibol Adulyadej !!!
+        # Anniversary for the Death of King Bhumibol Adulyadej.
         # วันคล้ายวันสวรรคตพระบาทสมเด็จพระปรมินทร มหาภูมิพลอดุลยเดช บรมนาถบพิตร
-        # Status: In-Use
-        # Started in 2017 (B.E 2560)
-        # Got conferred with 'the Great' title in 2019 (B.E. 2562)
+        # Status: In-Use.
+        # Started in 2017 (B.E 2560).
+        # Got conferred with 'the Great' title in 2019 (B.E. 2562).
 
         if 2017 <= year <= 2018:
             _add_with_observed(
@@ -500,21 +506,21 @@ class Thailand(HolidayBase):
                 ),
             )
 
-        # !!! HM King Chulalongkorn Memorial Day !!!
+        # HM King Chulalongkorn Memorial Day.
         # วันปิยมหาราช
-        # Status: In-Use
-        # Started in 1911 (B.E. 2454)
+        # Status: In-Use.
+        # Started in 1911 (B.E. 2454).
         # TODO: Add check for 1911 if we support earlier dates.
 
         _add_with_observed(date(year, OCT, 23), self.tr("วันปิยมหาราช"))
 
-        # !!! HM King Bhumibol Adulyadej's Birthday Anniversary !!!
-        # วันเฉลิมพระชนมพรรษา รัชกาลที่ 9 (1960-2016),
+        # HM King Bhumibol Adulyadej's Birthday Anniversary.
+        # วันเฉลิมพระชนมพรรษา รัชกาลที่ 9 (1960-2016)
         # วันคล้ายวันเฉลิมพระชนมพรรษา รัชกาลที่ 9 (2017-Present)
-        # Status: In-Use
-        # Replaced Nataion Day (26 June) in 1960 (B.E. 2503) by Sarit Thanarat
-        # Confirmed as still in-use in 2017
-        # Got conferred with 'the Great' title in 2019 (B.E. 2562)
+        # Status: In-Use.
+        # Replaced Nataion Day (26 June) in 1960 (B.E. 2503) by Sarit Thanarat.
+        # Confirmed as still in-use in 2017.
+        # Got conferred with 'the Great' title in 2019 (B.E. 2562).
 
         if 1960 <= year <= 2015:
             _add_with_observed(
@@ -541,38 +547,38 @@ class Thailand(HolidayBase):
                 ),
             )
 
-        # !!! National Father's Day !!!
+        # National Father's Day.
         # วันพ่อแห่งชาติ
-        # Status: In-Use
-        # Starts in 1980 (B.E 2523)
+        # Status: In-Use.
+        # Starts in 1980 (B.E 2523).
         # Technically, a replication of HM King Bhumibol Adulyadej's Birthday
-        #   but it's in the official calendar, so may as well have this here
+        #   but it's in the official calendar, so may as well have this here.
 
         if year >= 1980:
             _add_with_observed(date(year, DEC, 5), self.tr("วันพ่อแห่งชาติ"))
 
-        # !!! Constitution Day !!!
+        # Constitution Day.
         # วันรัฐธรรมนูญ
-        # Status: In-Use
-        # Presumed to starts in 1932 (B.E. 2475) ???
-        # Last known official record is Bank of Thailand's in 1992 (B.E. 2535)
+        # Status: In-Use.
+        # Presumed to starts in 1932 (B.E. 2475).
+        # Last known official record is Bank of Thailand's in 1992 (B.E. 2535).
         # TODO: Add check for 1932 if we support earlier dates.
 
         _add_with_observed(date(year, DEC, 10), self.tr("วันรัฐธรรมนูญ"))
 
-        # !!! New Year's Eve !!!
+        # New Year's Eve.
         # วันสิ้นปี
-        # Status: In-Use
-        # Presumed to start in the present form in 1941 (B.E. 2484) ???
-        # Last known official record is Bank of Thailand's in 1992 (B.E. 2535)
+        # Status: In-Use.
+        # Presumed to start in the present form in 1941 (B.E. 2484).
+        # Last known official record is Bank of Thailand's in 1992 (B.E. 2535).
         # TODO: Add check for 1941 if we support earlier dates.
-        # This has its own in-lieu trigger
+        # This has its own in-lieu trigger.
 
         self[date(year, DEC, 31)] = self.tr("วันสิ้นปี")
 
         ################################
         #
-        # THAI LUNAR CALENDAR HOLIDAYS
+        # Thai Lunar Calendar Holidays
         #
         ################################
 
@@ -582,48 +588,48 @@ class Thailand(HolidayBase):
         Thai Lunar Calendar Holidays only work from 1941 (B.E. 2484) onwards
         until 2057 (B.E. 2600).
         """
-        # !!! Makha Bucha !!!
+        # Makha Bucha.
         # วันมาฆบูชา
-        # Status: In-Use
+        # Status: In-Use.
 
         makha_bucha_date = self.thls.makha_bucha_date(year)
         if makha_bucha_date:
             _add_with_observed(makha_bucha_date, self.tr("วันมาฆบูชา"))
 
-        # !!! Visakha Bucha !!!
+        # Visakha Bucha.
         # วันวิสาขบูชา
-        # Status: In-Use
+        # Status: In-Use.
 
         visakha_bucha_date = self.thls.visakha_bucha_date(year)
         if visakha_bucha_date:
             _add_with_observed(visakha_bucha_date, self.tr("วันวิสาขบูชา"))
 
-        # !!! Asarnha Bucha !!!
+        # Asarnha Bucha.
         # วันอาสาฬหบูชา
-        # Status: In-Use
-        # This has its own in-lieu trigger
+        # Status: In-Use.
+        # This has its own in-lieu trigger.
 
         asarnha_bucha_date = self.thls.asarnha_bucha_date(year)
         if asarnha_bucha_date:
             self[asarnha_bucha_date] = self.tr("วันอาสาฬหบูชา")
 
-        # !!! Buddhist Lent Day !!!
+        # Buddhist Lent Day.
         # วันเข้าพรรษา
-        # Status: In-Use
-        # This has its own in-lieu trigger
+        # Status: In-Use.
+        # This has its own in-lieu trigger.
 
         khao_phansa_date = self.thls.khao_phansa_date(year)
         if khao_phansa_date:
             self[khao_phansa_date] = self.tr("วันเข้าพรรษา")
 
-        # !!! Asarnha Bucha/Buddhist Lent Day (in lieu) !!!
+        # Asarnha Bucha/Buddhist Lent Day (in lieu).
         # วันหยุดชดเชยวันอาสาฬหบูชา
         # วันหยุดชดเชยวันเข้าพรรษา
-        # Status: In Use
+        # Status: In Use.
         #  - CASE 1: FRI-SAT -> 1 in-lieu on MON
         #  - CASE 2: SAT-SUN -> 1 in-lieu on MON
         #  - CASE 3: SUN-MON -> 1 in-lieu on TUE
-        # See in lieu logic in `_add_with_observed(dt, holiday_name)`
+        # See in lieu logic in `_add_with_observed(dt, holiday_name)`.
 
         if (
             asarnha_bucha_date
@@ -641,25 +647,26 @@ class Thailand(HolidayBase):
 
         #################################
         #
-        # NO FUTURE FIXED DATE HOLIDAYS
+        # No Future Fixed Date Holidays
         #
         #################################
 
-        # !!! Royal Ploughing Ceremony !!!
+        # Royal Ploughing Ceremony.
         # วันพืชมงคล
-        # Restarts in 1957 (B.E. 2500)
-        # Is dated on an annual basis by the Royal Palace
+        # Restarts in 1957 (B.E. 2500).
+        # Is dated on an annual basis by the Royal Palace.
         # This isn't even fixed even by the Thai Lunar Calendar, but instead
         #   by Court Astrologers; All chosen dates are all around May, so we
         #   can technically assign it to 13 May for years prior with no data.
-        # *** NOTE: only observed by government sectors
-        # TODO: Update this annually around Dec of each year
+        # *** NOTE: only observed by government sectors.
+        # TODO: Update this annually around Dec of each year.
+
         raeknakhwan = self.tr("วันพืชมงคล")
 
         raeknakhwan_dates = {
             1997: (MAY, 13),
             1998: (MAY, 13),
-            # Not held in 1999 date
+            # Not held in 1999 date.
             2000: (MAY, 15),
             2001: (MAY, 16),
             2002: (MAY, 9),
@@ -685,12 +692,12 @@ class Thailand(HolidayBase):
             2022: (MAY, 17),
             2023: (MAY, 11),
         }
-        # For years with exact date data
+        # For years with exact date data.
         if year in raeknakhwan_dates:
             _add_with_observed(
                 date(year, *raeknakhwan_dates[year]), raeknakhwan
             )
-        # Approx. otherwise for 1957-2013
+        # Approx. otherwise for 1957-2013.
         elif 1957 <= year <= 1996:
             _add_with_observed(date(year, MAY, 13), raeknakhwan)
 

--- a/holidays/locale/en_US/LC_MESSAGES/TH.po
+++ b/holidays/locale/en_US/LC_MESSAGES/TH.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Python Holidays 0.20\n"
-"POT-Creation-Date: 2023-03-01 10:36+0700\n"
+"POT-Creation-Date: 2023-03-02 00:37+0700\n"
 "PO-Revision-Date: \n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Python Holidays localization team\n"
@@ -23,9 +23,9 @@ msgid "วันเลือกตั้ง"
 msgstr "Thai Election Day"
 
 #: holidays/countries/thailand.py:121 holidays/countries/thailand.py:145
-#: holidays/countries/thailand.py:286 holidays/countries/thailand.py:313
-#: holidays/countries/thailand.py:370 holidays/countries/thailand.py:640
-#: holidays/countries/thailand.py:644
+#: holidays/countries/thailand.py:286 holidays/countries/thailand.py:309
+#: holidays/countries/thailand.py:366 holidays/countries/thailand.py:632
+#: holidays/countries/thailand.py:636
 #, c-format
 msgid "ชดเชย%s"
 msgstr "%s (in lieu)"
@@ -66,108 +66,108 @@ msgstr "HM King Bhumibol Adulyadej's Royal Cremation Ceremony"
 msgid "พระราชพิธีบรมราชาภิเษก พระบาทสมเด็จพระวชิรเกล้าเจ้าอยู่หัว"
 msgstr "HM King Maha Vajiralongkorn's Coronation Celebrations"
 
-#: holidays/countries/thailand.py:145 holidays/countries/thailand.py:343
+#: holidays/countries/thailand.py:145 holidays/countries/thailand.py:339
 msgid "วันสงกรานต์"
 msgstr "Songkran Festival"
 
-#: holidays/countries/thailand.py:302
+#: holidays/countries/thailand.py:298
 msgid "วันขึ้นปีใหม่"
 msgstr "New Year's Day"
 
-#: holidays/countries/thailand.py:313 holidays/countries/thailand.py:577
+#: holidays/countries/thailand.py:309 holidays/countries/thailand.py:573
 msgid "วันสิ้นปี"
 msgstr "New Year's Eve"
 
-#: holidays/countries/thailand.py:327
+#: holidays/countries/thailand.py:323
 msgid "วันจักรี"
 msgstr "Chakri Memorial Day"
 
-#: holidays/countries/thailand.py:392
+#: holidays/countries/thailand.py:388
 msgid "วันแรงงานแห่งชาติ"
 msgstr "National Labour Day"
 
-#: holidays/countries/thailand.py:404
+#: holidays/countries/thailand.py:400
 msgid "วันชาติ"
 msgstr "National Day"
 
-#: holidays/countries/thailand.py:413
+#: holidays/countries/thailand.py:409
 msgid "วันฉัตรมงคล"
 msgstr "Coronation Day"
 
-#: holidays/countries/thailand.py:428
+#: holidays/countries/thailand.py:424
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระนางเจ้าสุทิดา พัชรสุธาพิมลลักษณ พระบรมราชินี"
 msgstr "HM Queen Suthida's Birthday"
 
-#: holidays/countries/thailand.py:442
+#: holidays/countries/thailand.py:438
 msgid ""
 "วันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรเมนทรรามาธิบดีศรีสินทรมหาวชิราลงกรณ "
 "พระวชิรเกล้าเจ้าอยู่หัว"
 msgstr "HM King Maha Vajiralongkorn's Birthday"
 
-#: holidays/countries/thailand.py:460
+#: holidays/countries/thailand.py:456
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระนางเจ้าสิริกิติ์ พระบรมราชินีนาถ"
 msgstr "HM Queen Sirikit's Birthday"
 
-#: holidays/countries/thailand.py:468
+#: holidays/countries/thailand.py:464
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระบรมราชชนนีพันปีหลวง"
 msgstr "HM Queen Sirikit The Queen Mother's Birthday"
 
-#: holidays/countries/thailand.py:479
+#: holidays/countries/thailand.py:475
 msgid "วันแม่แห่งชาติ"
 msgstr "National Mother's Day"
 
-#: holidays/countries/thailand.py:495
+#: holidays/countries/thailand.py:491
 msgid "วันคล้ายวันสวรรคตพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr "HM King Bhumibol Adulyadej Memorial Day"
 
-#: holidays/countries/thailand.py:503
+#: holidays/countries/thailand.py:499
 msgid ""
 "วันคล้ายวันสวรรคตพระบาทสมเด็จพระบรมชนกาธิเบศร มหาภูมิพลอดุลยเดชมหาราช บรมนาถบพิตร"
 msgstr "HM King Bhumibol Adulyadej the Great Memorial Day"
 
-#: holidays/countries/thailand.py:515
+#: holidays/countries/thailand.py:511
 msgid "วันปิยมหาราช"
 msgstr "HM King Chulalongkorn Memorial Day"
 
-#: holidays/countries/thailand.py:528
+#: holidays/countries/thailand.py:524
 #, fuzzy
 msgid "วันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr "HM King Bhumibol Adulyadej's Birthday"
 
-#: holidays/countries/thailand.py:536
+#: holidays/countries/thailand.py:532
 msgid "วันคล้ายวันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr "HM King Bhumibol Adulyadej's Birthday"
 
-#: holidays/countries/thailand.py:544
+#: holidays/countries/thailand.py:540
 msgid ""
 "วันคล้ายวันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระบรมชนกาธิเบศร มหาภูมิพลอดุลยเดชมหาราช "
 "บรมนาถบพิตร"
 msgstr "HM King Bhumibol Adulyadej the Great's Birthday"
 
-#: holidays/countries/thailand.py:558
+#: holidays/countries/thailand.py:554
 msgid "วันพ่อแห่งชาติ"
 msgstr "National Father's Day"
 
-#: holidays/countries/thailand.py:567
+#: holidays/countries/thailand.py:563
 msgid "วันรัฐธรรมนูญ"
 msgstr "Constitution Day"
 
-#: holidays/countries/thailand.py:597
+#: holidays/countries/thailand.py:589
 msgid "วันมาฆบูชา"
 msgstr "Makha Bucha"
 
-#: holidays/countries/thailand.py:605
+#: holidays/countries/thailand.py:597
 msgid "วันวิสาขบูชา"
 msgstr "Visakha Bucha"
 
-#: holidays/countries/thailand.py:614 holidays/countries/thailand.py:646
+#: holidays/countries/thailand.py:606 holidays/countries/thailand.py:638
 msgid "วันอาสาฬหบูชา"
 msgstr "Asarnha Bucha"
 
-#: holidays/countries/thailand.py:623 holidays/countries/thailand.py:642
+#: holidays/countries/thailand.py:615 holidays/countries/thailand.py:634
 msgid "วันเข้าพรรษา"
 msgstr "Buddhist Lent Day"
 
-#: holidays/countries/thailand.py:664
+#: holidays/countries/thailand.py:652
 msgid "วันพืชมงคล"
 msgstr "Royal Ploughing Ceremony"

--- a/holidays/locale/en_US/LC_MESSAGES/TH.po
+++ b/holidays/locale/en_US/LC_MESSAGES/TH.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Python Holidays 0.20\n"
-"POT-Creation-Date: 2023-02-23 09:43+0700\n"
+"POT-Creation-Date: 2023-03-01 10:36+0700\n"
 "PO-Revision-Date: \n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Python Holidays localization team\n"
@@ -14,193 +14,160 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#. วันหยุดพิเศษ (เพิ่มเติม) - see Bank of Thailand's DB for Cross-Check
-#: holidays/countries/thailand.py:118
+#: holidays/countries/thailand.py:119
 msgid "วันหยุดชดเชย"
 msgstr "Special In Lieu Holiday"
 
-#: holidays/countries/thailand.py:119
+#: holidays/countries/thailand.py:120
 msgid "วันเลือกตั้ง"
 msgstr "Thai Election Day"
 
-#.
-#. !!! New Year's Eve (in lieu) !!! วันหยุดชดเชยวันสิ้นปี Status: In-Use Added
-#. separately from New Year's Eve itself so that it would't go over the next
-#. year - CASE 1: SAT-SUN -> 1 in-lieu on TUE - CASE 2: SUN-MON -> 1 in-lieu on
-#. TUE See in lieu logic in `_add_with_observed(dt, holiday_name)`
-#: holidays/countries/thailand.py:120 holidays/countries/thailand.py:143
-#: holidays/countries/thailand.py:284 holidays/countries/thailand.py:310
-#: holidays/countries/thailand.py:366 holidays/countries/thailand.py:634
-#: holidays/countries/thailand.py:638
+#: holidays/countries/thailand.py:121 holidays/countries/thailand.py:145
+#: holidays/countries/thailand.py:286 holidays/countries/thailand.py:313
+#: holidays/countries/thailand.py:370 holidays/countries/thailand.py:640
+#: holidays/countries/thailand.py:644
 #, c-format
 msgid "ชดเชย%s"
 msgstr "%s (in lieu)"
 
-#: holidays/countries/thailand.py:121
+#: holidays/countries/thailand.py:122
 msgid "วันหยุดพิเศษ (เพิ่มเติม)"
 msgstr "Bridge Public Holiday"
 
-#. Special Cases
-#: holidays/countries/thailand.py:124
+#: holidays/countries/thailand.py:126
 msgid "พระราชพิธีกาญจนาภิเษก พ.ศ. 2539"
 msgstr "HM King Bhumibol Adulyadej's Golden Jubilee"
 
-#: holidays/countries/thailand.py:125
+#: holidays/countries/thailand.py:127
 msgid "พระราชพิธีฉลองสิริราชสมบัติครบ 60 ปี พ.ศ. 2549"
 msgstr "HM King Bhumibol Adulyadej's 60th Anniversary of Accession Event"
 
-#: holidays/countries/thailand.py:128
+#: holidays/countries/thailand.py:130
 msgid "วันหยุดพิเศษ (คมช.)"
 msgstr "Emergency Lockdown (Thai Military Coup d'état)"
 
-#: holidays/countries/thailand.py:129
+#: holidays/countries/thailand.py:131
 msgid "วันหยุดพิเศษ (การเมือง)"
 msgstr "Emergency Lockdown (Thai Political Unrest)"
 
-#: holidays/countries/thailand.py:130
+#: holidays/countries/thailand.py:132
 msgid "วันหยุดพิเศษ (มหาอุทกภัย พ.ศ. 2554)"
 msgstr "Emergency Lockdown (2011 Thailand Floods)"
 
-#: holidays/countries/thailand.py:133
+#: holidays/countries/thailand.py:135
 msgid "วันหยุดพิเศษ (ร่วมถวายอาลัย ส่งดวงพระวิญญาณพระบรมศพ)"
 msgstr "Day of Mourning for HM King Bhumibol Adulyadej"
 
-#: holidays/countries/thailand.py:136
+#: holidays/countries/thailand.py:138
 msgid "วันพระราชพิธีถวายพระเพลิงพระบรมศพพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช"
 msgstr "HM King Bhumibol Adulyadej's Royal Cremation Ceremony"
 
-#: holidays/countries/thailand.py:140
+#: holidays/countries/thailand.py:142
 msgid "พระราชพิธีบรมราชาภิเษก พระบาทสมเด็จพระวชิรเกล้าเจ้าอยู่หัว"
 msgstr "HM King Maha Vajiralongkorn's Coronation Celebrations"
 
-#.
-#. !!! Songkran Festival !!! วันสงกรานต์ Status: In-Use Used to be April 1st as
-#. Thai New Year Day Initially abandoned in 1941 (B.E. 2484), declared again as
-#. public holidays in 1948 (2491 B.E) - 1948-1953, celebrated on Apr 13-15 -
-#. 1954-1956, abandoned as a public holiday - 1957-1988, only celebrated on Apr
-#. 13 - 1989-1997, celebrated on Apr 12-14 - 1998-Present, celebrated on Apr
-#. 13-15 (Except for 2020 due to Covid-19 outbreaks) This has its own in-lieu
-#. trigger
-#: holidays/countries/thailand.py:143 holidays/countries/thailand.py:339
+#: holidays/countries/thailand.py:145 holidays/countries/thailand.py:343
 msgid "วันสงกรานต์"
 msgstr "Songkran Festival"
 
-#: holidays/countries/thailand.py:300
+#: holidays/countries/thailand.py:302
 msgid "วันขึ้นปีใหม่"
 msgstr "New Year's Day"
 
-#. !!! New Year's Eve (in lieu) !!! วันหยุดชดเชยวันสิ้นปี Status: In-Use Added
-#. separately from New Year's Eve itself so that it would't go over the next
-#. year - CASE 1: SAT-SUN -> 1 in-lieu on TUE - CASE 2: SUN-MON -> 1 in-lieu on
-#. TUE See in lieu logic in `_add_with_observed(dt, holiday_name)`
-#.
-#: holidays/countries/thailand.py:310 holidays/countries/thailand.py:571
+#: holidays/countries/thailand.py:313 holidays/countries/thailand.py:577
 msgid "วันสิ้นปี"
 msgstr "New Year's Eve"
 
-#: holidays/countries/thailand.py:324
+#: holidays/countries/thailand.py:327
 msgid "วันจักรี"
 msgstr "Chakri Memorial Day"
 
-#: holidays/countries/thailand.py:388
+#: holidays/countries/thailand.py:392
 msgid "วันแรงงานแห่งชาติ"
 msgstr "National Labour Day"
 
-#: holidays/countries/thailand.py:400
+#: holidays/countries/thailand.py:404
 msgid "วันชาติ"
 msgstr "National Day"
 
-#. !!! Coronation Day !!! วันฉัตรมงคล Starts in 1958 (B.E. 2501) for Rama IX's
-#. Coronation: May 5th No celebration in 2017-2019 (B.E 2560-2562) Reestablished
-#. with Rama X's Coronation in 2020: May 4th
-#: holidays/countries/thailand.py:408
+#: holidays/countries/thailand.py:413
 msgid "วันฉัตรมงคล"
 msgstr "Coronation Day"
 
-#: holidays/countries/thailand.py:423
+#: holidays/countries/thailand.py:428
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระนางเจ้าสุทิดา พัชรสุธาพิมลลักษณ พระบรมราชินี"
 msgstr "HM Queen Suthida's Birthday"
 
-#: holidays/countries/thailand.py:437
+#: holidays/countries/thailand.py:442
 msgid ""
 "วันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรเมนทรรามาธิบดีศรีสินทรมหาวชิราลงกรณ "
 "พระวชิรเกล้าเจ้าอยู่หัว"
 msgstr "HM King Maha Vajiralongkorn's Birthday"
 
-#: holidays/countries/thailand.py:455
+#: holidays/countries/thailand.py:460
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระนางเจ้าสิริกิติ์ พระบรมราชินีนาถ"
 msgstr "HM Queen Sirikit's Birthday"
 
-#: holidays/countries/thailand.py:463
+#: holidays/countries/thailand.py:468
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระบรมราชชนนีพันปีหลวง"
 msgstr "HM Queen Sirikit The Queen Mother's Birthday"
 
-#. !!! National Mother's Day !!! วันแม่แห่งชาติ Status: In-Use Started 1950 (B.E
-#. 2493) initially as April 15 and cancelled in 1958 (B.E 2501) when the Min. of
-#. Culture was abolished. Restarts again in 1976 (B.E. 2519) on Queen Sirikit's
-#. Birthday (August 12) and stay that way from that point onwards.
-#: holidays/countries/thailand.py:473
+#: holidays/countries/thailand.py:479
 msgid "วันแม่แห่งชาติ"
 msgstr "National Mother's Day"
 
-#: holidays/countries/thailand.py:489
+#: holidays/countries/thailand.py:495
 msgid "วันคล้ายวันสวรรคตพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr "HM King Bhumibol Adulyadej Memorial Day"
 
-#: holidays/countries/thailand.py:497
+#: holidays/countries/thailand.py:503
 msgid ""
 "วันคล้ายวันสวรรคตพระบาทสมเด็จพระบรมชนกาธิเบศร มหาภูมิพลอดุลยเดชมหาราช บรมนาถบพิตร"
 msgstr "HM King Bhumibol Adulyadej the Great Memorial Day"
 
-#: holidays/countries/thailand.py:509
+#: holidays/countries/thailand.py:515
 msgid "วันปิยมหาราช"
 msgstr "HM King Chulalongkorn Memorial Day"
 
-#: holidays/countries/thailand.py:522
+#: holidays/countries/thailand.py:528
 #, fuzzy
 msgid "วันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr "HM King Bhumibol Adulyadej's Birthday"
 
-#: holidays/countries/thailand.py:530
+#: holidays/countries/thailand.py:536
 msgid "วันคล้ายวันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr "HM King Bhumibol Adulyadej's Birthday"
 
-#: holidays/countries/thailand.py:538
+#: holidays/countries/thailand.py:544
 msgid ""
 "วันคล้ายวันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระบรมชนกาธิเบศร มหาภูมิพลอดุลยเดชมหาราช "
 "บรมนาถบพิตร"
 msgstr "HM King Bhumibol Adulyadej the Great's Birthday"
 
-#: holidays/countries/thailand.py:552
+#: holidays/countries/thailand.py:558
 msgid "วันพ่อแห่งชาติ"
 msgstr "National Father's Day"
 
-#: holidays/countries/thailand.py:561
+#: holidays/countries/thailand.py:567
 msgid "วันรัฐธรรมนูญ"
 msgstr "Constitution Day"
 
-#: holidays/countries/thailand.py:591
+#: holidays/countries/thailand.py:597
 msgid "วันมาฆบูชา"
 msgstr "Makha Bucha"
 
-#: holidays/countries/thailand.py:599
+#: holidays/countries/thailand.py:605
 msgid "วันวิสาขบูชา"
 msgstr "Visakha Bucha"
 
-#: holidays/countries/thailand.py:608 holidays/countries/thailand.py:640
+#: holidays/countries/thailand.py:614 holidays/countries/thailand.py:646
 msgid "วันอาสาฬหบูชา"
 msgstr "Asarnha Bucha"
 
-#: holidays/countries/thailand.py:617 holidays/countries/thailand.py:636
+#: holidays/countries/thailand.py:623 holidays/countries/thailand.py:642
 msgid "วันเข้าพรรษา"
 msgstr "Buddhist Lent Day"
 
-#. !!! Royal Ploughing Ceremony !!! วันพืชมงคล Restarts in 1957 (B.E. 2500) Is
-#. dated on an annual basis by the Royal Palace This isn't even fixed even by
-#. the Thai Lunar Calendar, but instead by Court Astrologers; All chosen dates
-#. are all around May, so we can technically assign it to 13 May for years prior
-#. with no data. *** NOTE: only observed by government sectors TODO: Update this
-#. annually around Dec of each year
-#: holidays/countries/thailand.py:657
+#: holidays/countries/thailand.py:664
 msgid "วันพืชมงคล"
 msgstr "Royal Ploughing Ceremony"

--- a/holidays/locale/th/LC_MESSAGES/TH.po
+++ b/holidays/locale/th/LC_MESSAGES/TH.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Python Holidays 0.20\n"
-"POT-Creation-Date: 2023-02-23 09:43+0700\n"
+"POT-Creation-Date: 2023-03-01 10:36+0700\n"
 "PO-Revision-Date: \n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Python Holidays Translation Team\n"
@@ -14,192 +14,159 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#. วันหยุดพิเศษ (เพิ่มเติม) - see Bank of Thailand's DB for Cross-Check
-#: holidays/countries/thailand.py:118
+#: holidays/countries/thailand.py:119
 msgid "วันหยุดชดเชย"
 msgstr ""
 
-#: holidays/countries/thailand.py:119
+#: holidays/countries/thailand.py:120
 msgid "วันเลือกตั้ง"
 msgstr ""
 
-#.
-#. !!! New Year's Eve (in lieu) !!! วันหยุดชดเชยวันสิ้นปี Status: In-Use Added
-#. separately from New Year's Eve itself so that it would't go over the next
-#. year - CASE 1: SAT-SUN -> 1 in-lieu on TUE - CASE 2: SUN-MON -> 1 in-lieu on
-#. TUE See in lieu logic in `_add_with_observed(dt, holiday_name)`
-#: holidays/countries/thailand.py:120 holidays/countries/thailand.py:143
-#: holidays/countries/thailand.py:284 holidays/countries/thailand.py:310
-#: holidays/countries/thailand.py:366 holidays/countries/thailand.py:634
-#: holidays/countries/thailand.py:638
+#: holidays/countries/thailand.py:121 holidays/countries/thailand.py:145
+#: holidays/countries/thailand.py:286 holidays/countries/thailand.py:313
+#: holidays/countries/thailand.py:370 holidays/countries/thailand.py:640
+#: holidays/countries/thailand.py:644
 #, c-format
 msgid "ชดเชย%s"
 msgstr ""
 
-#: holidays/countries/thailand.py:121
+#: holidays/countries/thailand.py:122
 msgid "วันหยุดพิเศษ (เพิ่มเติม)"
 msgstr ""
 
-#. Special Cases
-#: holidays/countries/thailand.py:124
+#: holidays/countries/thailand.py:126
 msgid "พระราชพิธีกาญจนาภิเษก พ.ศ. 2539"
 msgstr ""
 
-#: holidays/countries/thailand.py:125
+#: holidays/countries/thailand.py:127
 msgid "พระราชพิธีฉลองสิริราชสมบัติครบ 60 ปี พ.ศ. 2549"
 msgstr ""
 
-#: holidays/countries/thailand.py:128
+#: holidays/countries/thailand.py:130
 msgid "วันหยุดพิเศษ (คมช.)"
 msgstr ""
 
-#: holidays/countries/thailand.py:129
+#: holidays/countries/thailand.py:131
 msgid "วันหยุดพิเศษ (การเมือง)"
 msgstr ""
 
-#: holidays/countries/thailand.py:130
+#: holidays/countries/thailand.py:132
 msgid "วันหยุดพิเศษ (มหาอุทกภัย พ.ศ. 2554)"
 msgstr ""
 
-#: holidays/countries/thailand.py:133
+#: holidays/countries/thailand.py:135
 msgid "วันหยุดพิเศษ (ร่วมถวายอาลัย ส่งดวงพระวิญญาณพระบรมศพ)"
 msgstr ""
 
-#: holidays/countries/thailand.py:136
+#: holidays/countries/thailand.py:138
 msgid "วันพระราชพิธีถวายพระเพลิงพระบรมศพพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช"
 msgstr ""
 
-#: holidays/countries/thailand.py:140
+#: holidays/countries/thailand.py:142
 msgid "พระราชพิธีบรมราชาภิเษก พระบาทสมเด็จพระวชิรเกล้าเจ้าอยู่หัว"
 msgstr ""
 
-#.
-#. !!! Songkran Festival !!! วันสงกรานต์ Status: In-Use Used to be April 1st as
-#. Thai New Year Day Initially abandoned in 1941 (B.E. 2484), declared again as
-#. public holidays in 1948 (2491 B.E) - 1948-1953, celebrated on Apr 13-15 -
-#. 1954-1956, abandoned as a public holiday - 1957-1988, only celebrated on Apr
-#. 13 - 1989-1997, celebrated on Apr 12-14 - 1998-Present, celebrated on Apr
-#. 13-15 (Except for 2020 due to Covid-19 outbreaks) This has its own in-lieu
-#. trigger
-#: holidays/countries/thailand.py:143 holidays/countries/thailand.py:339
+#: holidays/countries/thailand.py:145 holidays/countries/thailand.py:343
 msgid "วันสงกรานต์"
 msgstr ""
 
-#: holidays/countries/thailand.py:300
+#: holidays/countries/thailand.py:302
 msgid "วันขึ้นปีใหม่"
 msgstr ""
 
-#. !!! New Year's Eve (in lieu) !!! วันหยุดชดเชยวันสิ้นปี Status: In-Use Added
-#. separately from New Year's Eve itself so that it would't go over the next
-#. year - CASE 1: SAT-SUN -> 1 in-lieu on TUE - CASE 2: SUN-MON -> 1 in-lieu on
-#. TUE See in lieu logic in `_add_with_observed(dt, holiday_name)`
-#.
-#: holidays/countries/thailand.py:310 holidays/countries/thailand.py:571
+#: holidays/countries/thailand.py:313 holidays/countries/thailand.py:577
 msgid "วันสิ้นปี"
 msgstr ""
 
-#: holidays/countries/thailand.py:324
+#: holidays/countries/thailand.py:327
 msgid "วันจักรี"
 msgstr ""
 
-#: holidays/countries/thailand.py:388
+#: holidays/countries/thailand.py:392
 msgid "วันแรงงานแห่งชาติ"
 msgstr ""
 
-#: holidays/countries/thailand.py:400
+#: holidays/countries/thailand.py:404
 msgid "วันชาติ"
 msgstr ""
 
-#. !!! Coronation Day !!! วันฉัตรมงคล Starts in 1958 (B.E. 2501) for Rama IX's
-#. Coronation: May 5th No celebration in 2017-2019 (B.E 2560-2562) Reestablished
-#. with Rama X's Coronation in 2020: May 4th
-#: holidays/countries/thailand.py:408
+#: holidays/countries/thailand.py:413
 msgid "วันฉัตรมงคล"
 msgstr ""
 
-#: holidays/countries/thailand.py:423
+#: holidays/countries/thailand.py:428
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระนางเจ้าสุทิดา พัชรสุธาพิมลลักษณ พระบรมราชินี"
 msgstr ""
 
-#: holidays/countries/thailand.py:437
+#: holidays/countries/thailand.py:442
 msgid ""
 "วันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรเมนทรรามาธิบดีศรีสินทรมหาวชิราลงกรณ "
 "พระวชิรเกล้าเจ้าอยู่หัว"
 msgstr ""
 
-#: holidays/countries/thailand.py:455
+#: holidays/countries/thailand.py:460
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระนางเจ้าสิริกิติ์ พระบรมราชินีนาถ"
 msgstr ""
 
-#: holidays/countries/thailand.py:463
+#: holidays/countries/thailand.py:468
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระบรมราชชนนีพันปีหลวง"
 msgstr ""
 
-#. !!! National Mother's Day !!! วันแม่แห่งชาติ Status: In-Use Started 1950 (B.E
-#. 2493) initially as April 15 and cancelled in 1958 (B.E 2501) when the Min. of
-#. Culture was abolished. Restarts again in 1976 (B.E. 2519) on Queen Sirikit's
-#. Birthday (August 12) and stay that way from that point onwards.
-#: holidays/countries/thailand.py:473
+#: holidays/countries/thailand.py:479
 msgid "วันแม่แห่งชาติ"
 msgstr ""
 
-#: holidays/countries/thailand.py:489
+#: holidays/countries/thailand.py:495
 msgid "วันคล้ายวันสวรรคตพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr ""
 
-#: holidays/countries/thailand.py:497
+#: holidays/countries/thailand.py:503
 msgid ""
 "วันคล้ายวันสวรรคตพระบาทสมเด็จพระบรมชนกาธิเบศร มหาภูมิพลอดุลยเดชมหาราช บรมนาถบพิตร"
 msgstr ""
 
-#: holidays/countries/thailand.py:509
+#: holidays/countries/thailand.py:515
 msgid "วันปิยมหาราช"
 msgstr ""
 
-#: holidays/countries/thailand.py:522
+#: holidays/countries/thailand.py:528
 msgid "วันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr ""
 
-#: holidays/countries/thailand.py:530
+#: holidays/countries/thailand.py:536
 msgid "วันคล้ายวันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr ""
 
-#: holidays/countries/thailand.py:538
+#: holidays/countries/thailand.py:544
 msgid ""
 "วันคล้ายวันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระบรมชนกาธิเบศร มหาภูมิพลอดุลยเดชมหาราช "
 "บรมนาถบพิตร"
 msgstr ""
 
-#: holidays/countries/thailand.py:552
+#: holidays/countries/thailand.py:558
 msgid "วันพ่อแห่งชาติ"
 msgstr ""
 
-#: holidays/countries/thailand.py:561
+#: holidays/countries/thailand.py:567
 msgid "วันรัฐธรรมนูญ"
 msgstr ""
 
-#: holidays/countries/thailand.py:591
+#: holidays/countries/thailand.py:597
 msgid "วันมาฆบูชา"
 msgstr ""
 
-#: holidays/countries/thailand.py:599
+#: holidays/countries/thailand.py:605
 msgid "วันวิสาขบูชา"
 msgstr ""
 
-#: holidays/countries/thailand.py:608 holidays/countries/thailand.py:640
+#: holidays/countries/thailand.py:614 holidays/countries/thailand.py:646
 msgid "วันอาสาฬหบูชา"
 msgstr ""
 
-#: holidays/countries/thailand.py:617 holidays/countries/thailand.py:636
+#: holidays/countries/thailand.py:623 holidays/countries/thailand.py:642
 msgid "วันเข้าพรรษา"
 msgstr ""
 
-#. !!! Royal Ploughing Ceremony !!! วันพืชมงคล Restarts in 1957 (B.E. 2500) Is
-#. dated on an annual basis by the Royal Palace This isn't even fixed even by
-#. the Thai Lunar Calendar, but instead by Court Astrologers; All chosen dates
-#. are all around May, so we can technically assign it to 13 May for years prior
-#. with no data. *** NOTE: only observed by government sectors TODO: Update this
-#. annually around Dec of each year
-#: holidays/countries/thailand.py:657
+#: holidays/countries/thailand.py:664
 msgid "วันพืชมงคล"
 msgstr ""

--- a/holidays/locale/th/LC_MESSAGES/TH.po
+++ b/holidays/locale/th/LC_MESSAGES/TH.po
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: Python Holidays 0.20\n"
-"POT-Creation-Date: 2023-03-01 10:36+0700\n"
+"POT-Creation-Date: 2023-03-02 00:37+0700\n"
 "PO-Revision-Date: \n"
 "Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
 "Language-Team: Python Holidays Translation Team\n"
@@ -23,9 +23,9 @@ msgid "วันเลือกตั้ง"
 msgstr ""
 
 #: holidays/countries/thailand.py:121 holidays/countries/thailand.py:145
-#: holidays/countries/thailand.py:286 holidays/countries/thailand.py:313
-#: holidays/countries/thailand.py:370 holidays/countries/thailand.py:640
-#: holidays/countries/thailand.py:644
+#: holidays/countries/thailand.py:286 holidays/countries/thailand.py:309
+#: holidays/countries/thailand.py:366 holidays/countries/thailand.py:632
+#: holidays/countries/thailand.py:636
 #, c-format
 msgid "ชดเชย%s"
 msgstr ""
@@ -66,107 +66,107 @@ msgstr ""
 msgid "พระราชพิธีบรมราชาภิเษก พระบาทสมเด็จพระวชิรเกล้าเจ้าอยู่หัว"
 msgstr ""
 
-#: holidays/countries/thailand.py:145 holidays/countries/thailand.py:343
+#: holidays/countries/thailand.py:145 holidays/countries/thailand.py:339
 msgid "วันสงกรานต์"
 msgstr ""
 
-#: holidays/countries/thailand.py:302
+#: holidays/countries/thailand.py:298
 msgid "วันขึ้นปีใหม่"
 msgstr ""
 
-#: holidays/countries/thailand.py:313 holidays/countries/thailand.py:577
+#: holidays/countries/thailand.py:309 holidays/countries/thailand.py:573
 msgid "วันสิ้นปี"
 msgstr ""
 
-#: holidays/countries/thailand.py:327
+#: holidays/countries/thailand.py:323
 msgid "วันจักรี"
 msgstr ""
 
-#: holidays/countries/thailand.py:392
+#: holidays/countries/thailand.py:388
 msgid "วันแรงงานแห่งชาติ"
 msgstr ""
 
-#: holidays/countries/thailand.py:404
+#: holidays/countries/thailand.py:400
 msgid "วันชาติ"
 msgstr ""
 
-#: holidays/countries/thailand.py:413
+#: holidays/countries/thailand.py:409
 msgid "วันฉัตรมงคล"
 msgstr ""
 
-#: holidays/countries/thailand.py:428
+#: holidays/countries/thailand.py:424
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระนางเจ้าสุทิดา พัชรสุธาพิมลลักษณ พระบรมราชินี"
 msgstr ""
 
-#: holidays/countries/thailand.py:442
+#: holidays/countries/thailand.py:438
 msgid ""
 "วันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรเมนทรรามาธิบดีศรีสินทรมหาวชิราลงกรณ "
 "พระวชิรเกล้าเจ้าอยู่หัว"
 msgstr ""
 
-#: holidays/countries/thailand.py:460
+#: holidays/countries/thailand.py:456
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระนางเจ้าสิริกิติ์ พระบรมราชินีนาถ"
 msgstr ""
 
-#: holidays/countries/thailand.py:468
+#: holidays/countries/thailand.py:464
 msgid "วันเฉลิมพระชนมพรรษาสมเด็จพระบรมราชชนนีพันปีหลวง"
 msgstr ""
 
-#: holidays/countries/thailand.py:479
+#: holidays/countries/thailand.py:475
 msgid "วันแม่แห่งชาติ"
 msgstr ""
 
-#: holidays/countries/thailand.py:495
+#: holidays/countries/thailand.py:491
 msgid "วันคล้ายวันสวรรคตพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr ""
 
-#: holidays/countries/thailand.py:503
+#: holidays/countries/thailand.py:499
 msgid ""
 "วันคล้ายวันสวรรคตพระบาทสมเด็จพระบรมชนกาธิเบศร มหาภูมิพลอดุลยเดชมหาราช บรมนาถบพิตร"
 msgstr ""
 
-#: holidays/countries/thailand.py:515
+#: holidays/countries/thailand.py:511
 msgid "วันปิยมหาราช"
 msgstr ""
 
-#: holidays/countries/thailand.py:528
+#: holidays/countries/thailand.py:524
 msgid "วันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr ""
 
-#: holidays/countries/thailand.py:536
+#: holidays/countries/thailand.py:532
 msgid "วันคล้ายวันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระปรมินทรมหาภูมิพลอดุลยเดช บรมนาถบพิตร"
 msgstr ""
 
-#: holidays/countries/thailand.py:544
+#: holidays/countries/thailand.py:540
 msgid ""
 "วันคล้ายวันเฉลิมพระชนมพรรษาพระบาทสมเด็จพระบรมชนกาธิเบศร มหาภูมิพลอดุลยเดชมหาราช "
 "บรมนาถบพิตร"
 msgstr ""
 
-#: holidays/countries/thailand.py:558
+#: holidays/countries/thailand.py:554
 msgid "วันพ่อแห่งชาติ"
 msgstr ""
 
-#: holidays/countries/thailand.py:567
+#: holidays/countries/thailand.py:563
 msgid "วันรัฐธรรมนูญ"
 msgstr ""
 
-#: holidays/countries/thailand.py:597
+#: holidays/countries/thailand.py:589
 msgid "วันมาฆบูชา"
 msgstr ""
 
-#: holidays/countries/thailand.py:605
+#: holidays/countries/thailand.py:597
 msgid "วันวิสาขบูชา"
 msgstr ""
 
-#: holidays/countries/thailand.py:614 holidays/countries/thailand.py:646
+#: holidays/countries/thailand.py:606 holidays/countries/thailand.py:638
 msgid "วันอาสาฬหบูชา"
 msgstr ""
 
-#: holidays/countries/thailand.py:623 holidays/countries/thailand.py:642
+#: holidays/countries/thailand.py:615 holidays/countries/thailand.py:634
 msgid "วันเข้าพรรษา"
 msgstr ""
 
-#: holidays/countries/thailand.py:664
+#: holidays/countries/thailand.py:652
 msgid "วันพืชมงคล"
 msgstr ""


### PR DESCRIPTION
## Proposed change

This standardizes Thailand's localization file by removing extra comments from running `make l10n` and standardizing in-line comments for codes in `Thailand.py` file as per @arkid15r 's styling recommendation mentioned in #988 .

## Type of change

- [ ] New country holidays support (thank you!)
- [ ] Supported country holidays update (calendar discrepancy fix, localization)
- [x] Existing code/tests/processes improvement (best practice, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (adds functionality to python-holidays in general)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts
- [x] The code style looks good (`make pre-commit`)
- [x] I've added tests to verify that the new code works and all tests pass locally (`make test`)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
