### PR TITLE
Improve Portugal holidays

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -383,7 +383,7 @@ subdivisions are available:
      - None
    * - Portugal
      - PT
-     - Districts: 01, 02, 03, 04, 05, 06, 07, 08, 09, 10, 11, 12, 13, 14, 15, 16, 17, 18, Ext; Use subdiv='Ext' to include holidays most people have off
+     - Districts: 01, 02, 03, 04, 05, 06, 07, 08, 09, 10, 11, 12, 13, 14, 15, 16, 17, 18, 20, 30, Ext; Use subdiv='Ext' to include holidays most people have off
    * - Puerto Rico
      - PR
      - None; Can also be loaded as country US, subdivision PR
@@ -574,6 +574,9 @@ default language code is a `ISO 639-1 code`_.
    * - Poland
      - pl
      - en_US, pl, uk
+   * - Portugal
+     - pt_PT
+     - en_US, pt_PT
    * - Russia
      - ru
      - en_US, ru

--- a/holidays/countries/portugal.py
+++ b/holidays/countries/portugal.py
@@ -21,12 +21,37 @@ from holidays.holiday_base import HolidayBase
 
 class Portugal(HolidayBase):
     """
-    https://en.wikipedia.org/wiki/Public_holidays_in_Portugal
+    A subclass of :py:class:`HolidayBase` representing public holidays
+    in Portugal.
+
+
+    References:
+
+    - Based on:
+        https://en.wikipedia.org/wiki/Public_holidays_in_Portugal
+
+    National Level:
+    - [Labour Day]
+        https://www.e-konomista.pt/dia-do-trabalhador/
+    - [Portugal Day]
+        Decreto 17.171
+    - [Restoration of Independence Day]
+        Gazeta de Lisboa, 8 de Dezembro de 1823 (n.º 290), pp. 1789 e 1790
+
+    Regional Level:
+    - [Azores]
+        https://files.dre.pt/1s/1980/08/19200/23052305.pdf
+    - [Madeira]
+        https://files.dre.pt/1s/1979/11/25900/28782878.pdf
+        https://files.dre.pt/1s/1989/02/02800/04360436.pdf
+        https://files.dre.pt/1s/2002/11/258a00/71837183.pdf
+
     """
 
     country = "PT"
-    # https://en.wikipedia.org/wiki/Districts_of_Portugal
-    # Only the 18 mainland districts have been included
+    default_language = "pt_PT"
+
+    # https://en.wikipedia.org/wiki/ISO_3166-2:PT
     # `Ext` represents the national holidays most people have off
     subdivisions = [
         "01",
@@ -47,35 +72,54 @@ class Portugal(HolidayBase):
         "16",
         "17",
         "18",
+        "20",
+        "30",
         "Ext",
     ]
 
     def _populate(self, year):
         super()._populate(year)
 
-        self[date(year, JAN, 1)] = "Ano Novo"
+        self[date(year, JAN, 1)] = self.tr("Ano Novo")
 
         easter_date = easter(year)
 
         # carnival is no longer a holiday, but some companies let workers off.
         # @todo recollect the years in which it was a public holiday
         # self[e + td(days=-47)] = "Carnaval"
-        self[easter_date + td(days=-2)] = "Sexta-feira Santa"
-        self[easter_date] = "Páscoa"
+
+        self[easter_date + td(days=-2)] = self.tr("Sexta-feira Santa")
+        self[easter_date] = self.tr("Páscoa")
 
         # Revoked holidays in 2013–2015
-        if year < 2013 or year > 2015:
-            self[easter_date + td(days=+60)] = "Corpo de Deus"
-            self[date(year, OCT, 5)] = "Implantação da República"
-            self[date(year, NOV, 1)] = "Dia de Todos os Santos"
-            self[date(year, DEC, 1)] = "Restauração da Independência"
 
-        self[date(year, APR, 25)] = "Dia da Liberdade"
-        self[date(year, MAY, 1)] = "Dia do Trabalhador"
-        self[date(year, JUN, 10)] = "Dia de Portugal"
-        self[date(year, AUG, 15)] = "Assunção de Nossa Senhora"
-        self[date(year, DEC, 8)] = "Imaculada Conceição"
-        self[date(year, DEC, 25)] = "Dia de Natal"
+        if year < 2013 or year > 2015:
+            self[easter_date + td(days=+60)] = self.tr("Corpo de Deus")
+            if year >= 1910:
+                self[date(year, OCT, 5)] = self.tr("Implantação da República")
+            self[date(year, NOV, 1)] = self.tr("Dia de Todos os Santos")
+            if year >= 1823:
+                self[date(year, DEC, 1)] = self.tr(
+                    "Restauração da Independência"
+                )
+
+        if year >= 1974:
+            self[date(year, APR, 25)] = self.tr("Dia da Liberdade")
+            self[date(year, MAY, 1)] = self.tr("Dia do Trabalhador")
+        if year >= 1911:
+            if 1933 >= year >= 1973:
+                self[date(year, JUN, 10)] = self.tr(
+                    "Dia de Camões, de Portugal e da Raça"
+                )
+            elif year >= 1978:
+                self[date(year, JUN, 10)] = self.tr(
+                    "Dia de Portugal, de Camões e das Comunidades Portuguesas"
+                )
+            else:
+                self[date(year, JUN, 10)] = self.tr("Dia de Portugal")
+        self[date(year, AUG, 15)] = self.tr("Assunção de Nossa Senhora")
+        self[date(year, DEC, 8)] = self.tr("Imaculada Conceição")
+        self[date(year, DEC, 25)] = self.tr("Dia de Natal")
 
         if self.subdiv == "Ext":
             """
@@ -88,51 +132,81 @@ class Portugal(HolidayBase):
             - Lisbon's city holiday
             """
 
-            self[easter_date + td(days=-47)] = "Carnaval"
-            self[date(year, DEC, 24)] = "Véspera de Natal"
-            self[date(year, DEC, 26)] = "26 de Dezembro"
-            self[date(year, DEC, 31)] = "Véspera de Ano Novo"
-            self[date(year, JUN, 13)] = "Dia de Santo António"
+            self[easter_date + td(days=-47)] = self.tr("Carnaval")
+            self[date(year, DEC, 24)] = self.tr("Véspera de Natal")
+            self[date(year, DEC, 26)] = self.tr("26 de Dezembro")
+            self[date(year, DEC, 31)] = self.tr("Véspera de Ano Novo")
+            self[date(year, JUN, 13)] = self.tr("Dia de Santo António")
 
             # TODO add bridging days
             # - get Holidays that occur on Tuesday  and add Monday (-1 day)
             # - get Holidays that occur on Thursday and add Friday (+1 day)
 
-        # District holidays
-        if self.subdiv == "01":
-            self[date(year, MAY, 12)] = "Dia de Santa Joana"
-        if self.subdiv == "02":
-            self[easter_date + td(days=+39)] = "Quinta-feira da Ascensão"
-        if self.subdiv in {"03", "13"}:
-            self[date(year, JUN, 24)] = "Dia de São João"
-        if self.subdiv == "04":
-            self[date(year, AUG, 22)] = "Dia de Nossa Senhora das Graças"
-        if self.subdiv == "05":
-            self[
-                easter_date + td(days=+16)
-            ] = "Dia de Nossa Senhora de Mércoles"
-        if self.subdiv == "06":
-            self[date(year, JUL, 4)] = "Dia de Santa Isabel"
-        if self.subdiv == "07":
-            self[date(year, JUN, 29)] = "Dia de S. Pedro"
-        if self.subdiv == "08":
-            self[date(year, SEP, 7)] = "Dia do Município de Faro"
-        if self.subdiv == "09":
-            self[date(year, NOV, 27)] = "Dia do Município da Guarda"
-        if self.subdiv == "10":
-            self[date(year, MAY, 22)] = "Dia do Município de Leiria"
-        if self.subdiv in {"11", "17"}:
-            self[date(year, JUN, 13)] = "Dia de Santo António"
-        if self.subdiv == "12":
-            self[date(year, MAY, 23)] = "Dia do Município de Portalegre"
-        if self.subdiv == "14":
-            self[date(year, MAR, 19)] = "Dia de S. José"
-        if self.subdiv == "15":
-            self[date(year, SEP, 15)] = "Dia de Bocage"
-        if self.subdiv == "16":
-            self[date(year, AUG, 20)] = "Dia de Nossa Senhora da Agonia"
-        if self.subdiv == "18":
-            self[date(year, SEP, 21)] = "Dia de S. Mateus"
+        # District holidays: starts in 12 October 1910 via decree
+
+        if year >= 1911:
+            if self.subdiv == "01":
+                self[date(year, MAY, 12)] = self.tr("Dia de Santa Joana")
+            if self.subdiv == "02":
+                self[easter_date + td(days=+39)] = self.tr(
+                    "Quinta-feira da Ascensão"
+                )
+            if self.subdiv in {"03", "13"}:
+                self[date(year, JUN, 24)] = self.tr("Dia de São João")
+            if self.subdiv == "04":
+                self[date(year, AUG, 22)] = self.tr(
+                    "Dia de Nossa Senhora das Graças"
+                )
+            if self.subdiv == "05":
+                self[easter_date + td(days=+16)] = self.tr(
+                    "Dia de Nossa Senhora de Mércoles"
+                )
+            if self.subdiv == "06":
+                self[date(year, JUL, 4)] = self.tr("Dia de Santa Isabel")
+            if self.subdiv == "07":
+                self[date(year, JUN, 29)] = self.tr("Dia de S. Pedro")
+            if self.subdiv == "08":
+                self[date(year, SEP, 7)] = self.tr("Dia do Município de Faro")
+            if self.subdiv == "09":
+                self[date(year, NOV, 27)] = self.tr(
+                    "Dia do Município da Guarda"
+                )
+            if self.subdiv == "10":
+                self[date(year, MAY, 22)] = self.tr(
+                    "Dia do Município de Leiria"
+                )
+            if self.subdiv in {"11", "17"}:
+                self[date(year, JUN, 13)] = self.tr("Dia de Santo António")
+            if self.subdiv == "12":
+                self[date(year, MAY, 23)] = self.tr(
+                    "Dia do Município de Portalegre"
+                )
+            if self.subdiv == "14":
+                self[date(year, MAR, 19)] = self.tr("Dia de S. José")
+            if self.subdiv == "15":
+                self[date(year, SEP, 15)] = self.tr("Dia de Bocage")
+            if self.subdiv == "16":
+                self[date(year, AUG, 20)] = self.tr(
+                    "Dia de Nossa Senhora da Agonia"
+                )
+            if self.subdiv == "18":
+                self[date(year, SEP, 21)] = self.tr("Dia de S. Mateus")
+            if self.subdiv == "20" and year >= 1981:
+                self[easter_date + td(days=+50)] = self.tr(
+                    "Dia da Região Autónoma dos Açores"
+                )
+            if self.subdiv == "30":
+                if 1979 <= year <= 1988:
+                    self[date(year, JUL, 1)] = self.tr(
+                        "Dia da Região Autónoma da Madeira"
+                    )
+                elif year >= 1989:
+                    self[date(year, JUL, 1)] = self.tr(
+                        "Dia da Região Autónoma da Madeira e "
+                        "das Comunidades Madeirenses"
+                    )
+                if year >= 2002:
+                    self[date(year, DEC, 26)] = self.tr("Primeira Oitava")
 
 
 class PT(Portugal):

--- a/holidays/locale/en_US/LC_MESSAGES/PT.po
+++ b/holidays/locale/en_US/LC_MESSAGES/PT.po
@@ -1,0 +1,173 @@
+# Portugal holidays en_US localization.
+# Authors: PPsyrius <ppsyrius@ppsyrius.dev>, (c) 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Python Holidays 0.20\n"
+"POT-Creation-Date: 2023-03-07 16:27+0700\n"
+"PO-Revision-Date: 2023-02-20 19:10+0200\n"
+"Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
+"Language-Team: Python Holidays localization team\n"
+"Language: en_US\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: pygettext.py 1.5\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: holidays/countries/portugal.py:83
+msgid "Ano Novo"
+msgstr "New Year's Day"
+
+#: holidays/countries/portugal.py:91
+msgid "Sexta-feira Santa"
+msgstr "Good Friday"
+
+#: holidays/countries/portugal.py:92
+msgid "Páscoa"
+msgstr "Easter Sunday"
+
+#: holidays/countries/portugal.py:97
+msgid "Corpo de Deus"
+msgstr "Corpus Christi"
+
+#: holidays/countries/portugal.py:99
+msgid "Implantação da República"
+msgstr "Republic Day"
+
+#: holidays/countries/portugal.py:100
+msgid "Dia de Todos os Santos"
+msgstr "All Saints Day"
+
+#: holidays/countries/portugal.py:102
+msgid "Restauração da Independência"
+msgstr "Restoration of Independence Day"
+
+#: holidays/countries/portugal.py:107
+msgid "Dia da Liberdade"
+msgstr "Freedom Day"
+
+#: holidays/countries/portugal.py:108
+msgid "Dia do Trabalhador"
+msgstr "Labour Day"
+
+#: holidays/countries/portugal.py:111
+msgid "Dia de Camões, de Portugal e da Raça"
+msgstr "Day of Camões, Portugal, and the Portuguese Race"
+
+#: holidays/countries/portugal.py:115
+msgid "Dia de Portugal, de Camões e das Comunidades Portuguesas"
+msgstr "Day of Portugal, Camões, and the Portuguese Communities"
+
+#: holidays/countries/portugal.py:119
+msgid "Dia de Portugal"
+msgstr "Portugal Day"
+
+#: holidays/countries/portugal.py:120
+msgid "Assunção de Nossa Senhora"
+msgstr "Assumption Day"
+
+#: holidays/countries/portugal.py:121
+msgid "Imaculada Conceição"
+msgstr "Immaculate Conception"
+
+#: holidays/countries/portugal.py:122
+msgid "Dia de Natal"
+msgstr "Christmas"
+
+#: holidays/countries/portugal.py:135
+msgid "Carnaval"
+msgstr "Carnival"
+
+#: holidays/countries/portugal.py:136
+msgid "Véspera de Natal"
+msgstr "Christmas Eve"
+
+#: holidays/countries/portugal.py:137
+msgid "26 de Dezembro"
+msgstr "Boxing Day"
+
+#: holidays/countries/portugal.py:138
+msgid "Véspera de Ano Novo"
+msgstr "New Year's Eve"
+
+#: holidays/countries/portugal.py:139 holidays/countries/portugal.py:179
+msgid "Dia de Santo António"
+msgstr "St. Anthony's Day"
+
+#: holidays/countries/portugal.py:149
+msgid "Dia de Santa Joana"
+msgstr "St. Joanna's Day"
+
+#: holidays/countries/portugal.py:151
+msgid "Quinta-feira da Ascensão"
+msgstr "Ascension of Jesus"
+
+#: holidays/countries/portugal.py:155
+msgid "Dia de São João"
+msgstr "St. John's Day"
+
+#: holidays/countries/portugal.py:157
+msgid "Dia de Nossa Senhora das Graças"
+msgstr "Feast of Our Lady of Graces"
+
+#: holidays/countries/portugal.py:161
+msgid "Dia de Nossa Senhora de Mércoles"
+msgstr "Feast of Senhora de Mércoles"
+
+#: holidays/countries/portugal.py:165
+msgid "Dia de Santa Isabel"
+msgstr "St. Elizabeth's Day"
+
+#: holidays/countries/portugal.py:167
+msgid "Dia de S. Pedro"
+msgstr "St. Peter's Day"
+
+#: holidays/countries/portugal.py:169
+msgid "Dia do Município de Faro"
+msgstr "Municipal Holiday (Faro)"
+
+#: holidays/countries/portugal.py:171
+msgid "Dia do Município da Guarda"
+msgstr "Municipal Holiday (Guarda)"
+
+#: holidays/countries/portugal.py:175
+msgid "Dia do Município de Leiria"
+msgstr "Municipal Holiday (Leiria)"
+
+#: holidays/countries/portugal.py:181
+msgid "Dia do Município de Portalegre"
+msgstr "Municipal Holiday (Portalegre)"
+
+#: holidays/countries/portugal.py:185
+msgid "Dia de S. José"
+msgstr "St. Joseph's Day"
+
+#: holidays/countries/portugal.py:187
+msgid "Dia de Bocage"
+msgstr "Bocage Day"
+
+#: holidays/countries/portugal.py:189
+msgid "Dia de Nossa Senhora da Agonia"
+msgstr "Feast of Senhora da Agonia"
+
+#: holidays/countries/portugal.py:193
+msgid "Dia de S. Mateus"
+msgstr "St. Matthew's Day"
+
+#: holidays/countries/portugal.py:195
+msgid "Dia da Região Autónoma dos Açores"
+msgstr "Day of the Autonomous Region of the Azores"
+
+#: holidays/countries/portugal.py:200
+msgid "Dia da Região Autónoma da Madeira"
+msgstr "Day of the Autonomous Region of Madeira"
+
+#: holidays/countries/portugal.py:204
+msgid "Dia da Região Autónoma da Madeira e das Comunidades Madeirenses"
+msgstr "Day of the Autonomous Region of Madeira and the Madeiran Communities"
+
+#: holidays/countries/portugal.py:209
+msgid "Primeira Oitava"
+msgstr "1st Octave"

--- a/holidays/locale/pt_PT/LC_MESSAGES/PT.po
+++ b/holidays/locale/pt_PT/LC_MESSAGES/PT.po
@@ -1,0 +1,173 @@
+# Portugal holidays pt_PT localization.
+# Authors: PPsyrius <ppsyrius@ppsyrius.dev>, (c) 2023.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Python Holidays 0.20\n"
+"POT-Creation-Date: 2023-03-07 16:27+0700\n"
+"PO-Revision-Date: 2023-02-20 19:10+0200\n"
+"Last-Translator: PPsyrius <ppsyrius@ppsyrius.dev>\n"
+"Language-Team: Python Holidays localization team\n"
+"Language: pt_PT\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Generated-By: pygettext.py 1.5\n"
+"X-Generator: Poedit 3.2.2\n"
+
+#: holidays/countries/portugal.py:83
+msgid "Ano Novo"
+msgstr ""
+
+#: holidays/countries/portugal.py:91
+msgid "Sexta-feira Santa"
+msgstr ""
+
+#: holidays/countries/portugal.py:92
+msgid "Páscoa"
+msgstr ""
+
+#: holidays/countries/portugal.py:97
+msgid "Corpo de Deus"
+msgstr ""
+
+#: holidays/countries/portugal.py:99
+msgid "Implantação da República"
+msgstr ""
+
+#: holidays/countries/portugal.py:100
+msgid "Dia de Todos os Santos"
+msgstr ""
+
+#: holidays/countries/portugal.py:102
+msgid "Restauração da Independência"
+msgstr ""
+
+#: holidays/countries/portugal.py:107
+msgid "Dia da Liberdade"
+msgstr ""
+
+#: holidays/countries/portugal.py:108
+msgid "Dia do Trabalhador"
+msgstr ""
+
+#: holidays/countries/portugal.py:111
+msgid "Dia de Camões, de Portugal e da Raça"
+msgstr ""
+
+#: holidays/countries/portugal.py:115
+msgid "Dia de Portugal, de Camões e das Comunidades Portuguesas"
+msgstr ""
+
+#: holidays/countries/portugal.py:119
+msgid "Dia de Portugal"
+msgstr ""
+
+#: holidays/countries/portugal.py:120
+msgid "Assunção de Nossa Senhora"
+msgstr ""
+
+#: holidays/countries/portugal.py:121
+msgid "Imaculada Conceição"
+msgstr ""
+
+#: holidays/countries/portugal.py:122
+msgid "Dia de Natal"
+msgstr ""
+
+#: holidays/countries/portugal.py:135
+msgid "Carnaval"
+msgstr ""
+
+#: holidays/countries/portugal.py:136
+msgid "Véspera de Natal"
+msgstr ""
+
+#: holidays/countries/portugal.py:137
+msgid "26 de Dezembro"
+msgstr ""
+
+#: holidays/countries/portugal.py:138
+msgid "Véspera de Ano Novo"
+msgstr ""
+
+#: holidays/countries/portugal.py:139 holidays/countries/portugal.py:179
+msgid "Dia de Santo António"
+msgstr ""
+
+#: holidays/countries/portugal.py:149
+msgid "Dia de Santa Joana"
+msgstr ""
+
+#: holidays/countries/portugal.py:151
+msgid "Quinta-feira da Ascensão"
+msgstr ""
+
+#: holidays/countries/portugal.py:155
+msgid "Dia de São João"
+msgstr ""
+
+#: holidays/countries/portugal.py:157
+msgid "Dia de Nossa Senhora das Graças"
+msgstr ""
+
+#: holidays/countries/portugal.py:161
+msgid "Dia de Nossa Senhora de Mércoles"
+msgstr ""
+
+#: holidays/countries/portugal.py:165
+msgid "Dia de Santa Isabel"
+msgstr ""
+
+#: holidays/countries/portugal.py:167
+msgid "Dia de S. Pedro"
+msgstr ""
+
+#: holidays/countries/portugal.py:169
+msgid "Dia do Município de Faro"
+msgstr ""
+
+#: holidays/countries/portugal.py:171
+msgid "Dia do Município da Guarda"
+msgstr ""
+
+#: holidays/countries/portugal.py:175
+msgid "Dia do Município de Leiria"
+msgstr ""
+
+#: holidays/countries/portugal.py:181
+msgid "Dia do Município de Portalegre"
+msgstr ""
+
+#: holidays/countries/portugal.py:185
+msgid "Dia de S. José"
+msgstr ""
+
+#: holidays/countries/portugal.py:187
+msgid "Dia de Bocage"
+msgstr ""
+
+#: holidays/countries/portugal.py:189
+msgid "Dia de Nossa Senhora da Agonia"
+msgstr ""
+
+#: holidays/countries/portugal.py:193
+msgid "Dia de S. Mateus"
+msgstr ""
+
+#: holidays/countries/portugal.py:195
+msgid "Dia da Região Autónoma dos Açores"
+msgstr ""
+
+#: holidays/countries/portugal.py:200
+msgid "Dia da Região Autónoma da Madeira"
+msgstr ""
+
+#: holidays/countries/portugal.py:204
+msgid "Dia da Região Autónoma da Madeira e das Comunidades Madeirenses"
+msgstr ""
+
+#: holidays/countries/portugal.py:209
+msgid "Primeira Oitava"
+msgstr ""

--- a/tests/countries/test_portugal.py
+++ b/tests/countries/test_portugal.py
@@ -9,95 +9,195 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-import unittest
-from datetime import date
-
-import holidays
+from holidays.countries.portugal import Portugal, PT, PRT
+from tests.common import TestCase
 
 
-class TestPT(unittest.TestCase):
+class TestPortugal(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass(Portugal)
+
     def setUp(self):
-        self.holidays = holidays.PT()
+        super().setUp()
+
+        years = range(2014, 2018)
+        self.district_01 = Portugal(years=years, subdiv="01")
+        self.district_02 = Portugal(years=years, subdiv="02")
+        self.district_03 = Portugal(years=years, subdiv="03")
+        self.district_04 = Portugal(years=years, subdiv="04")
+        self.district_05 = Portugal(years=years, subdiv="05")
+        self.district_06 = Portugal(years=years, subdiv="06")
+        self.district_07 = Portugal(years=years, subdiv="07")
+        self.district_08 = Portugal(years=years, subdiv="08")
+        self.district_09 = Portugal(years=years, subdiv="09")
+        self.district_10 = Portugal(years=years, subdiv="10")
+        self.district_11 = Portugal(years=years, subdiv="11")
+        self.district_12 = Portugal(years=years, subdiv="12")
+        self.district_13 = Portugal(years=years, subdiv="13")
+        self.district_14 = Portugal(years=years, subdiv="14")
+        self.district_15 = Portugal(years=years, subdiv="15")
+        self.district_16 = Portugal(years=years, subdiv="16")
+        self.district_17 = Portugal(years=years, subdiv="17")
+        self.district_18 = Portugal(years=years, subdiv="18")
+        self.district_20 = Portugal(years=years, subdiv="20")
+        self.district_30 = Portugal(years=years, subdiv="30")
+        self.ext = Portugal(years=years, subdiv="Ext")
+
+    def test_country_aliases(self):
+        self.assertCountryAliases(Portugal, PT, PRT)
 
     def test_2014(self):
-        year = 2014
         # http://www.officeholidays.com/countries/portugal/2014.php
-        self.assertIn(date(year, 1, 1), self.holidays)  # New Year
-        self.assertIn(date(year, 4, 18), self.holidays)  # Good Friday
-        self.assertIn(date(year, 4, 20), self.holidays)  # Easter
-        self.assertIn(date(year, 4, 25), self.holidays)  # Liberation Day
-        self.assertIn(date(year, 5, 1), self.holidays)  # Labour Day
-        self.assertIn(date(year, 6, 10), self.holidays)  # Portugal Day
-        self.assertNotIn(date(year, 6, 15), self.holidays)  # Corpus Christi
-        self.assertIn(date(year, 8, 15), self.holidays)  # Assumption Day
-        self.assertNotIn(date(year, 10, 5), self.holidays)  # Republic Day
-        self.assertNotIn(date(year, 11, 1), self.holidays)  # All Saints Day
-        self.assertNotIn(date(year, 12, 1), self.holidays)  # Independence
-        self.assertIn(date(year, 12, 8), self.holidays)  # Immaculate
-        self.assertIn(date(year, 12, 25), self.holidays)  # Christmas
+        self.assertHolidays(
+            (
+                "2014-01-01",
+                "Ano Novo",
+            ),
+            (
+                "2014-04-18",
+                "Sexta-feira Santa",
+            ),
+            (
+                "2014-04-20",
+                "Páscoa",
+            ),
+            (
+                "2014-04-25",
+                "Dia da Liberdade",
+            ),
+            (
+                "2014-05-01",
+                "Dia do Trabalhador",
+            ),
+            (
+                "2014-06-10",
+                "Dia de Portugal, de Camões e das Comunidades Portuguesas",
+            ),
+            (
+                "2014-08-15",
+                "Assunção de Nossa Senhora",
+            ),
+            (
+                "2014-12-08",
+                "Imaculada Conceição",
+            ),
+            (
+                "2014-12-25",
+                "Dia de Natal",
+            ),
+        )
 
     def test_2017(self):
         # http://www.officeholidays.com/countries/portugal/2017.php
-        self.assertIn(date(2017, 1, 1), self.holidays)  # New Year
-        self.assertIn(date(2017, 4, 14), self.holidays)  # Good Friday
-        self.assertIn(date(2017, 4, 16), self.holidays)  # Easter
-        self.assertIn(date(2017, 4, 25), self.holidays)  # Liberation Day
-        self.assertIn(date(2017, 5, 1), self.holidays)  # Labour Day
-        self.assertIn(date(2017, 6, 10), self.holidays)  # Portugal Day
-        self.assertIn(date(2017, 6, 15), self.holidays)  # Corpus Christi
-        self.assertIn(date(2017, 8, 15), self.holidays)  # Assumption Day
-        self.assertIn(date(2017, 10, 5), self.holidays)  # Republic Day
-        self.assertIn(date(2017, 11, 1), self.holidays)  # All Saints Day
-        self.assertIn(date(2017, 12, 1), self.holidays)  # Independence
-        self.assertIn(date(2017, 12, 8), self.holidays)  # Immaculate
-        self.assertIn(date(2017, 12, 25), self.holidays)  # Christmas
+        self.assertHolidays(
+            (
+                "2017-01-01",
+                "Ano Novo",
+            ),
+            (
+                "2017-04-14",
+                "Sexta-feira Santa",
+            ),
+            (
+                "2017-04-16",
+                "Páscoa",
+            ),
+            (
+                "2017-04-25",
+                "Dia da Liberdade",
+            ),
+            (
+                "2017-05-01",
+                "Dia do Trabalhador",
+            ),
+            (
+                "2017-06-10",
+                "Dia de Portugal, de Camões e das Comunidades Portuguesas",
+            ),
+            (
+                "2017-06-15",
+                "Corpo de Deus",
+            ),
+            (
+                "2017-08-15",
+                "Assunção de Nossa Senhora",
+            ),
+            (
+                "2017-10-05",
+                "Implantação da República",
+            ),
+            (
+                "2017-11-01",
+                "Dia de Todos os Santos",
+            ),
+            (
+                "2017-12-01",
+                "Restauração da Independência",
+            ),
+            (
+                "2017-12-08",
+                "Imaculada Conceição",
+            ),
+            (
+                "2017-12-25",
+                "Dia de Natal",
+            ),
+        )
 
+    def test_ext_2017(self):
+        # Christmas's Eve, S. Stephen & New Year's Eve
+        self.assertHoliday(
+            self.ext,
+            "2017-12-24",
+            "2017-12-26",
+            "2017-12-26",
+        )
 
-class TestPortugalExt(unittest.TestCase):
-    def setUp(self):
-        self.holidays = holidays.Portugal(subdiv="Ext")
+    def test_district_specific_days_2017(self):
+        self.assertHoliday(self.district_01, "2017-05-12")
+        self.assertHoliday(self.district_02, "2017-05-25")
+        self.assertHoliday(self.district_03, "2017-06-24")
+        self.assertHoliday(self.district_04, "2017-08-22")
+        self.assertHoliday(self.district_05, "2017-05-02")
+        self.assertHoliday(self.district_06, "2017-07-04")
+        self.assertHoliday(self.district_07, "2017-06-29")
+        self.assertHoliday(self.district_08, "2017-09-07")
+        self.assertHoliday(self.district_09, "2017-11-27")
+        self.assertHoliday(self.district_10, "2017-05-22")
+        self.assertHoliday(self.district_11, "2017-06-13")
+        self.assertHoliday(self.district_12, "2017-05-23")
+        self.assertHoliday(self.district_13, "2017-06-24")
+        self.assertHoliday(self.district_14, "2017-03-19")
+        self.assertHoliday(self.district_15, "2017-09-15")
+        self.assertHoliday(self.district_16, "2017-08-20")
+        self.assertHoliday(self.district_17, "2017-06-13")
+        self.assertHoliday(self.district_18, "2017-09-21")
+        self.assertHoliday(self.district_20, "2017-06-05")
+        self.assertHoliday(self.district_30, "2017-07-01")
+        self.assertHoliday(self.district_30, "2017-12-26")
 
-    def test_2017(self):
-        self.assertIn(date(2017, 12, 24), self.holidays)  # Christmas' Eve
-        self.assertIn(date(2017, 12, 26), self.holidays)  # S.Stephan
-        self.assertIn(date(2017, 12, 26), self.holidays)  # New Year's Eve
+    def test_l10n_default(self):
+        def run_tests(languages):
+            for language in languages:
+                pt = Portugal(language=language)
+                self.assertEqual(pt["2017-01-01"], "Ano Novo")
+                self.assertEqual(pt["2017-12-25"], "Dia de Natal")
 
+        run_tests((Portugal.default_language, None, "invalid"))
 
-class TestPortugalMunicipal(unittest.TestCase):
-    def test_district_specific_days(self):
-        district_01 = holidays.PT(subdiv="01", years=[2017])
-        district_02 = holidays.PT(subdiv="02", years=[2017])
-        district_03 = holidays.PT(subdiv="03", years=[2017])
-        district_04 = holidays.PT(subdiv="04", years=[2017])
-        district_05 = holidays.PT(subdiv="05", years=[2017])
-        district_06 = holidays.PT(subdiv="06", years=[2017])
-        district_07 = holidays.PT(subdiv="07", years=[2017])
-        district_08 = holidays.PT(subdiv="08", years=[2017])
-        district_09 = holidays.PT(subdiv="09", years=[2017])
-        district_10 = holidays.PT(subdiv="10", years=[2017])
-        district_11 = holidays.PT(subdiv="11", years=[2017])
-        district_12 = holidays.PT(subdiv="12", years=[2017])
-        district_13 = holidays.PT(subdiv="13", years=[2017])
-        district_14 = holidays.PT(subdiv="14", years=[2017])
-        district_15 = holidays.PT(subdiv="15", years=[2017])
-        district_16 = holidays.PT(subdiv="16", years=[2017])
-        district_17 = holidays.PT(subdiv="17", years=[2017])
-        district_18 = holidays.PT(subdiv="18", years=[2017])
-        self.assertIn("2017-05-12", district_01)
-        self.assertIn("2017-05-25", district_02)
-        self.assertIn("2017-06-24", district_03)
-        self.assertIn("2017-08-22", district_04)
-        self.assertIn("2017-05-02", district_05)
-        self.assertIn("2017-07-04", district_06)
-        self.assertIn("2017-06-29", district_07)
-        self.assertIn("2017-09-07", district_08)
-        self.assertIn("2017-11-27", district_09)
-        self.assertIn("2017-05-22", district_10)
-        self.assertIn("2017-06-13", district_11)
-        self.assertIn("2017-05-23", district_12)
-        self.assertIn("2017-06-24", district_13)
-        self.assertIn("2017-03-19", district_14)
-        self.assertIn("2017-09-15", district_15)
-        self.assertIn("2017-08-20", district_16)
-        self.assertIn("2017-06-13", district_17)
-        self.assertIn("2017-09-21", district_18)
+        self.set_language("en_US")
+        run_tests((Portugal.default_language,))
+
+    def test_l10n_en_us(self):
+        en_us = "en_US"
+
+        pt = Portugal(language=en_us)
+        self.assertEqual(pt["2017-01-01"], "New Year's Day")
+        self.assertEqual(pt["2017-12-25"], "Christmas")
+
+        self.set_language(en_us)
+        for language in (None, en_us, "invalid"):
+            pt = Portugal(language=language)
+            self.assertEqual(pt["2017-01-01"], "New Year's Day")
+            self.assertEqual(pt["2017-12-25"], "Christmas")


### PR DESCRIPTION
## Proposed change

This extends @Nalguedo's Portuguese work in #753 which now covers the autonomous regions of the Azores and Madeira, implementing date triggers whenever possible and add `en_US` translation.

Test cases still need some work for individual national dates, but are more or less updated to v0.21 coding standard as seen in Argentina and Malaysia.

This should hopefully solves #331 for good.

## Type of change

- [ ] New country holidays support (thank you!)
- [x] Supported country holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/test/process improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts and has clean commit history
- [x] The code style looks good (`make pre-commit`)
- [x] I've added tests to verify that the new code works and all tests pass locally (`make test`, `make tox`)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
