### PR TITLE
Update README: add missing th localization for Canada

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -540,7 +540,7 @@ default language code is a `ISO 639-1 code`_.
      - bg, en_US
    * - Canada
      - en
-     - en, fr
+     - en, fr, th
    * - Chile
      - es
      - en_US, es, uk


### PR DESCRIPTION
## Proposed change

This adds the missing `th` support for Canada in the readme file that was added in #986 which has since been merged for 0.21 release. No other changes are done to the codebase.

## Type of change

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [ ] Existing code/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts and has clean commit history
- [x] The code style looks good (`make pre-commit`)
- [x] I've added tests to verify that the new code works and all tests pass locally (`make test`, `make tox`)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
