### PR TITLE
Fixes pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,12 +33,12 @@ Your PR description goes here.
   Put an `x` in the boxes that apply. You can change them after PR is created.
 -->
 
-- [x ] I've followed the [contributing guidelines][contributing-guidelines]
-- [x ] This PR is filed against `beta` branch of the repository
-- [x ] This PR doesn't contain any merge conflicts and has clean commit history
-- [x ] The code style looks good (`make pre-commit`)
-- [x ] I've added tests to verify that the new code works and all tests pass locally (`make test`, `make tox`)
-- [x ] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)
+- [x] I've followed the [contributing guidelines][contributing-guidelines]
+- [x] This PR is filed against `beta` branch of the repository
+- [x] This PR doesn't contain any merge conflicts and has clean commit history
+- [x] The code style looks good (`make pre-commit`)
+- [x] I've added tests to verify that the new code works and all tests pass locally (`make test`, `make tox`)
+- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)
 
 <!--
   Thanks again for your contribution!


### PR DESCRIPTION
## Proposed change

This fixes PR template so that it appears like this:
![image](https://user-images.githubusercontent.com/19505219/223605520-81f51358-913a-48e2-96ca-2e0681a1dc5e.png)
Instead of:
![image](https://user-images.githubusercontent.com/19505219/223605558-33348a7d-2580-4bff-99c8-dc3ac4fcacfc.png)


## Type of change

- [ ] New country holidays support (thank you!)
- [ ] Supported country holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/test/process improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts and has clean commit history
- [x] The code style looks good (`make pre-commit`)
- [x] I've added tests to verify that the new code works and all tests pass locally (`make test`, `make tox`)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
