### PR TITLE
Fix NYSE New Year's Day observance calculation

### DIFF
--- a/holidays/financial/ny_stock_exchange.py
+++ b/holidays/financial/ny_stock_exchange.py
@@ -57,7 +57,9 @@ class NewYorkStockExchange(HolidayBase):
 
         # NYD
         # This year's New Year Day.
-        self._set_observed_date(date(year, JAN, 1), "New Year's Day")
+        jan_1 = date(year, JAN, 1)
+        if not self._is_saturday(jan_1):
+            self._set_observed_date(jan_1, "New Year's Day")
 
         # https://www.nyse.com/publicdocs/nyse/regulation/nyse/NYSE_Rules.pdf
         # As per Rule 7.2.: check if next year's NYD falls on Saturday and

--- a/tests/financial/test_ny_stock_exchange.py
+++ b/tests/financial/test_ny_stock_exchange.py
@@ -44,6 +44,17 @@ class TestNewYorkStockExchange(unittest.TestCase):
             self.assertNotIn(dt + td(days=+1), self.holidays)
             self.assertNotIn(dt + td(days=+7), self.holidays)
 
+        # observed on previous year Dec 31
+        for dt in (
+            date(1994, JAN, 1),
+            date(2000, JAN, 1),
+            date(2005, JAN, 1),
+            date(2011, JAN, 1),
+            date(2022, JAN, 1),
+        ):
+            self.assertNotIn(dt, self.holidays)
+            self.assertIn(dt + td(days=-1), self.holidays)
+
     def test_mlk(self):
         for dt in [
             date(1999, JAN, 18),


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

When New Year falls on Saturday, observed holiday falls on Dec 31 of the previous year and we received error `RuntimeError: Set changed size during iteration`.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country holidays support (thank you!)
- [ ] Supported country holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/tests/processes improvement (best practice, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (adds functionality to python-holidays in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts
- [x] The code style looks good (`make pre-commit`)
- [x] I've added tests to verify that the new code works and all tests pass locally (`make test`)
- [ ] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source