### PR TITLE
Use aware UTC datetimes internally

### DIFF
--- a/holidays/holiday_base.py
+++ b/holidays/holiday_base.py
@@ -15,7 +15,7 @@ import copy
 import os
 import warnings
 from calendar import isleap
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from gettext import NullTranslations, gettext, translation
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Mapping, Optional, Set, Tuple
@@ -459,7 +459,7 @@ class HolidayBase(Dict[date, str]):
         elif isinstance(
             key, (float, int)
         ):  # Key type is derived from `float` or `int`.
-            dt = datetime.utcfromtimestamp(key).date()
+            dt = datetime.fromtimestamp(key, timezone.utc).date()
 
         else:  # Key type is not supported.
             raise TypeError(f"Cannot convert type '{type(key)}' to date.")


### PR DESCRIPTION


<!--
  Thanks for contributing to python-holidays!
-->

## Proposed change

<!--
  Describe the big picture of your changes.
  Don't forget to link your PR to an existing issue if any.
-->

SSIA. Naive UTC ones are deprecated as of Python 3.12.

## Type of change

<!--
  Type of change you want to introduce. Please, check one (1) box only!
  If your PR requires multiple boxes to be checked, most likely it needs to
  be split into multiple PRs.
-->

- [ ] New country/market holidays support (thank you!)
- [ ] Supported country/market holidays update (calendar discrepancy fix, localization)
- [x] Existing code/documentation/test/process quality improvement (best practice, cleanup, refactoring, optimization)
- [ ] Dependency upgrade (version update)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] Breaking change (a code change causing existing functionality to break)
- [ ] New feature (new python-holidays functionality in general)

## Checklist

<!--
  Put an `x` in the boxes that apply. You can change them after PR is created.
-->

- [ ] I've followed the [contributing guidelines][contributing-guidelines]
- [x] This PR is filed against `beta` branch of the repository
- [x] This PR doesn't contain any merge conflicts and has clean commit history
- [ ] The code style looks good: `make pre-commit`
- [ ] All tests pass locally: `make test`, `make tox` (we strongly encourage adding tests to your code)
- [ ] The related [documentation][docs] has been added/updated (check off the box for free if no updates is required)

<!--
  Thanks again for your contribution!
-->

[contributing-guidelines]: https://github.com/dr-prodigy/python-holidays/blob/beta/CONTRIBUTING.rst
[docs]: https://github.com/dr-prodigy/python-holidays/tree/beta/docs/source
