### PR TITLE
Migrate Cuba holidays to holiday groups

### DIFF
--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -13,7 +13,7 @@ from datetime import date
 from datetime import timedelta as td
 from gettext import gettext as tr
 
-from holidays.constants import JUL, OCT
+from holidays.constants import JAN, JUL, OCT
 from holidays.holiday_base import HolidayBase
 from holidays.holiday_groups import ChristianHolidays, InternationalHolidays
 

--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -57,14 +57,14 @@ class Cuba(HolidayBase, ChristianHolidays, InternationalHolidays):
         super()._populate(year)
 
         # Liberation Day.
-        jan_1 = self._add_new_years_day(tr("Triunfo de la Revolución"))
+        jan_1 = self._add_holiday(tr("Triunfo de la Revolución"), JAN, 1)
         if year <= 2013:
             _add_observed(jan_1)
 
         # Granted in 2007 decree.
         if year >= 2008:
             #  Victory Day.
-            self._add_new_years_day_two(tr("Día de la Victoria"))
+            self._add_holiday(tr("Día de la Victoria"), JAN, 2)
 
         # Granted temporarily in 2012 and 2013:
         #   https://cnn.it/3v5V6GY
@@ -74,11 +74,10 @@ class Cuba(HolidayBase, ChristianHolidays, InternationalHolidays):
             # Good Friday.
             self._add_good_friday(tr("Viernes Santo"))
 
-        # Labour Day.
-        may_1 = self._add_labor_day(
-            tr("Día Internacional de los Trabajadores")
+        _add_observed(
+            # Labour Day.
+            self._add_labor_day(tr("Día Internacional de los Trabajadores"))
         )
-        _add_observed(may_1)
 
         # Commemoration of the Assault of the Moncada garrison.
         self._add_holiday(tr("Conmemoración del asalto a Moncada"), JUL, 25)
@@ -89,13 +88,14 @@ class Cuba(HolidayBase, ChristianHolidays, InternationalHolidays):
         # Commemoration of the Assault of the Moncada garrison.
         self._add_holiday(tr("Conmemoración del asalto a Moncada"), JUL, 27)
 
-        # Independence Day.
-        oct_10 = self._add_holiday(
-            tr("Inicio de las Guerras de Independencia"),
-            OCT,
-            10,
+        _add_observed(
+            self._add_holiday(
+                # Independence Day.
+                tr("Inicio de las Guerras de Independencia"),
+                OCT,
+                10,
+            )
         )
-        _add_observed(oct_10)
 
         # In 1969, Christmas was cancelled for the sugar harvest but then was
         # cancelled for good:

--- a/holidays/countries/cuba.py
+++ b/holidays/countries/cuba.py
@@ -13,13 +13,12 @@ from datetime import date
 from datetime import timedelta as td
 from gettext import gettext as tr
 
-from dateutil.easter import easter
-
-from holidays.constants import JAN, MAY, JUL, OCT, DEC
+from holidays.constants import JUL, OCT
 from holidays.holiday_base import HolidayBase
+from holidays.holiday_groups import ChristianHolidays, InternationalHolidays
 
 
-class Cuba(HolidayBase):
+class Cuba(HolidayBase, ChristianHolidays, InternationalHolidays):
     """
     Overview: https://en.wikipedia.org/wiki/Public_holidays_in_Cuba
     1984 (DEC 28): https://bit.ly/3okNBbt
@@ -38,7 +37,16 @@ class Cuba(HolidayBase):
     default_language = "es"
     supported_languages = ("en_US", "es", "uk")
 
+    def __init__(self, *args, **kwargs):
+        ChristianHolidays.__init__(self)
+        InternationalHolidays.__init__(self)
+        super().__init__(*args, **kwargs)
+
     def _populate(self, year):
+        # This calendar only works from 1959 onwards.
+        if year <= 1958:
+            return None
+
         def _add_observed(hol_date: date) -> None:
             if self.observed and self._is_sunday(hol_date):
                 self._add_holiday(
@@ -49,14 +57,14 @@ class Cuba(HolidayBase):
         super()._populate(year)
 
         # Liberation Day.
-        jan_1 = self._add_holiday(tr("Triunfo de la Revolución"), JAN, 1)
+        jan_1 = self._add_new_years_day(tr("Triunfo de la Revolución"))
         if year <= 2013:
             _add_observed(jan_1)
 
         # Granted in 2007 decree.
         if year >= 2008:
             #  Victory Day.
-            self._add_holiday(tr("Día de la Victoria"), JAN, 2)
+            self._add_new_years_day_two(tr("Día de la Victoria"))
 
         # Granted temporarily in 2012 and 2013:
         #   https://cnn.it/3v5V6GY
@@ -64,12 +72,13 @@ class Cuba(HolidayBase):
         # Permanently granted in 2013 decree for 2014 and onwards.
         if year >= 2012:
             # Good Friday.
-            self._add_holiday(tr("Viernes Santo"), easter(year) + td(days=-2))
+            self._add_good_friday(tr("Viernes Santo"))
 
         # Labour Day.
-        dt = date(year, MAY, 1)
-        self._add_holiday(tr("Día Internacional de los Trabajadores"), dt)
-        _add_observed(dt)
+        may_1 = self._add_labor_day(
+            tr("Día Internacional de los Trabajadores")
+        )
+        _add_observed(may_1)
 
         # Commemoration of the Assault of the Moncada garrison.
         self._add_holiday(tr("Conmemoración del asalto a Moncada"), JUL, 25)
@@ -80,10 +89,13 @@ class Cuba(HolidayBase):
         # Commemoration of the Assault of the Moncada garrison.
         self._add_holiday(tr("Conmemoración del asalto a Moncada"), JUL, 27)
 
-        dt = date(year, OCT, 10)
         # Independence Day.
-        self._add_holiday(tr("Inicio de las Guerras de Independencia"), dt)
-        _add_observed(dt)
+        oct_10 = self._add_holiday(
+            tr("Inicio de las Guerras de Independencia"),
+            OCT,
+            10,
+        )
+        _add_observed(oct_10)
 
         # In 1969, Christmas was cancelled for the sugar harvest but then was
         # cancelled for good:
@@ -95,12 +107,12 @@ class Cuba(HolidayBase):
         #   https://bit.ly/3cyXj7F
         if year <= 1968 or year >= 1997:
             # Christmas Day.
-            self._add_holiday(tr("Día de Navidad"), DEC, 25)
+            self._add_christmas_day(tr("Día de Navidad"))
 
         # Granted in 2007 decree.
         if year >= 2007:
             # New Year's Eve.
-            self._add_holiday(tr("Fiesta de Fin de Año"), DEC, 31)
+            self._add_new_years_eve(tr("Fiesta de Fin de Año"))
 
 
 class CU(Cuba):

--- a/holidays/locale/en_US/LC_MESSAGES/CU.po
+++ b/holidays/locale/en_US/LC_MESSAGES/CU.po
@@ -16,51 +16,50 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: ./holidays/countries/cuba.py:45
+#: ./holidays/countries/cuba.py:53
 #, c-format
 msgid "%s (Observado)"
 msgstr "%s (Observed)"
 
 #. Liberation Day.
-#: ./holidays/countries/cuba.py:52
+#: ./holidays/countries/cuba.py:60
 msgid "Triunfo de la Revolución"
 msgstr "Liberation Day"
 
 #. Victory Day.
-#: ./holidays/countries/cuba.py:59
+#: ./holidays/countries/cuba.py:67
 msgid "Día de la Victoria"
 msgstr "Victory Day"
 
 #. Good Friday.
-#: ./holidays/countries/cuba.py:67
+#: ./holidays/countries/cuba.py:75
 msgid "Viernes Santo"
 msgstr "Good Friday"
 
-#: ./holidays/countries/cuba.py:71
+#: ./holidays/countries/cuba.py:79
 msgid "Día Internacional de los Trabajadores"
 msgstr "Labour Day"
 
 #. Commemoration of the Assault of the Moncada garrison.
-#: ./holidays/countries/cuba.py:75 ./holidays/countries/cuba.py:81
+#: ./holidays/countries/cuba.py:84 ./holidays/countries/cuba.py:90
 msgid "Conmemoración del asalto a Moncada"
 msgstr "Commemoration of the Assault of the Moncada garrison"
 
 #. Day of the National Rebellion.
-#: ./holidays/countries/cuba.py:78
+#: ./holidays/countries/cuba.py:87
 msgid "Día de la Rebeldía Nacional"
 msgstr "Day of the National Rebellion"
 
-#. Independence Day.
-#: ./holidays/countries/cuba.py:85
+#: ./holidays/countries/cuba.py:94
 msgid "Inicio de las Guerras de Independencia"
 msgstr "Independence Day"
 
 #. Christmas Day.
-#: ./holidays/countries/cuba.py:98
+#: ./holidays/countries/cuba.py:110
 msgid "Día de Navidad"
 msgstr "Christmas Day"
 
 #. New Year's Eve.
-#: ./holidays/countries/cuba.py:103
+#: ./holidays/countries/cuba.py:115
 msgid "Fiesta de Fin de Año"
 msgstr "New Year's Eve"

--- a/holidays/locale/en_US/LC_MESSAGES/CU.po
+++ b/holidays/locale/en_US/LC_MESSAGES/CU.po
@@ -36,20 +36,22 @@ msgstr "Victory Day"
 msgid "Viernes Santo"
 msgstr "Good Friday"
 
+#. Labour Day.
 #: ./holidays/countries/cuba.py:79
 msgid "Día Internacional de los Trabajadores"
 msgstr "Labour Day"
 
 #. Commemoration of the Assault of the Moncada garrison.
-#: ./holidays/countries/cuba.py:84 ./holidays/countries/cuba.py:90
+#: ./holidays/countries/cuba.py:83 ./holidays/countries/cuba.py:89
 msgid "Conmemoración del asalto a Moncada"
 msgstr "Commemoration of the Assault of the Moncada garrison"
 
 #. Day of the National Rebellion.
-#: ./holidays/countries/cuba.py:87
+#: ./holidays/countries/cuba.py:86
 msgid "Día de la Rebeldía Nacional"
 msgstr "Day of the National Rebellion"
 
+#. Independence Day.
 #: ./holidays/countries/cuba.py:94
 msgid "Inicio de las Guerras de Independencia"
 msgstr "Independence Day"

--- a/holidays/locale/es/LC_MESSAGES/CU.po
+++ b/holidays/locale/es/LC_MESSAGES/CU.po
@@ -16,51 +16,50 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: ./holidays/countries/cuba.py:45
+#: ./holidays/countries/cuba.py:53
 #, c-format
 msgid "%s (Observado)"
 msgstr ""
 
 #. Liberation Day.
-#: ./holidays/countries/cuba.py:52
+#: ./holidays/countries/cuba.py:60
 msgid "Triunfo de la Revolución"
 msgstr ""
 
 #. Victory Day.
-#: ./holidays/countries/cuba.py:59
+#: ./holidays/countries/cuba.py:67
 msgid "Día de la Victoria"
 msgstr ""
 
 #. Good Friday.
-#: ./holidays/countries/cuba.py:67
+#: ./holidays/countries/cuba.py:75
 msgid "Viernes Santo"
 msgstr ""
 
-#: ./holidays/countries/cuba.py:71
+#: ./holidays/countries/cuba.py:79
 msgid "Día Internacional de los Trabajadores"
 msgstr ""
 
 #. Commemoration of the Assault of the Moncada garrison.
-#: ./holidays/countries/cuba.py:75 ./holidays/countries/cuba.py:81
+#: ./holidays/countries/cuba.py:84 ./holidays/countries/cuba.py:90
 msgid "Conmemoración del asalto a Moncada"
 msgstr ""
 
 #. Day of the National Rebellion.
-#: ./holidays/countries/cuba.py:78
+#: ./holidays/countries/cuba.py:87
 msgid "Día de la Rebeldía Nacional"
 msgstr ""
 
-#. Independence Day.
-#: ./holidays/countries/cuba.py:85
+#: ./holidays/countries/cuba.py:94
 msgid "Inicio de las Guerras de Independencia"
 msgstr ""
 
 #. Christmas Day.
-#: ./holidays/countries/cuba.py:98
+#: ./holidays/countries/cuba.py:110
 msgid "Día de Navidad"
 msgstr ""
 
 #. New Year's Eve.
-#: ./holidays/countries/cuba.py:103
+#: ./holidays/countries/cuba.py:115
 msgid "Fiesta de Fin de Año"
 msgstr ""

--- a/holidays/locale/es/LC_MESSAGES/CU.po
+++ b/holidays/locale/es/LC_MESSAGES/CU.po
@@ -36,20 +36,22 @@ msgstr ""
 msgid "Viernes Santo"
 msgstr ""
 
+#. Labour Day.
 #: ./holidays/countries/cuba.py:79
 msgid "Día Internacional de los Trabajadores"
 msgstr ""
 
 #. Commemoration of the Assault of the Moncada garrison.
-#: ./holidays/countries/cuba.py:84 ./holidays/countries/cuba.py:90
+#: ./holidays/countries/cuba.py:83 ./holidays/countries/cuba.py:89
 msgid "Conmemoración del asalto a Moncada"
 msgstr ""
 
 #. Day of the National Rebellion.
-#: ./holidays/countries/cuba.py:87
+#: ./holidays/countries/cuba.py:86
 msgid "Día de la Rebeldía Nacional"
 msgstr ""
 
+#. Independence Day.
 #: ./holidays/countries/cuba.py:94
 msgid "Inicio de las Guerras de Independencia"
 msgstr ""

--- a/holidays/locale/uk/LC_MESSAGES/CU.po
+++ b/holidays/locale/uk/LC_MESSAGES/CU.po
@@ -36,20 +36,22 @@ msgstr "День перемоги"
 msgid "Viernes Santo"
 msgstr "Страсна пʼятниця"
 
+#. Labour Day.
 #: ./holidays/countries/cuba.py:79
 msgid "Día Internacional de los Trabajadores"
 msgstr "Міжнародний день трудящих"
 
 #. Commemoration of the Assault of the Moncada garrison.
-#: ./holidays/countries/cuba.py:84 ./holidays/countries/cuba.py:90
+#: ./holidays/countries/cuba.py:83 ./holidays/countries/cuba.py:89
 msgid "Conmemoración del asalto a Moncada"
 msgstr "Вшанування памʼяті штурму Монкади"
 
 #. Day of the National Rebellion.
-#: ./holidays/countries/cuba.py:87
+#: ./holidays/countries/cuba.py:86
 msgid "Día de la Rebeldía Nacional"
 msgstr "День національного повстання"
 
+#. Independence Day.
 #: ./holidays/countries/cuba.py:94
 msgid "Inicio de las Guerras de Independencia"
 msgstr "Початок війни за незалежність"

--- a/holidays/locale/uk/LC_MESSAGES/CU.po
+++ b/holidays/locale/uk/LC_MESSAGES/CU.po
@@ -16,51 +16,50 @@ msgstr ""
 "Generated-By: pygettext.py 1.5\n"
 "X-Generator: Poedit 3.2.2\n"
 
-#: ./holidays/countries/cuba.py:45
+#: ./holidays/countries/cuba.py:53
 #, c-format
 msgid "%s (Observado)"
 msgstr "%s (вихідний)"
 
 #. Liberation Day.
-#: ./holidays/countries/cuba.py:52
+#: ./holidays/countries/cuba.py:60
 msgid "Triunfo de la Revolución"
 msgstr "Тріумф революції"
 
 #. Victory Day.
-#: ./holidays/countries/cuba.py:59
+#: ./holidays/countries/cuba.py:67
 msgid "Día de la Victoria"
 msgstr "День перемоги"
 
 #. Good Friday.
-#: ./holidays/countries/cuba.py:67
+#: ./holidays/countries/cuba.py:75
 msgid "Viernes Santo"
 msgstr "Страсна пʼятниця"
 
-#: ./holidays/countries/cuba.py:71
+#: ./holidays/countries/cuba.py:79
 msgid "Día Internacional de los Trabajadores"
 msgstr "Міжнародний день трудящих"
 
 #. Commemoration of the Assault of the Moncada garrison.
-#: ./holidays/countries/cuba.py:75 ./holidays/countries/cuba.py:81
+#: ./holidays/countries/cuba.py:84 ./holidays/countries/cuba.py:90
 msgid "Conmemoración del asalto a Moncada"
 msgstr "Вшанування памʼяті штурму Монкади"
 
 #. Day of the National Rebellion.
-#: ./holidays/countries/cuba.py:78
+#: ./holidays/countries/cuba.py:87
 msgid "Día de la Rebeldía Nacional"
 msgstr "День національного повстання"
 
-#. Independence Day.
-#: ./holidays/countries/cuba.py:85
+#: ./holidays/countries/cuba.py:94
 msgid "Inicio de las Guerras de Independencia"
 msgstr "Початок війни за незалежність"
 
 #. Christmas Day.
-#: ./holidays/countries/cuba.py:98
+#: ./holidays/countries/cuba.py:110
 msgid "Día de Navidad"
 msgstr "Різдво Христове"
 
 #. New Year's Eve.
-#: ./holidays/countries/cuba.py:103
+#: ./holidays/countries/cuba.py:115
 msgid "Fiesta de Fin de Año"
 msgstr "Переддень Нового року"

--- a/tests/countries/test_cuba.py
+++ b/tests/countries/test_cuba.py
@@ -16,7 +16,7 @@ from tests.common import TestCase
 class TestCuba(TestCase):
     @classmethod
     def setUpClass(cls):
-        super().setUpClass(Cuba)
+        super().setUpClass(Cuba, years=range(1959, 2050))
 
     def test_country_aliases(self):
         self.assertCountryAliases(Cuba, CU, CUB)
@@ -34,15 +34,15 @@ class TestCuba(TestCase):
         )
 
     def test_national_rebellion_day(self):
-        name = "Día de la Rebeldía Nacional"
         self.assertHolidaysName(
-            name, (f"{year}-07-26" for year in range(1959, 2050))
+            "Día de la Rebeldía Nacional",
+            (f"{year}-07-26" for year in range(1959, 2050)),
         )
 
     def test_independence_day(self):
-        name = "Inicio de las Guerras de Independencia"
         self.assertHolidaysName(
-            name, (f"{year}-10-10" for year in range(1959, 2050))
+            "Inicio de las Guerras de Independencia",
+            (f"{year}-10-10" for year in range(1959, 2050)),
         )
 
     def test_1968(self):

--- a/tests/countries/test_cuba.py
+++ b/tests/countries/test_cuba.py
@@ -21,6 +21,30 @@ class TestCuba(TestCase):
     def test_country_aliases(self):
         self.assertCountryAliases(Cuba, CU, CUB)
 
+    def test_no_holidays(self):
+        self.assertNoHolidays(Cuba(years=1958))
+
+    def test_assault_moncada_day(self):
+        name = "Conmemoración del asalto a Moncada"
+        self.assertHolidaysName(
+            name, (f"{year}-07-25" for year in range(1959, 2050))
+        )
+        self.assertHolidaysName(
+            name, (f"{year}-07-27" for year in range(1959, 2050))
+        )
+
+    def test_national_rebellion_day(self):
+        name = "Día de la Rebeldía Nacional"
+        self.assertHolidaysName(
+            name, (f"{year}-07-26" for year in range(1959, 2050))
+        )
+
+    def test_independence_day(self):
+        name = "Inicio de las Guerras de Independencia"
+        self.assertHolidaysName(
+            name, (f"{year}-10-10" for year in range(1959, 2050))
+        )
+
     def test_1968(self):
         self.assertHolidayDates(
             Cuba(years=1968),


### PR DESCRIPTION
<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

Migrate Cuba holidays to `holiday_groups` standard.
This PR also adds a cut-off date for 1959 to prevent Cuban Revolution holidays from firing before the event.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [x] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts and has clean commit history
- [x] The code style looks good: `make pre-commit`
- [x] All tests pass locally: `make test`, `make tox` (we strongly encourage adding tests to your code)
- [x] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
