### PR TITLE
Update Vatican City holidays: add Saint Joseph the Worker's Day introduction year check

### DIFF
--- a/holidays/countries/vatican_city.py
+++ b/holidays/countries/vatican_city.py
@@ -9,12 +9,12 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from holidays.constants import FEB, MAR, APR, OCT, NOV
+from holidays.constants import JAN, FEB, MAR, APR, MAY, OCT, NOV
 from holidays.holiday_base import HolidayBase
-from holidays.holiday_groups import ChristianHolidays, InternationalHolidays
+from holidays.holiday_groups import ChristianHolidays
 
 
-class VaticanCity(HolidayBase, ChristianHolidays, InternationalHolidays):
+class VaticanCity(HolidayBase, ChristianHolidays):
     """
     References:
       - https://en.wikipedia.org/wiki/Public_holidays_in_Vatican_City
@@ -26,7 +26,6 @@ class VaticanCity(HolidayBase, ChristianHolidays, InternationalHolidays):
 
     def __init__(self, *args, **kwargs) -> None:
         ChristianHolidays.__init__(self)
-        InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
     def _populate(self, year: int) -> None:
@@ -38,7 +37,7 @@ class VaticanCity(HolidayBase, ChristianHolidays, InternationalHolidays):
         # This is supposedly the same as International New Year.
         # Modern adoption across the entire Latin Church in 1931 though this
         # was already celebrated in Rome as the Octave day of Christmas.
-        self._add_new_years_day("Solemnity of Mary Day")
+        self._add_holiday("Solemnity of Mary Day", JAN, 1)
 
         # Epiphany.
         self._add_epiphany_day("Epiphany")
@@ -80,7 +79,7 @@ class VaticanCity(HolidayBase, ChristianHolidays, InternationalHolidays):
         if year >= 1955:
             # Saint Joseph the Worker's Day.
             # Created in response to May Day holidays by Pope Pius XII in 1955.
-            self._add_labor_day("Saint Joseph the Worker's Day")
+            self._add_holiday("Saint Joseph the Worker's Day", MAY, 1)
 
         if year <= 2009:
             # Ascension of Christ.

--- a/holidays/countries/vatican_city.py
+++ b/holidays/countries/vatican_city.py
@@ -9,21 +9,24 @@
 #  Website: https://github.com/dr-prodigy/python-holidays
 #  License: MIT (see LICENSE file)
 
-from holidays.constants import JAN, FEB, MAR, APR, MAY, OCT, NOV
+from holidays.constants import FEB, MAR, APR, OCT, NOV
 from holidays.holiday_base import HolidayBase
-from holidays.holiday_groups import ChristianHolidays
+from holidays.holiday_groups import ChristianHolidays, InternationalHolidays
 
 
-class VaticanCity(HolidayBase, ChristianHolidays):
+class VaticanCity(HolidayBase, ChristianHolidays, InternationalHolidays):
     """
     References:
       - https://en.wikipedia.org/wiki/Public_holidays_in_Vatican_City
+      - https://www.ewtn.com/catholicism/library/solemnity-of-mary-mother-of-god-5826  # noqa: E501
+      - https://www.franciscanmedia.org/saint-of-the-day/saint-joseph-the-worker/  # noqa: E501
     """
 
     country = "VA"
 
     def __init__(self, *args, **kwargs) -> None:
         ChristianHolidays.__init__(self)
+        InternationalHolidays.__init__(self)
         super().__init__(*args, **kwargs)
 
     def _populate(self, year: int) -> None:
@@ -32,7 +35,10 @@ class VaticanCity(HolidayBase, ChristianHolidays):
         super()._populate(year)
 
         # Solemnity of Mary Day.
-        self._add_holiday("Solemnity of Mary Day", JAN, 1)
+        # This is supposedly the same as International New Year.
+        # Modern adoption across the entire Latin Church in 1931 though this
+        # was already celebrated in Rome as the Octave day of Christmas.
+        self._add_new_years_day("Solemnity of Mary Day")
 
         # Epiphany.
         self._add_epiphany_day("Epiphany")
@@ -71,8 +77,10 @@ class VaticanCity(HolidayBase, ChristianHolidays):
             # Saint George's Day.
             self._add_saint_georges_day("Saint George's Day")
 
-        # Saint Joseph the Worker's Day.
-        self._add_holiday("Saint Joseph the Worker's Day", MAY, 1)
+        if year >= 1955:
+            # Saint Joseph the Worker's Day.
+            # Created in response to May Day holidays by Pope Pius XII in 1955.
+            self._add_labor_day("Saint Joseph the Worker's Day")
 
         if year <= 2009:
             # Ascension of Christ.

--- a/tests/countries/test_vatican_city.py
+++ b/tests/countries/test_vatican_city.py
@@ -123,9 +123,10 @@ class TestVaticanCity(TestCase):
         self.assertNoHolidayName(name, range(2010, 2050))
 
     def test_saint_joseph_workers_day(self):
+        name = "Saint Joseph the Worker's Day"
+        self.assertNoHolidayName(name, VaticanCity(years=1954))
         self.assertHolidaysName(
-            "Saint Joseph the Worker's Day",
-            (f"{year}-05-01" for year in range(1970, 2050)),
+            name, (f"{year}-05-01" for year in range(1955, 2050))
         )
 
     def test_saints_peter_and_paul_day(self):


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

This PR migrates the two remaining international holidays for the Vatican (New Year's Day and Labor Day) to their respective holiday groups. 

While ["Solemnity of Mary Day"](https://www.ewtn.com/catholicism/library/solemnity-of-mary-mother-of-god-5826) was only adopted by the entire Latin Church in 1931, this matches the already existing Octave Day of Christmas celebrations in Rome so I'm going to leave this untouched for now.

["Saint Joseph the Worker's Day"](https://www.franciscanmedia.org/saint-of-the-day/saint-joseph-the-worker/) feast is also corrected to only appear from 1955 onwards (this was instituted by Pope Pius XII).

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts and has clean commit history
- [x] The code style looks good: `make pre-commit`
- [x] All tests pass locally: `make test`, `make tox` (we strongly encourage adding tests to your code)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
